### PR TITLE
release: prepare v0.1.3-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rginx"
-version = "0.1.3-rc.6"
+version = "0.1.3-rc.7"
 dependencies = [
  "anyhow",
  "base64",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "rginx-config"
-version = "0.1.3-rc.6"
+version = "0.1.3-rc.7"
 dependencies = [
  "http",
  "ipnet",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "rginx-core"
-version = "0.1.3-rc.6"
+version = "0.1.3-rc.7"
 dependencies = [
  "http",
  "ipnet",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "rginx-http"
-version = "0.1.3-rc.6"
+version = "0.1.3-rc.7"
 dependencies = [
  "base64",
  "brotli",
@@ -1251,14 +1251,14 @@ dependencies = [
 
 [[package]]
 name = "rginx-observability"
-version = "0.1.3-rc.6"
+version = "0.1.3-rc.7"
 dependencies = [
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "rginx-runtime"
-version = "0.1.3-rc.6"
+version = "0.1.3-rc.7"
 dependencies = [
  "bytes",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/rginx-app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3-rc.6"
+version = "0.1.3-rc.7"
 edition = "2024"
 authors = ["vansour"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `rginx` 是一个面向中小规模部署的 Rust 入口反向代理。
 
-当前版本：`v0.1.3-rc.6`
+当前版本：`v0.1.3-rc.7`
 
 它的目标很收口：
 
@@ -311,7 +311,7 @@ sudo apt install rginx
 
 当前约定：
 
-- 预发布 tag，例如 `v0.1.3-rc.6`：发布 GitHub Release 资产，但不更新 APT 仓库
+- 预发布 tag，例如 `v0.1.3-rc.7`：发布 GitHub Release 资产，但不更新 APT 仓库
 - 稳定 tag，例如 `v0.1.3`：同时发布 GitHub Release 和 GitHub Pages APT 仓库
 
 要让稳定版自动发布 APT 仓库，还需要一次性配置：


### PR DESCRIPTION
## Summary
- bump workspace version to 0.1.3-rc.7
- refresh lockfile and README current version
- prepare prerelease tag v0.1.3-rc.7

## Testing
- `./scripts/prepare-release.sh --tag v0.1.3-rc.7 --skip-fetch`
