### PR TITLE
feat: add install and uninstall scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,12 @@ jobs:
           mkdir -p "${INSTALL_DIR}"
           install -m 755 "target/${{ matrix.target }}/release/${BIN_NAME}" "${INSTALL_DIR}/${BIN_NAME}"
           cp README.md "${INSTALL_DIR}/README.md"
+          cp CHANGELOG.md "${INSTALL_DIR}/CHANGELOG.md"
+          cp LICENSE "${INSTALL_DIR}/LICENSE"
+          cp LICENSE-APACHE "${INSTALL_DIR}/LICENSE-APACHE"
+          cp LICENSE-MIT "${INSTALL_DIR}/LICENSE-MIT"
           cp -R configs "${INSTALL_DIR}/configs"
+          cp -R scripts "${INSTALL_DIR}/scripts"
 
           mkdir -p dist
           tar -C "${STAGING_ROOT}" -czf "dist/${ARCHIVE_NAME}" "${PKG_DIR}"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,75 @@
 
 ## 快速开始
 
-默认配置文件是 `configs/rginx.ron`。
+源码目录下的默认配置文件是 `configs/rginx.ron`。安装版会优先尝试 `<prefix>/etc/rginx/rginx.ron`，也支持通过 `RGINX_CONFIG` 或 `--config` 显式指定配置文件。若你安装时使用了自定义 `--config-dir`，运行时也应继续通过 `RGINX_CONFIG` 或 `--config` 指向那份活跃配置。
+
+### 一键安装
+
+从当前源码仓库安装：
+
+```bash
+./scripts/install.sh --mode source
+```
+
+安装指定 GitHub Release 版本：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/vansour/rginx/main/scripts/install.sh | bash -s -- --mode release --version <tag>
+```
+
+其中 `latest` 只会解析最新稳定版；如果你要安装预发布版，请显式传入具体 tag，例如 `v0.1.1-rc.2`。
+
+安装脚本默认会：
+
+- 安装 `rginx` 到 `<prefix>/bin/rginx`
+- 安装卸载脚本到 `<prefix>/bin/rginx-uninstall`
+- 安装活跃配置到 `<prefix>/etc/rginx/rginx.ron`
+- 安装示例配置到 `<prefix>/share/rginx/configs`
+
+默认前缀：
+
+- Linux: `/usr/local`
+- macOS Intel: `/usr/local`
+- macOS Apple Silicon: `/opt/homebrew`（存在该目录时）
+
+常用参数：
+
+```bash
+./scripts/install.sh --mode source --prefix /tmp/rginx
+./scripts/install.sh --mode source --prefix /tmp/rginx --config-dir /tmp/rginx-config
+./scripts/install.sh --mode source --force
+```
+
+安装完成后，默认配置路径可以直接这样验证：
+
+```bash
+rginx check
+rginx
+```
+
+### 一键卸载
+
+安装完成后可以直接运行：
+
+```bash
+rginx-uninstall
+```
+
+默认会保留活跃配置目录；如果要连配置一起删除：
+
+```bash
+rginx-uninstall --purge-config
+```
+
+如果你使用了自定义前缀或配置目录，也可以显式指定：
+
+```bash
+./scripts/uninstall.sh --prefix /tmp/rginx --config-dir /tmp/rginx-config --purge-config
+```
+
+### 源码运行
+
+直接运行仓库内默认配置：
 
 ```bash
 cargo run -p rginx -- --config configs/rginx.ron
@@ -64,6 +132,8 @@ cargo build -p rginx
 ./target/debug/rginx --config configs/rginx.ron
 ./target/debug/rginx check --config configs/rginx.ron
 ```
+
+### 仓库自带示例配置
 
 仓库已自带几个示例配置：
 
@@ -661,6 +731,16 @@ tag 被 push 之后，GitHub Actions 会自动：
 - `aarch64-unknown-linux-gnu`
 - `x86_64-apple-darwin`
 - `aarch64-apple-darwin`
+
+每个 release archive 现在会同时包含：
+
+- `rginx`
+- `configs/`
+- `scripts/install.sh`
+- `scripts/uninstall.sh`
+- `README.md`
+- `CHANGELOG.md`
+- `LICENSE*`
 
 Release Notes 分类规则来自：
 

--- a/crates/rginx-app/src/cli.rs
+++ b/crates/rginx-app/src/cli.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::env;
+use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 
@@ -9,7 +10,7 @@ use clap::{Parser, Subcommand};
     about = "A Rust edge reverse proxy for small and medium deployments"
 )]
 pub struct Cli {
-    #[arg(short, long, global = true, default_value = "configs/rginx.ron")]
+    #[arg(short, long, global = true, default_value_os_t = default_config_path())]
     pub config: PathBuf,
 
     #[command(subcommand)]
@@ -19,4 +20,59 @@ pub struct Cli {
 #[derive(Debug, Clone, Copy, Subcommand)]
 pub enum Command {
     Check,
+}
+
+fn default_config_path() -> PathBuf {
+    if let Some(path) = env::var_os("RGINX_CONFIG") {
+        return PathBuf::from(path);
+    }
+
+    if let Ok(executable) = env::current_exe()
+        && let Some(path) = installed_config_path(&executable)
+        && path.exists()
+    {
+        return path;
+    }
+
+    #[cfg(unix)]
+    for candidate in [
+        "/etc/rginx/rginx.ron",
+        "/usr/local/etc/rginx/rginx.ron",
+        "/opt/homebrew/etc/rginx/rginx.ron",
+    ] {
+        let path = PathBuf::from(candidate);
+        if path.exists() {
+            return path;
+        }
+    }
+
+    PathBuf::from("configs/rginx.ron")
+}
+
+fn installed_config_path(executable: &Path) -> Option<PathBuf> {
+    executable.parent()?.parent().map(|prefix| prefix.join("etc/rginx/rginx.ron"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::installed_config_path;
+
+    #[test]
+    fn installed_config_path_uses_prefix_relative_etc_directory() {
+        let executable = PathBuf::from("/usr/local/bin/rginx");
+
+        assert_eq!(
+            installed_config_path(&executable),
+            Some(PathBuf::from("/usr/local/etc/rginx/rginx.ron"))
+        );
+    }
+
+    #[test]
+    fn installed_config_path_returns_none_for_rootless_paths() {
+        let executable = PathBuf::from("rginx");
+
+        assert_eq!(installed_config_path(&executable), None);
+    }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_SLUG="vansour/rginx"
+
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-$0}"
+SCRIPT_PATH=""
+SCRIPT_DIR=""
+LOCAL_ROOT=""
+
+MODE="auto"
+VERSION="latest"
+PREFIX=""
+CONFIG_DIR=""
+FORCE=0
+TMP_ROOT=""
+SUDO=""
+
+usage() {
+    cat <<'EOF'
+Usage: install.sh [options]
+
+Options:
+  --mode auto|source|archive|release
+      auto    : 优先使用当前目录下的 release archive，其次源码构建，最后下载 GitHub Release
+      source  : 从当前源码仓库执行 cargo build --release 后安装
+      archive : 从当前解压后的 release archive 安装
+      release : 直接从 GitHub Release 下载并安装
+  --version <tag|latest>
+      release 模式下使用的版本，默认 latest；latest 只解析最新稳定版
+  --prefix <path>
+      安装前缀。Linux 默认 /usr/local；macOS arm64 且存在 /opt/homebrew 时默认 /opt/homebrew
+  --config-dir <path>
+      活跃配置目录，默认 <prefix>/etc/rginx
+  --force
+      强制覆盖已存在的活跃配置文件
+  -h, --help
+      显示帮助
+EOF
+}
+
+log() {
+    printf '[install] %s\n' "$*"
+}
+
+die() {
+    printf '[install] error: %s\n' "$*" >&2
+    exit 1
+}
+
+have() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+cleanup() {
+    if [[ -n "${TMP_ROOT}" && -d "${TMP_ROOT}" ]]; then
+        rm -rf "${TMP_ROOT}"
+    fi
+}
+
+trap cleanup EXIT
+
+if [[ "${SCRIPT_SOURCE}" != "bash" && -f "${SCRIPT_SOURCE}" ]]; then
+    SCRIPT_PATH="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)/$(basename "${SCRIPT_SOURCE}")"
+    SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" && pwd)"
+
+    if [[ "$(basename "${SCRIPT_DIR}")" == "scripts" ]]; then
+        LOCAL_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+    else
+        LOCAL_ROOT="${SCRIPT_DIR}"
+    fi
+fi
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --mode)
+            [[ $# -ge 2 ]] || die "--mode requires a value"
+            MODE="$2"
+            shift 2
+            ;;
+        --version)
+            [[ $# -ge 2 ]] || die "--version requires a value"
+            VERSION="$2"
+            shift 2
+            ;;
+        --prefix)
+            [[ $# -ge 2 ]] || die "--prefix requires a value"
+            PREFIX="$2"
+            shift 2
+            ;;
+        --config-dir)
+            [[ $# -ge 2 ]] || die "--config-dir requires a value"
+            CONFIG_DIR="$2"
+            shift 2
+            ;;
+        --force)
+            FORCE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+default_prefix() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    if [[ "${os}" == "Darwin" && "${arch}" == "arm64" && -d /opt/homebrew ]]; then
+        printf '%s\n' "/opt/homebrew"
+        return
+    fi
+
+    printf '%s\n' "/usr/local"
+}
+
+nearest_existing_parent() {
+    local path="$1"
+
+    while [[ ! -e "${path}" ]]; do
+        path="$(dirname "${path}")"
+    done
+
+    printf '%s\n' "${path}"
+}
+
+prepare_privileges() {
+    local target parent
+
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        return
+    fi
+
+    for target in "${BIN_DIR}" "${CONFIG_DIR}" "${DOC_DIR}" "${SHARE_DIR}"; do
+        parent="$(nearest_existing_parent "${target}")"
+        if [[ ! -w "${parent}" ]]; then
+            have sudo || die "install target requires elevated privileges, but sudo is not available"
+            SUDO="sudo"
+            return
+        fi
+    done
+}
+
+run_root() {
+    if [[ -n "${SUDO}" ]]; then
+        "${SUDO}" "$@"
+        return
+    fi
+
+    "$@"
+}
+
+detect_release_platform() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "${os}" in
+        Linux)
+            RELEASE_OS="linux"
+            ;;
+        Darwin)
+            RELEASE_OS="darwin"
+            ;;
+        *)
+            die "unsupported operating system: ${os}"
+            ;;
+    esac
+
+    case "${arch}" in
+        x86_64|amd64)
+            RELEASE_ARCH="amd64"
+            ;;
+        aarch64|arm64)
+            RELEASE_ARCH="arm64"
+            ;;
+        *)
+            die "unsupported architecture: ${arch}"
+            ;;
+    esac
+}
+
+is_source_root() {
+    local path="${1:-}"
+
+    [[ -n "${path}" ]] || return 1
+    [[ -f "${path}/Cargo.toml" ]] || return 1
+    [[ -d "${path}/crates/rginx-app" ]] || return 1
+    [[ -d "${path}/configs" ]] || return 1
+}
+
+is_archive_root() {
+    local path="${1:-}"
+
+    [[ -n "${path}" ]] || return 1
+    [[ -x "${path}/rginx" ]] || return 1
+    [[ -d "${path}/configs" ]] || return 1
+    [[ -f "${path}/scripts/uninstall.sh" ]] || return 1
+}
+
+resolve_latest_release() {
+    local response tag
+
+    have curl || die "curl is required to resolve the latest release"
+
+    response="$(curl -fsSL "https://api.github.com/repos/${REPO_SLUG}/releases/latest")" \
+        || die "failed to resolve the latest stable release; use --version or --mode source"
+
+    tag="$(printf '%s' "${response}" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+    [[ -n "${tag}" ]] || die "unable to parse the latest release tag from GitHub API"
+
+    printf '%s\n' "${tag}"
+}
+
+resolve_mode() {
+    case "${MODE}" in
+        auto)
+            if is_archive_root "${LOCAL_ROOT}"; then
+                MODE="archive"
+            elif is_source_root "${LOCAL_ROOT}" && have cargo; then
+                MODE="source"
+            else
+                MODE="release"
+            fi
+            ;;
+        source|archive|release)
+            ;;
+        *)
+            die "unsupported mode: ${MODE}"
+            ;;
+    esac
+}
+
+stage_from_source() {
+    have cargo || die "cargo is required for --mode source"
+    is_source_root "${LOCAL_ROOT}" || die "--mode source must be run from the repository scripts directory"
+
+    log "building rginx from source"
+    cargo build --locked --release -p rginx --manifest-path "${LOCAL_ROOT}/Cargo.toml"
+
+    STAGED_ROOT="${LOCAL_ROOT}"
+    STAGED_BIN="${LOCAL_ROOT}/target/release/rginx"
+    STAGED_UNINSTALL="${LOCAL_ROOT}/scripts/uninstall.sh"
+}
+
+stage_from_archive() {
+    is_archive_root "${LOCAL_ROOT}" || die "--mode archive must be run from an extracted release archive"
+
+    STAGED_ROOT="${LOCAL_ROOT}"
+    STAGED_BIN="${LOCAL_ROOT}/rginx"
+    STAGED_UNINSTALL="${LOCAL_ROOT}/scripts/uninstall.sh"
+}
+
+stage_from_release() {
+    local tag archive_name archive_url unpack_dir
+
+    have curl || die "curl is required for --mode release"
+    have tar || die "tar is required for --mode release"
+
+    detect_release_platform
+
+    tag="${VERSION}"
+    if [[ "${tag}" == "latest" ]]; then
+        tag="$(resolve_latest_release)"
+    fi
+
+    TMP_ROOT="$(mktemp -d)"
+    archive_name="rginx-${tag}-${RELEASE_OS}-${RELEASE_ARCH}.tar.gz"
+    archive_url="https://github.com/${REPO_SLUG}/releases/download/${tag}/${archive_name}"
+
+    log "downloading ${archive_url}"
+    curl -fL --retry 3 --retry-delay 1 --connect-timeout 10 "${archive_url}" -o "${TMP_ROOT}/${archive_name}" \
+        || die "failed to download ${archive_url}"
+
+    tar -C "${TMP_ROOT}" -xzf "${TMP_ROOT}/${archive_name}"
+    unpack_dir="${TMP_ROOT}/rginx-${tag#v}-${RELEASE_OS}-${RELEASE_ARCH}"
+    [[ -d "${unpack_dir}" ]] || die "unexpected archive layout: ${archive_name}"
+
+    STAGED_ROOT="${unpack_dir}"
+    STAGED_BIN="${unpack_dir}/rginx"
+    STAGED_UNINSTALL="${unpack_dir}/scripts/uninstall.sh"
+}
+
+PREFIX="${PREFIX:-$(default_prefix)}"
+CONFIG_DIR="${CONFIG_DIR:-${PREFIX}/etc/rginx}"
+BIN_DIR="${PREFIX}/bin"
+SHARE_DIR="${PREFIX}/share/rginx"
+DOC_DIR="${PREFIX}/share/doc/rginx"
+EXAMPLES_DIR="${SHARE_DIR}/configs"
+MANIFEST_PATH="${SHARE_DIR}/install-manifest.txt"
+ACTIVE_CONFIG="${CONFIG_DIR}/rginx.ron"
+
+resolve_mode
+
+case "${MODE}" in
+    source)
+        stage_from_source
+        ;;
+    archive)
+        stage_from_archive
+        ;;
+    release)
+        stage_from_release
+        ;;
+esac
+
+[[ -x "${STAGED_BIN}" ]] || die "staged rginx binary not found: ${STAGED_BIN}"
+[[ -d "${STAGED_ROOT}/configs" ]] || die "staged configs directory not found: ${STAGED_ROOT}/configs"
+[[ -f "${STAGED_UNINSTALL}" ]] || die "staged uninstall script not found: ${STAGED_UNINSTALL}"
+
+prepare_privileges
+
+log "resolved install mode: ${MODE}"
+log "installing to prefix ${PREFIX}"
+run_root install -d "${BIN_DIR}" "${CONFIG_DIR}" "${SHARE_DIR}" "${DOC_DIR}"
+run_root rm -rf "${EXAMPLES_DIR}"
+run_root install -d "${EXAMPLES_DIR}"
+
+run_root install -m 755 "${STAGED_BIN}" "${BIN_DIR}/rginx"
+run_root install -m 755 "${STAGED_UNINSTALL}" "${BIN_DIR}/rginx-uninstall"
+
+for doc in README.md CHANGELOG.md LICENSE LICENSE-APACHE LICENSE-MIT; do
+    if [[ -f "${STAGED_ROOT}/${doc}" ]]; then
+        run_root install -m 644 "${STAGED_ROOT}/${doc}" "${DOC_DIR}/${doc}"
+    elif [[ -n "${LOCAL_ROOT}" && -f "${LOCAL_ROOT}/${doc}" ]]; then
+        run_root install -m 644 "${LOCAL_ROOT}/${doc}" "${DOC_DIR}/${doc}"
+    fi
+done
+
+run_root cp -R "${STAGED_ROOT}/configs/." "${EXAMPLES_DIR}/"
+
+if [[ ! -f "${ACTIVE_CONFIG}" || "${FORCE}" -eq 1 ]]; then
+    run_root install -m 644 "${STAGED_ROOT}/configs/rginx.ron" "${ACTIVE_CONFIG}"
+    ACTIVE_CONFIG_RESULT="installed"
+else
+    ACTIVE_CONFIG_RESULT="preserved"
+fi
+
+TMP_MANIFEST="$(mktemp)"
+{
+    printf 'prefix=%q\n' "${PREFIX}"
+    printf 'config_dir=%q\n' "${CONFIG_DIR}"
+    printf 'bin_dir=%q\n' "${BIN_DIR}"
+    printf 'share_dir=%q\n' "${SHARE_DIR}"
+    printf 'doc_dir=%q\n' "${DOC_DIR}"
+    printf 'examples_dir=%q\n' "${EXAMPLES_DIR}"
+    printf 'active_config=%q\n' "${ACTIVE_CONFIG}"
+} > "${TMP_MANIFEST}"
+run_root install -m 644 "${TMP_MANIFEST}" "${MANIFEST_PATH}"
+rm -f "${TMP_MANIFEST}"
+
+log "binary: ${BIN_DIR}/rginx"
+log "uninstall: ${BIN_DIR}/rginx-uninstall"
+log "active config (${ACTIVE_CONFIG_RESULT}): ${ACTIVE_CONFIG}"
+log "example configs: ${EXAMPLES_DIR}"
+log "default config search will now pick ${ACTIVE_CONFIG} when running ${BIN_DIR}/rginx"
+
+if [[ "${CONFIG_DIR}" != "${PREFIX}/etc/rginx" ]]; then
+    log "custom config dir detected; run with --config ${ACTIVE_CONFIG} or set RGINX_CONFIG=${ACTIVE_CONFIG}"
+fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-$0}"
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
+DEFAULT_PREFIX="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PREFIX="${DEFAULT_PREFIX}"
+CONFIG_DIR=""
+PURGE_CONFIG=0
+YES=0
+SUDO=""
+
+usage() {
+    cat <<'EOF'
+Usage: uninstall.sh [options]
+
+Options:
+  --prefix <path>
+      安装前缀，默认从脚本所在位置推断
+  --config-dir <path>
+      活跃配置目录，默认读取安装 manifest 或使用 <prefix>/etc/rginx
+  --purge-config
+      一并删除活跃配置目录
+  -y, --yes
+      不提示确认，直接执行
+  -h, --help
+      显示帮助
+EOF
+}
+
+log() {
+    printf '[uninstall] %s\n' "$*"
+}
+
+die() {
+    printf '[uninstall] error: %s\n' "$*" >&2
+    exit 1
+}
+
+have() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prefix)
+            [[ $# -ge 2 ]] || die "--prefix requires a value"
+            PREFIX="$2"
+            shift 2
+            ;;
+        --config-dir)
+            [[ $# -ge 2 ]] || die "--config-dir requires a value"
+            CONFIG_DIR="$2"
+            shift 2
+            ;;
+        --purge-config)
+            PURGE_CONFIG=1
+            shift
+            ;;
+        -y|--yes)
+            YES=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+nearest_existing_parent() {
+    local path="$1"
+
+    while [[ ! -e "${path}" ]]; do
+        path="$(dirname "${path}")"
+    done
+
+    printf '%s\n' "${path}"
+}
+
+prepare_privileges() {
+    local target parent
+
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        return
+    fi
+
+    for target in "${BIN_DIR}" "${CONFIG_DIR}" "${DOC_DIR}" "${SHARE_DIR}"; do
+        parent="$(nearest_existing_parent "${target}")"
+        if [[ ! -w "${parent}" ]]; then
+            have sudo || die "uninstall target requires elevated privileges, but sudo is not available"
+            SUDO="sudo"
+            return
+        fi
+    done
+}
+
+run_root() {
+    if [[ -n "${SUDO}" ]]; then
+        "${SUDO}" "$@"
+        return
+    fi
+
+    "$@"
+}
+
+BIN_DIR="${PREFIX}/bin"
+SHARE_DIR="${PREFIX}/share/rginx"
+DOC_DIR="${PREFIX}/share/doc/rginx"
+EXAMPLES_DIR="${SHARE_DIR}/configs"
+MANIFEST_PATH="${SHARE_DIR}/install-manifest.txt"
+
+if [[ -f "${MANIFEST_PATH}" ]]; then
+    # shellcheck disable=SC1090
+    source "${MANIFEST_PATH}"
+fi
+
+PREFIX="${prefix:-${PREFIX}}"
+CONFIG_DIR="${CONFIG_DIR:-${config_dir:-${PREFIX}/etc/rginx}}"
+BIN_DIR="${bin_dir:-${PREFIX}/bin}"
+SHARE_DIR="${share_dir:-${PREFIX}/share/rginx}"
+DOC_DIR="${doc_dir:-${PREFIX}/share/doc/rginx}"
+EXAMPLES_DIR="${examples_dir:-${SHARE_DIR}/configs}"
+ACTIVE_CONFIG="${active_config:-${CONFIG_DIR}/rginx.ron}"
+MANIFEST_PATH="${SHARE_DIR}/install-manifest.txt"
+
+prepare_privileges
+
+if [[ "${YES}" -ne 1 ]]; then
+    printf 'This will remove:\n'
+    printf '  - %s\n' "${BIN_DIR}/rginx"
+    printf '  - %s\n' "${BIN_DIR}/rginx-uninstall"
+    printf '  - %s\n' "${DOC_DIR}"
+    printf '  - %s\n' "${EXAMPLES_DIR}"
+    if [[ "${PURGE_CONFIG}" -eq 1 ]]; then
+        printf '  - %s\n' "${CONFIG_DIR}"
+    else
+        printf '  - preserve %s\n' "${CONFIG_DIR}"
+    fi
+    printf 'Continue? [y/N] '
+    read -r answer
+    case "${answer}" in
+        y|Y|yes|YES)
+            ;;
+        *)
+            die "aborted"
+            ;;
+    esac
+fi
+
+run_root rm -f "${BIN_DIR}/rginx"
+run_root rm -f "${BIN_DIR}/rginx-uninstall"
+run_root rm -rf "${DOC_DIR}"
+run_root rm -rf "${EXAMPLES_DIR}"
+run_root rm -f "${MANIFEST_PATH}"
+
+if [[ "${PURGE_CONFIG}" -eq 1 ]]; then
+    run_root rm -rf "${CONFIG_DIR}"
+    run_root rmdir "$(dirname "${CONFIG_DIR}")" 2>/dev/null || true
+    log "removed config dir: ${CONFIG_DIR}"
+else
+    log "preserved config dir: ${CONFIG_DIR}"
+fi
+
+run_root rmdir "$(dirname "${DOC_DIR}")" 2>/dev/null || true
+run_root rmdir "${SHARE_DIR}" 2>/dev/null || true
+run_root rmdir "${PREFIX}/share" 2>/dev/null || true
+run_root rmdir "${BIN_DIR}" 2>/dev/null || true
+run_root rmdir "${PREFIX}" 2>/dev/null || true
+
+log "uninstall complete"

--- a/wiki/Quick-Start.md
+++ b/wiki/Quick-Start.md
@@ -4,9 +4,48 @@
 
 ## 前置条件
 
-- Rust 工具链可用
 - 本机可以绑定一个监听端口
+- 如果你要从源码构建，Rust 工具链需要可用
 - 如果你要测试热重载，建议在 Unix 环境下运行，因为 `SIGHUP` 只在 Unix 上启用
+
+## 一键安装与卸载
+
+源码目录下默认配置文件是 `configs/rginx.ron`。安装版会优先尝试 `<prefix>/etc/rginx/rginx.ron`。如果你安装时用了自定义 `--config-dir`，运行时请继续通过 `RGINX_CONFIG` 或 `--config` 显式指定。
+
+从源码仓库安装：
+
+```bash
+./scripts/install.sh --mode source
+```
+
+安装指定 GitHub Release 版本：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/vansour/rginx/main/scripts/install.sh | bash -s -- --mode release --version <tag>
+```
+
+其中 `latest` 只会解析最新稳定版；如果你要安装预发布版，请显式传入具体 tag，例如 `v0.1.1-rc.2`。
+
+默认安装位置：
+
+- `<prefix>/bin/rginx`
+- `<prefix>/bin/rginx-uninstall`
+- `<prefix>/etc/rginx/rginx.ron`
+- `<prefix>/share/rginx/configs`
+
+卸载：
+
+```bash
+rginx-uninstall
+rginx-uninstall --purge-config
+```
+
+安装完成后，默认配置路径可以直接这样验证：
+
+```bash
+rginx check
+rginx
+```
 
 ## 构建与启动
 


### PR DESCRIPTION
## Summary
- add install and uninstall scripts for source, archive, and release-based installation
- teach the CLI to auto-discover the installed default config path
- include scripts and release documentation files in packaged release archives
- document one-command install and uninstall flows in the README and wiki

## Validation
- bash -n scripts/install.sh scripts/uninstall.sh
- cargo fmt --all
- cargo fmt --all --check
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- source install/uninstall smoke test with default config discovery
- archive install/uninstall smoke test with manifest-based uninstall behavior
