### PR TITLE
Add end-to-end HTTP/3 support and prepare v0.1.3-rc.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: ./scripts/run-tls-gate.sh
 
   clippy:
-    name: Clippy Gate
+    name: Clippy
     runs-on: ubuntu-24.04
     steps:
       - name: Check Out Source

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - test-fast
+      - clippy
     steps:
       - name: Check Out Source
         uses: actions/checkout@v6.0.2
@@ -75,6 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - test-fast
+      - clippy
     steps:
       - name: Check Out Source
         uses: actions/checkout@v6.0.2
@@ -89,7 +91,7 @@ jobs:
         run: ./scripts/run-tls-gate.sh
 
   clippy:
-    name: Clippy
+    name: Clippy Gate
     runs-on: ubuntu-24.04
     steps:
       - name: Check Out Source
@@ -104,4 +106,4 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.1
 
       - name: Run Clippy
-        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+        run: ./scripts/run-clippy-gate.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,14 +114,14 @@ jobs:
       - name: Run Fast Test Layer
         run: ./scripts/test-fast.sh
 
+      - name: Run Clippy
+        run: ./scripts/run-clippy-gate.sh
+
       - name: Run Slow Test Layer
         run: ./scripts/test-slow.sh
 
       - name: Run TLS Release Gate
         run: ./scripts/run-tls-gate.sh
-
-      - name: Run Clippy
-        run: ./scripts/run-clippy-gate.sh
 
   build:
     name: Build ${{ matrix.asset_name }} Assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         run: ./scripts/run-tls-gate.sh
 
       - name: Run Clippy
-        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+        run: ./scripts/run-clippy-gate.sh
 
   build:
     name: Build ${{ matrix.asset_name }} Assets

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /target
 .aider*
 docs/
+/perf.data
+/perf.data.*
+/flamegraph-*.svg
+__pycache__/
+*.py[cod]

--- a/ARCHITECTURE_HTTP3_PHASE0_FREEZE.md
+++ b/ARCHITECTURE_HTTP3_PHASE0_FREEZE.md
@@ -1,0 +1,198 @@
+# HTTP/3 Phase 0 Semantics Freeze
+
+Updated: `2026-04-12`
+
+Status: `completed`
+
+## Purpose
+
+This document freezes the intended semantics for the first HTTP/3 delivery
+cycle before implementation work begins.
+
+It is not a schema document and it is not a transport implementation design.
+Its role is narrower:
+
+- define the first supported HTTP/3 surface area
+- define what is explicitly deferred
+- define the initial client-discovery policy
+- define which compatibility expectations later phases must preserve
+
+Phase 1 and later phases should treat this file as a contract unless a later
+document explicitly replaces it.
+
+## Terminology
+
+For clarity, this document uses three milestone labels:
+
+- `M1`: first downstream HTTP/3 release
+- `M2`: upstream HTTP/3 proxy support
+- `M3`: HTTP/3 gRPC and advanced parity work
+
+These labels are semantic groupings, not release numbers.
+
+## Frozen Decisions
+
+### 1. Activation Model
+
+HTTP/3 is frozen as an explicit opt-in capability.
+
+Implications:
+
+- HTTP/3 must not be enabled implicitly just because a listener already has TLS
+- HTTP/3 configuration is listener-scoped, not a global process toggle
+- the exact config field names are deferred to Phase 2
+- legacy single-listener configurations must keep working without silent HTTP/3
+  activation
+
+### 2. Transport and Discovery Model
+
+The initial client-discovery strategy is frozen as `Alt-Svc`.
+
+Implications:
+
+- `h3c` is out of scope
+- first-release HTTP/3 is TLS-only
+- HTTP/3 discovery should be advertised from compatible HTTPS responses via
+  `Alt-Svc`
+- HTTPS resource records are deferred and are not required for M1
+- DNS-level automatic discovery is not part of the first implementation target
+
+### 3. Downstream Scope for M1
+
+The first downstream HTTP/3 milestone is intentionally narrow.
+
+Included in M1:
+
+- ordinary downstream HTTP requests over HTTP/3
+- `Return` handlers
+- `Proxy` handlers
+- the same host and path routing semantics used by existing HTTP/1.1 and
+  HTTP/2 paths
+- the same route access control semantics
+- the same route rate-limit semantics
+- request ID propagation and generation
+- access logging integration
+- counters and traffic snapshot integration
+
+Explicitly not required in M1:
+
+- downstream gRPC over HTTP/3
+- downstream grpc-web over HTTP/3
+- websocket-over-HTTP/3
+- extended CONNECT support beyond what a later milestone explicitly approves
+- WebTransport
+- QUIC datagram application features
+
+### 4. Upstream Scope Freeze
+
+Upstream HTTP/3 is frozen as a later milestone, not part of M1.
+
+When upstream HTTP/3 is introduced:
+
+- it must be explicit, not silently folded into the current `Auto` behavior
+- first support should require explicit upstream protocol selection
+- current failover semantics remain unchanged:
+  - retry only idempotent requests
+  - retry only replayable requests
+
+This avoids turning "support upstream HTTP/3" into "change every current
+upstream selection rule at once".
+
+### 5. Compatibility Expectations Across Transports
+
+Later HTTP/3 phases are required to preserve these invariants:
+
+- the same `Host` to vhost selection rules as current HTTP/1.1 and HTTP/2
+- the same route priority rules
+- the same route access-control decisions
+- the same rate-limit decisions
+- the same request ID semantics
+- the same access-log field meanings
+- the same traffic and admin accounting semantics, modulo transport-specific
+  fields added later
+
+This is a freeze on behavior, not on implementation details.
+
+### 6. Control-Plane Expectations
+
+HTTP/3 must not be declared supported while control-plane output still hides or
+misreports transport state.
+
+Before support is claimed:
+
+- `check` must describe HTTP/3 listener state accurately
+- `status` must describe HTTP/3 listener state accurately
+- `snapshot` and `delta` must not collapse HTTP/3 into a TCP-only view
+
+The exact output format is deferred, but accurate transport-aware reporting is
+not optional.
+
+### 7. Reload and Restart Expectations
+
+Phase 0 freezes one negative rule:
+
+- HTTP/3 listener lifecycle behavior must not be left implicit
+
+Implications:
+
+- reloadability of HTTP/3 fields is deferred, not assumed
+- restart-boundary behavior for HTTP/3 listeners must be made explicit before
+  release
+- UDP socket inheritance and QUIC drain behavior are later design work, not an
+  implementation footnote
+
+### 8. Security and TLS Expectations
+
+Phase 0 freezes these security expectations:
+
+- first-release HTTP/3 is tied to TLS-enabled listeners
+- HTTP/3 certificate selection must not diverge from the listener’s effective
+  SNI and vhost rules
+- any future HTTP/3 TLS diagnostics must reflect runtime behavior, not a
+  synthetic TCP-only view
+
+Deferred from M1 unless later phases explicitly add them:
+
+- downstream mTLS over HTTP/3
+- full OCSP runtime parity for HTTP/3 listeners
+- advanced QUIC transport tuning exposure
+
+## Deferred Items
+
+The following are explicitly deferred beyond Phase 0 and must not be treated as
+accidental commitments:
+
+- downstream gRPC over HTTP/3
+- downstream grpc-web over HTTP/3
+- upstream HTTP/3 proxy support
+- active HTTP/3 health checks
+- downstream mTLS over HTTP/3
+- websocket-over-HTTP/3
+- WebTransport
+- HTTPS RR support
+- automatic `Auto`-mode upgrade to upstream HTTP/3
+
+## First Milestone Contract
+
+The frozen first milestone is:
+
+- downstream HTTP/3 ingress
+- explicit opt-in listener configuration
+- `Alt-Svc`-based discovery
+- `Return` and basic `Proxy`
+- parity for routing, policy, request ID, logging, counters, and traffic stats
+- no claim yet for upstream HTTP/3 or gRPC-over-HTTP/3
+
+If implementation work grows beyond this contract, that expansion must be
+captured in a new architecture decision, not smuggled into Phase 1 or Phase 3.
+
+## Phase 0 Exit Criteria
+
+Phase 0 is complete when:
+
+- the first-release HTTP/3 semantics are frozen in writing
+- deferred items are explicit
+- the staged architecture plan points to this freeze document
+
+Those criteria are satisfied by this document together with
+`ARCHITECTURE_HTTP3_PLAN.md`.

--- a/ARCHITECTURE_HTTP3_PLAN.md
+++ b/ARCHITECTURE_HTTP3_PLAN.md
@@ -1,0 +1,579 @@
+# HTTP/3 Architecture Plan
+
+Updated: `2026-04-12`
+
+## Purpose
+
+This document describes a staged plan for adding end-to-end HTTP/3 support to
+`rginx`.
+
+The target is broader than "accept HTTP/3 requests":
+
+- downstream HTTP/3 ingress
+- upstream HTTP/3 proxying
+- consistent routing, policy, logging, and observability across HTTP/1.1,
+  HTTP/2, and HTTP/3
+- explicit reload and restart semantics for HTTP/3 listeners
+
+The plan intentionally avoids mixing transport enablement with large semantic
+changes in a single batch.
+
+## Status
+
+- Phase 0 is complete.
+- Phase 1 is complete.
+- Phase 2 is complete.
+- Phase 3 is complete.
+- Phase 4 is complete.
+- Phase 5 is complete.
+- Phase 6 is complete.
+- Phase 7 is complete.
+- Phase 8 is complete.
+- The frozen first-release semantics live in
+  `ARCHITECTURE_HTTP3_PHASE0_FREEZE.md`.
+- The staged HTTP/3 delivery plan is complete.
+
+## Current Architectural Constraints
+
+The current codebase is organized around two assumptions that must be relaxed
+before HTTP/3 can land cleanly:
+
+1. one listener is effectively one TCP bind target
+2. request and response plumbing is tightly coupled to Hyper
+   `Incoming`-centric HTTP/1.1 and HTTP/2 paths
+
+These assumptions currently leak into:
+
+- config model and validation
+- runtime listener bootstrap and restart handoff
+- request-body preparation
+- upstream client selection
+- status and admin reporting
+- reload-boundary planning
+
+HTTP/3 should therefore be implemented as an explicit transport extension, not
+as an ad hoc patch on the current TCP-only path.
+
+## Guiding Principles
+
+- keep the existing HTTP/1.1 and HTTP/2 paths stable while HTTP/3 is added in
+  parallel
+- separate transport refactors from protocol-semantics work
+- do not promise feature parity for every advanced protocol feature in the
+  first delivery
+- make control-plane reporting accurate before shipping user-visible behavior
+- treat reload and restart behavior as first-class architecture work, not as a
+  postscript
+
+## Scope Target
+
+The intended final state is:
+
+- downstream HTTP/1.1, HTTP/2, and HTTP/3 on the same logical listener model
+- upstream HTTP/1.1, HTTP/2, and HTTP/3 proxy targets
+- shared routing, access control, rate limiting, access logging, counters, and
+  traffic snapshots across all downstream transports
+- shared peer selection, passive health, active health, TLS policy, and
+  upstream stats across all upstream transports
+
+The initial HTTP/3 delivery should not include:
+
+- cleartext `h3c`
+- WebTransport
+- extended CONNECT tunneling beyond what is required for a conservative first
+  release
+- a promise of websocket-over-HTTP/3 parity in the first batch
+
+## Recommended Transport Stack
+
+Recommended implementation stack:
+
+- QUIC transport: `quinn`
+- HTTP/3 protocol: `h3`
+- Quinn adapter: `h3-quinn`
+
+Rationale:
+
+- the current `hyper` APIs used in `rginx` are centered on HTTP/1.1 and HTTP/2
+- HTTP/3 support should be introduced as a parallel transport path rather than
+  waiting for a hypothetical drop-in `hyper` migration
+- this keeps the existing data plane stable while allowing a transport-neutral
+  internal request pipeline to emerge
+
+## Delivery Strategy
+
+Recommended delivery split:
+
+1. Batch 1: Phase 0, Phase 1, and Phase 2
+2. Batch 2: Phase 3 and Phase 4
+3. Batch 3: Phase 5 and Phase 6
+4. Batch 4: Phase 7 and Phase 8
+
+Each batch should be mergeable and testable on its own.
+
+## Phase 0: Semantics Freeze
+
+Goal:
+
+- define the first supported HTTP/3 surface area before code changes begin
+
+Scope:
+
+- write down explicit first-release semantics
+- define what is and is not included in the first HTTP/3 milestone
+- define the downstream discovery strategy for clients
+
+First-release recommendations:
+
+- downstream HTTP/3 only over TLS
+- no cleartext `h3c`
+- downstream `Return` and `Proxy` handlers supported
+- upstream HTTP/3 supported only through explicit upstream protocol
+  configuration
+- client discovery via `Alt-Svc`
+- HTTPS RR support deferred to a later enhancement
+- websocket-over-HTTP/3 and extended CONNECT deferred
+
+Exit criteria:
+
+- architecture notes, config semantics, and release scope are frozen
+- later phases can rely on a stable HTTP/3 target
+
+Completion status:
+
+- completed in `ARCHITECTURE_HTTP3_PHASE0_FREEZE.md`
+
+## Phase 1: Transport-Neutral Internal HTTP Pipeline
+
+Goal:
+
+- decouple request and response handling from transport-specific Hyper types
+
+Scope:
+
+- isolate Hyper HTTP/1.1 and HTTP/2 adaptation at the server edge
+- reshape internal handler and proxy entrypoints to work on transport-neutral
+  body and response abstractions
+- reduce direct dependence on `Incoming` and `Response<Incoming>` outside the
+  transport adapters
+
+Primary files:
+
+- `crates/rginx-http/src/handler/mod.rs`
+- `crates/rginx-http/src/handler/dispatch.rs`
+- `crates/rginx-http/src/proxy/request_body.rs`
+- `crates/rginx-http/src/proxy/forward/mod.rs`
+- `crates/rginx-http/src/proxy/forward/response.rs`
+- `crates/rginx-http/src/server/connection.rs`
+- `crates/rginx-http/src/server/graceful.rs`
+
+Implementation notes:
+
+- keep Hyper-specific adaptation near the accept and connection layers
+- keep the existing H1 and H2 behavior unchanged while refactoring
+- do not couple the internal pipeline to Quinn or `h3` yet
+
+Exit criteria:
+
+- HTTP/1.1 and HTTP/2 continue to pass existing tests
+- handler and proxy internals are no longer shaped primarily by Hyper
+  `Incoming`
+
+Completion status:
+
+- completed by pushing Hyper request-body adaptation to `server/graceful.rs`
+- completed by changing internal handler and proxy entrypoints to use
+  `HttpBody`
+- completed by changing upstream response finalization to consume
+  transport-neutral boxed bodies
+
+## Phase 2: Listener and Control-Plane Model Upgrade
+
+Goal:
+
+- replace the implicit TCP-only listener model with an explicit transport-aware
+  listener model
+
+Scope:
+
+- allow one logical listener to own multiple transport bindings
+- represent TCP and UDP bind points explicitly
+- expose HTTP/3 state in `check`, `status`, `snapshot`, and admin output
+- define reload and restart boundaries for new HTTP/3 fields
+
+Primary files:
+
+- `crates/rginx-core/src/config.rs`
+- `crates/rginx-config/src/model.rs`
+- `crates/rginx-config/src/validate/server.rs`
+- `crates/rginx-config/src/compile/server.rs`
+- `crates/rginx-http/src/transition.rs`
+- `crates/rginx-http/src/state/snapshots.rs`
+- `crates/rginx-app/src/main.rs`
+- `crates/rginx-app/src/admin_cli/status.rs`
+- `crates/rginx-runtime/src/bootstrap/listeners.rs`
+
+Recommended config direction:
+
+- add explicit HTTP/3 listener settings rather than overloading the existing
+  `listen` field
+- model UDP bind settings and QUIC transport settings explicitly
+- keep legacy single-listener configuration working
+
+Exit criteria:
+
+- the runtime can describe listener transport inventory accurately
+- restart-boundary planning no longer assumes every listener is only TCP
+
+Completion status:
+
+- completed by adding explicit listener-level `http3` configuration metadata
+- completed by exposing transport-aware listener bindings in compiled runtime
+  state
+- completed by updating `check`, `status`, and snapshot output to report TCP and
+  UDP listener bindings
+- completed by defining HTTP/3-specific reload and restart boundary fields
+
+## Phase 3: Downstream HTTP/3 Minimum Viable Path
+
+Goal:
+
+- accept downstream HTTP/3 requests and route them through the existing data
+  plane
+
+Scope:
+
+- add QUIC endpoint bootstrap and accept loops
+- terminate HTTP/3 requests and feed them into the transport-neutral internal
+  handler path
+- support `Return` and basic `Proxy`
+- expose HTTP/3 readiness to clients through `Alt-Svc`
+
+Primary files:
+
+- `crates/rginx-runtime/src/bootstrap/`
+- `crates/rginx-http/src/server/`
+- new HTTP/3 transport modules under `crates/rginx-http/src/`
+- `crates/rginx-http/src/handler/dispatch.rs`
+
+Implementation notes:
+
+- keep HTTP/3 as a parallel listener path, not a replacement for H1 and H2
+- do not block this phase on advanced gRPC-over-H3 support
+- keep QUIC transport configuration conservative in the first pass
+
+Exit criteria:
+
+- a configured listener can serve HTTP/3 requests
+- host routing, path routing, `Return`, and basic upstream proxying work over
+  HTTP/3
+- clients can discover HTTP/3 via `Alt-Svc`
+
+Completion status:
+
+- completed by adding a downstream QUIC/HTTP/3 accept path alongside the
+  existing Hyper HTTP/1.1 and HTTP/2 path
+- completed by bridging incoming HTTP/3 request bodies into the existing
+  transport-neutral handler pipeline
+- completed by bridging internal `HttpResponse` values back onto HTTP/3
+  response streams
+- completed by advertising HTTP/3 availability through `Alt-Svc` on compatible
+  TLS listeners
+
+## Phase 4: Downstream HTTP/3 Feature Parity for Core Middleware
+
+Goal:
+
+- align HTTP/3 ingress behavior with the existing HTTP/1.1 and HTTP/2
+  downstream feature set
+
+Scope:
+
+- downstream request size enforcement
+- downstream request-body read timeout semantics
+- downstream response idle timeout semantics
+- access control and rate limiting
+- request ID generation and propagation
+- access logging and counters
+- traffic snapshots and listener stats
+
+Primary files:
+
+- `crates/rginx-http/src/handler/access_log.rs`
+- `crates/rginx-http/src/handler/dispatch.rs`
+- `crates/rginx-http/src/rate_limit.rs`
+- `crates/rginx-http/src/state/connections.rs`
+- `crates/rginx-http/src/state/traffic.rs`
+- `crates/rginx-http/src/state/lifecycle.rs`
+- new HTTP/3 body and stream timeout adapters
+
+Focus areas:
+
+- keep the same routing and policy semantics across H1, H2, and H3
+- decide which response transforms remain valid on HTTP/3
+- ensure access logs and admin output record HTTP/3 traffic accurately
+
+Exit criteria:
+
+- HTTP/3 is part of the same policy and observability model as existing
+  downstream transports
+
+Completion status:
+
+- completed by validating route access control over downstream HTTP/3
+- completed by validating route rate limiting over downstream HTTP/3
+- completed by validating response compression over downstream HTTP/3
+- completed by validating request ID propagation and access log output over
+  downstream HTTP/3
+- completed by validating listener traffic accounting over downstream HTTP/3
+
+## Phase 5: Upstream HTTP/3 Client and Proxy Path
+
+Goal:
+
+- proxy from downstream requests to upstream HTTP/3 targets
+
+Scope:
+
+- add upstream HTTP/3 client profiles and connection management
+- support explicit `Http3` upstream protocol selection
+- preserve existing peer selection, failover, and health-registry integration
+- support upstream TLS validation, server-name override, and client identity
+  configuration
+
+Primary files:
+
+- `crates/rginx-core/src/config/upstream.rs`
+- `crates/rginx-config/src/model.rs`
+- `crates/rginx-config/src/validate/upstream.rs`
+- `crates/rginx-config/src/compile/upstream.rs`
+- `crates/rginx-http/src/proxy/clients/mod.rs`
+- new upstream HTTP/3 client modules under `crates/rginx-http/src/proxy/`
+- `crates/rginx-http/src/proxy/forward/mod.rs`
+
+Implementation notes:
+
+- do not overload the existing `Auto` upstream protocol behavior in the first
+  pass
+- first ship explicit `protocol: Http3`
+- keep the HTTP/1.1 and HTTP/2 upstream client cache stable
+
+Exit criteria:
+
+- an explicit HTTP/3 upstream can be selected and proxied successfully
+- failover rules remain coherent for replayable requests
+
+Completion status:
+
+- completed by extending upstream protocol configuration with explicit
+  `Http3`
+- completed by adding a dedicated upstream HTTP/3 client path alongside the
+  existing Hyper client path
+- completed by reusing existing peer selection, passive health, failover, and
+  upstream stats semantics for upstream HTTP/3 requests
+- completed by validating upstream HTTP/3 proxying with both basic TLS and
+  `server_name_override` plus client-identity configuration
+
+## Phase 6: gRPC, grpc-web, and Active Health over HTTP/3
+
+Goal:
+
+- extend HTTP/3 support to the project’s gRPC-oriented features
+
+Scope:
+
+- gRPC over downstream HTTP/3
+- gRPC over upstream HTTP/3
+- deadline and trailer behavior over HTTP/3
+- grpc-web compatibility review
+- active gRPC health checks over HTTP/3
+
+Primary files:
+
+- `crates/rginx-http/src/handler/grpc.rs`
+- `crates/rginx-http/src/proxy/forward/grpc.rs`
+- `crates/rginx-http/src/proxy/grpc_web/`
+- `crates/rginx-http/src/proxy/health.rs`
+- `crates/rginx-http/src/proxy/health/grpc_health_codec.rs`
+
+Focus areas:
+
+- trailer handling and observability extraction
+- grpc-web translation viability over downstream HTTP/3
+- deadline semantics and timeout mapping
+- parity between H2 gRPC and H3 gRPC diagnostics
+
+Exit criteria:
+
+- gRPC over HTTP/3 is no longer a separate experimental lane
+- active gRPC health checks can target HTTP/3-capable upstreams
+
+Completion status:
+
+- completed by validating downstream gRPC over HTTP/3 against explicit HTTP/3
+  upstreams, including gRPC response trailers
+- completed by validating grpc-web binary proxying over downstream and upstream
+  HTTP/3
+- completed by validating `grpc-timeout` deadline handling over HTTP/3 upstream
+  paths
+- completed by extending active gRPC health checks to target explicit HTTP/3
+  upstream peers
+- completed by covering the Phase 6 behavior in dedicated `grpc_http3`
+  integration tests
+
+## Phase 7: TLS, QUIC Runtime Semantics, Reload, and Restart
+
+Goal:
+
+- make HTTP/3 transport lifecycle behavior explicit and operationally safe
+
+Scope:
+
+- QUIC listener TLS settings
+- HTTP/3 certificate and SNI reporting
+- OCSP and certificate diagnostics for HTTP/3 listeners
+- UDP listener reload semantics
+- graceful restart and listener inheritance for UDP sockets
+- connection drain semantics for long-lived QUIC sessions
+
+Primary files:
+
+- `crates/rginx-http/src/tls/`
+- `crates/rginx-http/src/state/tls_runtime/`
+- `crates/rginx-runtime/src/bootstrap/listeners.rs`
+- `crates/rginx-runtime/src/restart.rs`
+- `crates/rginx-http/src/transition.rs`
+
+Key decisions:
+
+- which HTTP/3 listener fields are reloadable
+- which HTTP/3 transport settings require restart
+- how inherited UDP sockets are represented during graceful restart
+- whether `Alt-Svc` changes are reloadable or restart-boundary state
+
+Exit criteria:
+
+- reload and restart behavior for HTTP/3 is documented by code and tests
+- control-plane diagnostics reflect actual runtime behavior
+
+Completion status:
+
+- completed by extending TLS listener diagnostics to expose HTTP/3 listener
+  bindings, QUIC/TLS version constraints, and `h3` ALPN state alongside
+  existing certificate, SNI, and OCSP reporting
+- completed by preserving explicit HTTP/3 UDP listener sockets across graceful
+  restart handoff
+- completed by rejecting new HTTP/3 handshakes during drain while allowing
+  in-flight HTTP/3 requests to finish before listener shutdown completes
+- completed by validating HTTP/3 restart handoff and listener-removal drain
+  behavior in dedicated reload integration tests
+
+## Phase 8: Validation, Benchmarking, and Release Gate
+
+Goal:
+
+- validate HTTP/3 as a supported project capability rather than an opt-in demo
+
+Required coverage:
+
+- crate-local unit tests for HTTP/3 config, routing, TLS, and proxy behavior
+- integration tests for downstream HTTP/3
+- integration tests for upstream HTTP/3
+- integration tests for reload, restart, admin status, and access logs with
+  HTTP/3 enabled
+
+Required script updates:
+
+- `scripts/test-fast.sh`
+- `scripts/test-slow.sh`
+- `scripts/run-tls-gate.sh`
+- `scripts/run-soak.sh`
+- `scripts/nginx_compare/`
+
+Recommended new integration test groups:
+
+- `http3`
+- `upstream_http3`
+- `grpc_http3`
+- `reload_http3`
+- `multi_listener_http3`
+- `alt_svc`
+
+Exit criteria:
+
+- HTTP/3 is exercised by the normal project test and release gates
+- benchmark and soak tooling includes HTTP/3 scenarios
+
+Completion status:
+
+- completed by making `scripts/test-fast.sh` and `scripts/test-slow.sh` treat
+  HTTP/3 coverage as part of the default fast and slow validation paths
+- completed by extending `scripts/run-tls-gate.sh` to include downstream,
+  upstream, and gRPC-over-HTTP/3 regression suites
+- completed by extending `scripts/run-soak.sh` to include downstream HTTP/3,
+  upstream HTTP/3, and gRPC-over-HTTP/3 soak scenarios
+- completed by extending `scripts/run-benchmark-matrix.py` with HTTP/3 and
+  gRPC-over-HTTP/3 curl benchmark entries
+- completed by extending `scripts/nginx_compare/` with an explicit rginx
+  HTTP/3 benchmark scenario and an unsupported marker for nginx in the current
+  harness
+
+## Cross-Cutting Risks
+
+### Risk 1: Transport Refactor Without Behavior Freeze
+
+If HTTP/3 transport work begins before semantics are frozen, request handling,
+gRPC behavior, and reload semantics will drift during implementation.
+
+Mitigation:
+
+- complete Phase 0 before transport work starts
+
+### Risk 2: Hyper-Coupling Reappears During H3 Integration
+
+If new code keeps bending HTTP/3 around Hyper-specific request types, the code
+will become harder to reason about than it is today.
+
+Mitigation:
+
+- complete Phase 1 before serious HTTP/3 transport work
+- keep transport adapters at the edge
+
+### Risk 3: Listener Model Drift Between Runtime and Admin Output
+
+HTTP/3 adds UDP transport and QUIC state; if listener reporting is not fixed
+early, `check`, `status`, and snapshots will lie about runtime shape.
+
+Mitigation:
+
+- land Phase 2 before claiming first-class HTTP/3 support
+
+### Risk 4: Reload and Restart Become Underspecified
+
+The current restart flow is explicitly fd-inheritance-based. HTTP/3 will add
+UDP socket inheritance and QUIC drain behavior, which must not be left implicit.
+
+Mitigation:
+
+- treat Phase 7 as release-critical, not optional cleanup
+
+## Recommended Immediate Next Steps
+
+1. Start Phase 8 by folding the HTTP/3 suites into the normal release gate and
+   long-running validation scripts.
+2. Add broader soak and benchmark coverage for downstream and upstream HTTP/3
+   traffic profiles.
+3. Tighten any remaining HTTP/3-specific release criteria around reload,
+   restart, and access-log observability.
+
+## Suggested First Milestone
+
+Recommended first milestone:
+
+- downstream HTTP/3 ingress for `Return` and basic `Proxy`
+- `Alt-Svc` advertisement on compatible listeners
+- no upstream HTTP/3 yet
+- no gRPC-over-H3 parity requirement yet
+
+This keeps the first shipping target valuable while avoiding premature
+entanglement with the hardest protocol and lifecycle edges.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,12 +516,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -523,6 +545,23 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -553,9 +592,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -567,8 +610,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -578,9 +623,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -613,6 +660,34 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "h3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
+dependencies = [
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "h3-quinn"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2e732c8d91a74731663ac8479ab505042fbf547b9a207213ab7fbcbfc4f8b4"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3",
+ "quinn",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -869,6 +944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1094,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1119,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "futures-io",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1057,6 +1204,35 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rasn"
@@ -1158,7 +1334,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rginx"
-version = "0.1.3-rc.9"
+version = "0.1.3-rc.10"
 dependencies = [
  "anyhow",
  "base64",
@@ -1167,12 +1343,14 @@ dependencies = [
  "chrono",
  "clap",
  "flate2",
- "http",
+ "h3",
+ "h3-quinn",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
  "libc",
+ "quinn",
  "rasn",
  "rasn-ocsp",
  "rasn-pkix",
@@ -1182,7 +1360,6 @@ dependencies = [
  "rginx-observability",
  "rginx-runtime",
  "rustls",
- "rustls-pemfile",
  "serde_json",
  "sha1",
  "tokio",
@@ -1191,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "rginx-config"
-version = "0.1.3-rc.9"
+version = "0.1.3-rc.10"
 dependencies = [
  "http",
  "ipnet",
@@ -1204,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "rginx-core"
-version = "0.1.3-rc.9"
+version = "0.1.3-rc.10"
 dependencies = [
  "http",
  "ipnet",
@@ -1213,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "rginx-http"
-version = "0.1.3-rc.9"
+version = "0.1.3-rc.10"
 dependencies = [
  "base64",
  "brotli",
@@ -1221,22 +1398,22 @@ dependencies = [
  "chrono",
  "flate2",
  "futures-util",
+ "h3",
+ "h3-quinn",
  "http",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "num-bigint",
  "pin-project-lite",
+ "quinn",
  "rasn",
  "rasn-ocsp",
  "rasn-pkix",
  "rcgen",
- "rginx-config",
  "rginx-core",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-webpki",
  "serde",
  "sha1",
@@ -1249,14 +1426,14 @@ dependencies = [
 
 [[package]]
 name = "rginx-observability"
-version = "0.1.3-rc.9"
+version = "0.1.3-rc.10"
 dependencies = [
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "rginx-runtime"
-version = "0.1.3-rc.9"
+version = "0.1.3-rc.10"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -1264,6 +1441,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "libc",
+ "quinn",
  "rginx-config",
  "rginx-core",
  "rginx-http",
@@ -1302,6 +1480,12 @@ dependencies = [
  "typeid",
  "unicode-ident",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rusticata-macros"
@@ -1353,20 +1537,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1679,6 +1855,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +2156,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,6 +2434,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/rginx-app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3-rc.9"
+version = "0.1.3-rc.10"
 edition = "2024"
 authors = ["vansour"]
 license = "MIT OR Apache-2.0"
@@ -25,16 +25,18 @@ futures-util = "0.3"
 flate2 = "1.1"
 http = "1.4"
 http-body-util = "0.1"
+h3 = "0.0.8"
+h3-quinn = "0.0.10"
 hyper = { version = "1.9", features = ["client", "http1", "http2", "server"] }
 hyper-rustls = { version = "0.27.7", default-features = false, features = ["aws-lc-rs", "http1", "http2", "native-tokio", "tls12"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
 ipnet = "2.12"
 percent-encoding = "2.3"
 pin-project-lite = "0.2"
+quinn = { version = "0.11.9", default-features = false, features = ["runtime-tokio", "rustls-aws-lc-rs"] }
 ron = "0.12"
 rustls = "0.23.37"
 rustls-native-certs = "0.8.3"
-rustls-pemfile = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha1 = "0.11"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `rginx` 是一个面向中小规模部署的 Rust 入口反向代理。
 
-当前版本：`v0.1.3-rc.9`
+当前版本：`v0.1.3-rc.10`
 
 它的目标很收口：
 
@@ -33,6 +33,15 @@
 - peer `weight` / `backup`
 - 幂等或可重放请求的 failover
 - 入站 HTTP/2（TLS / ALPN）
+- 入站 HTTP/3（TLS / QUIC / Alt-Svc）
+- HTTP/3 下游路由级 ACL / 限流 / 压缩 / request-id / access log / traffic 统计
+- 上游 HTTP/3（显式 `protocol: Http3`）
+- gRPC / grpc-web over HTTP/3
+- HTTP/3 下的 gRPC trailers / deadline 语义
+- 面向 HTTP/3 upstream 的主动 gRPC health check
+- HTTP/3 listener 的 TLS / SNI / OCSP 诊断
+- HTTP/3 listener 的 reload / restart / drain 语义
+- HTTP/3 已纳入默认 fast/slow test gate、TLS gate、soak 和 benchmark 入口
 - 下游 TLS 版本控制（`TLS1.2` / `TLS1.3`）
 - 下游 ALPN 控制
 - 无 SNI 客户端的默认证书回退
@@ -69,6 +78,28 @@
 - Linux 下显式 fd 继承式优雅重启
 - `rginx check`
 - 本地只读运维面：`snapshot / snapshot-version / delta / wait / status / counters / traffic / peers / upstreams`
+
+## HTTP/3 规划
+
+当前仓库已经完成 HTTP/3 的全部八个阶段：
+
+- 下游 HTTP/3 ingress
+- `Return` / 基础 `Proxy`
+- `Alt-Svc` 广播
+- ACL / 限流 / 压缩 / request-id / access log / traffic 统计
+- 上游 HTTP/3 基础代理
+- 上游 HTTP/3 `server_name_override` / client identity
+- gRPC over HTTP/3
+- grpc-web over HTTP/3
+- HTTP/3 下的 gRPC deadline / trailers 行为
+- 面向 HTTP/3 upstream 的主动 gRPC health check
+- HTTP/3 listener 的 TLS / SNI / OCSP 诊断
+- HTTP/3 listener 的 reload / restart / drain 语义
+- HTTP/3 已纳入默认 fast/slow test gate、TLS gate、soak 和 benchmark 入口
+
+- 分阶段实施计划见 `ARCHITECTURE_HTTP3_PLAN.md`
+- 阶段 0 语义冻结见 `ARCHITECTURE_HTTP3_PHASE0_FREEZE.md`
+- 当前已完成阶段：Phase 0、Phase 1、Phase 2、Phase 3、Phase 4、Phase 5、Phase 6、Phase 7、Phase 8
 
 ## 仓库结构
 
@@ -127,12 +158,14 @@ cargo build -p rginx
 
 ```bash
 ./scripts/test-fast.sh
+./scripts/run-clippy-gate.sh
 ./scripts/test-slow.sh
 ```
 
-- `test-fast.sh` 运行 `rginx-core`、`rginx-config`、`rginx-http`、`rginx-runtime`、`rginx-observability` 的 crate 内测试，以及 `rginx` 二进制本身的单测。
-- `test-slow.sh` 运行 `crates/rginx-app/tests/` 下的集成测试。
-- `scripts/run-tls-gate.sh` 继续保留给 TLS 相关回归门禁和发布前检查。
+- `test-fast.sh` 运行 `rginx-core`、`rginx-config`、`rginx-http`、`rginx-runtime`、`rginx-observability` 的 crate 内测试，以及 `rginx` 二进制本身的单测；其中已经包含 HTTP/3 运行时与控制面单测。
+- `run-clippy-gate.sh` 运行 workspace 级 `cargo clippy --all-targets --all-features -- -D warnings`，并读取仓库根目录的 `clippy.toml` 作为默认 lint 基线。
+- `test-slow.sh` 顺序执行 `crates/rginx-app/tests/` 下的全部集成测试目标，并显式要求 `http3`、`upstream_http3`、`grpc_http3`、`reload`、`admin`、`check` 这些 HTTP/3 gate 目标存在。
+- `scripts/run-tls-gate.sh` 继续保留给 TLS 相关回归门禁和发布前检查；现在也包含 downstream / upstream / gRPC over HTTP/3 回归。
 
 ### 热更新边界
 
@@ -310,7 +343,7 @@ sudo apt install rginx
 
 当前约定：
 
-- 预发布 tag，例如 `v0.1.3-rc.9`：发布 GitHub Release 资产，但不更新 APT 仓库
+- 预发布 tag，例如 `v0.1.3-rc.10`：发布 GitHub Release 资产，但不更新 APT 仓库
 - 稳定 tag，例如 `v0.1.3`：同时发布 GitHub Release 和 GitHub Pages APT 仓库
 
 要让稳定版自动发布 APT 仓库，还需要一次性配置：
@@ -573,7 +606,9 @@ python3 scripts/run-benchmark-matrix.py \
   --http1-url http://127.0.0.1:18080/ \
   --https-url https://127.0.0.1:18443/ \
   --http2-url https://127.0.0.1:18443/ \
+  --http3-url https://127.0.0.1:18443/ \
   --grpc-url https://127.0.0.1:18443/grpc.health.v1.Health/Check \
+  --grpc-http3-url https://127.0.0.1:18443/grpc.health.v1.Health/Check \
   --grpc-web-url http://127.0.0.1:18080/grpc.health.v1.Health/Check \
   --grpc-web-text-url http://127.0.0.1:18080/grpc.health.v1.Health/Check \
   --requests 200 \
@@ -590,9 +625,20 @@ python3 scripts/run-benchmark-matrix.py \
 
 ```bash
 ./scripts/test-fast.sh
+./scripts/run-clippy-gate.sh
 ./scripts/test-slow.sh
 ./scripts/run-soak.sh --iterations 1
 ```
+
+如果你需要本地对比 `rginx` 和 `nginx` 的基准结果，可以继续用：
+
+```bash
+python3 scripts/nginx_compare/main.py \
+  --workspace . \
+  --out-dir target/nginx-compare
+```
+
+当前 compare harness 会实际跑 `rginx` 的 HTTP/3 场景；`nginx` 一侧在这套本地构建配置下会被标记为 unsupported，因为当前 harness 没有启用 QUIC/HTTP/3 构建链路。
 
 ### TLS Release Gate
 
@@ -600,6 +646,7 @@ python3 scripts/run-benchmark-matrix.py \
 
 ```bash
 ./scripts/test-fast.sh
+./scripts/run-clippy-gate.sh
 ./scripts/test-slow.sh
 ./scripts/run-tls-gate.sh
 ./scripts/run-soak.sh --iterations 1
@@ -609,6 +656,7 @@ rginx check --config /etc/rginx/rginx.ron
 建议把这几项当成 TLS 子系统的最小发布门槛：
 
 - 下游 TLS / SNI / 默认证书回退通过
+- downstream / upstream / gRPC over HTTP/3 regression 通过
 - 下游 mTLS 通过
 - 上游 HTTPS / mTLS / HTTP2 / SNI 通过
 - access log / admin / check 的 TLS 可观测性通过

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,4 @@
+# Keep the repo-wide Clippy baseline explicit so local runs and CI use the same
+# policy surface.
+msrv = "1.85.0"
 too-many-arguments-threshold = 8

--- a/configs/conf.d/default.ron
+++ b/configs/conf.d/default.ron
@@ -1,6 +1,7 @@
 VirtualHostConfig(
     server_names: ["app.example.com"],
     // For per-vhost certificate overrides, see the commented TLS examples in `example/conf.d/default.ron`.
+    // Reverse-proxy examples live in `example/conf.d/default.ron`.
     // Example:
     // tls: Some(VirtualHostTlsConfig(
     //     cert_path: "/etc/rginx/certs/app.example.com.crt",
@@ -17,8 +18,10 @@ VirtualHostConfig(
         ),
         LocationConfig(
             matcher: Prefix("/v1"),
-            handler: Proxy(
-                upstream: "backend",
+            handler: Return(
+                status: 200,
+                location: "",
+                body: Some("app.example.com v1\n"),
             ),
         ),
     ],

--- a/configs/rginx.ron
+++ b/configs/rginx.ron
@@ -14,31 +14,18 @@ Config(
         //     ocsp_staple_path: Some("/var/cache/rginx/default.ocsp"),
         //     session_tickets: Some(false),
         // )),
+        // Fresh installs should work without any upstream dependencies.
+        // Reverse-proxy examples live in `example/rginx.ron`.
         // For per-vhost certificate overrides, see `configs/conf.d/default.ron`.
     ),
-    upstreams: [
-        UpstreamConfig(
-            name: "backend",
-            peers: [
-                UpstreamPeerConfig(
-                    url: "http://127.0.0.1:9000",
-                ),
-            ],
-            connect_timeout_secs: Some(3),
-            read_timeout_secs: Some(30),
-            write_timeout_secs: Some(30),
-            idle_timeout_secs: Some(60),
-            pool_idle_timeout_secs: Some(90),
-            pool_max_idle_per_host: Some(64),
-            tcp_keepalive_secs: Some(30),
-            tcp_nodelay: Some(true),
-        ),
-    ],
+    upstreams: [],
     locations: [
         LocationConfig(
             matcher: Exact("/"),
-            handler: Proxy(
-                upstream: "backend",
+            handler: Return(
+                status: 200,
+                location: "",
+                body: Some("Welcome to rginx!\nIf you see this page, the rginx web server is successfully installed and working.\n"),
             ),
         ),
         LocationConfig(
@@ -48,14 +35,6 @@ Config(
                 location: "",
                 body: Some("ok\n"),
             ),
-        ),
-        LocationConfig(
-            matcher: Prefix("/api"),
-            handler: Proxy(
-                upstream: "backend",
-            ),
-            requests_per_sec: Some(20),
-            burst: Some(10),
         ),
     ],
     servers: [

--- a/crates/rginx-app/Cargo.toml
+++ b/crates/rginx-app/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["network-programming", "web-programming::http-server"]
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-http.workspace = true
 libc = "0.2"
 rginx-config = { path = "../rginx-config" }
 rginx-http = { path = "../rginx-http" }
@@ -31,13 +30,15 @@ brotli.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 flate2.workspace = true
+h3.workspace = true
+h3-quinn.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
 hyper-rustls.workspace = true
 hyper-util.workspace = true
 libc = "0.2"
+quinn.workspace = true
 rustls.workspace = true
-rustls-pemfile.workspace = true
 rcgen = "0.14"
 rasn = "0.28.11"
 rasn-ocsp = "0.28.11"

--- a/crates/rginx-app/src/admin_cli/status.rs
+++ b/crates/rginx-app/src/admin_cli/status.rs
@@ -18,10 +18,8 @@ pub(super) fn print_admin_status(config_path: &Path) -> anyhow::Result<()> {
                     .collect::<Vec<_>>()
                     .join(",")
             };
-            let bind_addrs = if status.listeners.is_empty() {
-                "-".to_string()
-            } else {
-                status
+            let bind_addrs = {
+                let bind_addrs = status
                     .listeners
                     .iter()
                     .flat_map(|listener| {
@@ -29,8 +27,8 @@ pub(super) fn print_admin_status(config_path: &Path) -> anyhow::Result<()> {
                             format!("{}://{}", binding.transport, binding.listen_addr)
                         })
                     })
-                    .collect::<Vec<_>>()
-                    .join(",")
+                    .collect::<Vec<_>>();
+                if bind_addrs.is_empty() { "-".to_string() } else { bind_addrs.join(",") }
             };
             print_record(
                 "status",

--- a/crates/rginx-app/src/admin_cli/status.rs
+++ b/crates/rginx-app/src/admin_cli/status.rs
@@ -18,6 +18,20 @@ pub(super) fn print_admin_status(config_path: &Path) -> anyhow::Result<()> {
                     .collect::<Vec<_>>()
                     .join(",")
             };
+            let bind_addrs = if status.listeners.is_empty() {
+                "-".to_string()
+            } else {
+                status
+                    .listeners
+                    .iter()
+                    .flat_map(|listener| {
+                        listener.bindings.iter().map(|binding| {
+                            format!("{}://{}", binding.transport, binding.listen_addr)
+                        })
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",")
+            };
             print_record(
                 "status",
                 [
@@ -32,7 +46,17 @@ pub(super) fn print_admin_status(config_path: &Path) -> anyhow::Result<()> {
                             .unwrap_or_else(|| "-".to_string()),
                     ),
                     ("listeners", status.listeners.len().to_string()),
+                    (
+                        "listener_bindings",
+                        status
+                            .listeners
+                            .iter()
+                            .map(|listener| listener.binding_count)
+                            .sum::<usize>()
+                            .to_string(),
+                    ),
                     ("listen_addrs", listen_addrs),
+                    ("bind_addrs", bind_addrs),
                     (
                         "worker_threads",
                         status
@@ -45,6 +69,15 @@ pub(super) fn print_admin_status(config_path: &Path) -> anyhow::Result<()> {
                     ("routes", status.total_routes.to_string()),
                     ("upstreams", status.total_upstreams.to_string()),
                     ("tls", if status.tls_enabled { "enabled" } else { "disabled" }.to_string()),
+                    (
+                        "http3",
+                        if status.listeners.iter().any(|listener| listener.http3_enabled) {
+                            "enabled"
+                        } else {
+                            "disabled"
+                        }
+                        .to_string(),
+                    ),
                     ("tls_listeners", status.tls.listeners.len().to_string()),
                     ("tls_certificates", status.tls.certificates.len().to_string()),
                     ("tls_ocsp_entries", status.tls.ocsp.len().to_string()),
@@ -107,9 +140,14 @@ pub(super) fn print_admin_status(config_path: &Path) -> anyhow::Result<()> {
                         ("listener", listener.listener_name.clone()),
                         ("listener_id", listener.listener_id.clone()),
                         ("listen", listener.listen_addr.to_string()),
+                        ("transport_bindings", listener.binding_count.to_string()),
                         (
                             "tls",
                             if listener.tls_enabled { "enabled" } else { "disabled" }.to_string(),
+                        ),
+                        (
+                            "http3",
+                            if listener.http3_enabled { "enabled" } else { "disabled" }.to_string(),
                         ),
                         ("proxy_protocol", listener.proxy_protocol_enabled.to_string()),
                         (
@@ -127,6 +165,98 @@ pub(super) fn print_admin_status(config_path: &Path) -> anyhow::Result<()> {
                         (
                             "access_log_format_configured",
                             listener.access_log_format_configured.to_string(),
+                        ),
+                    ],
+                );
+                for binding in &listener.bindings {
+                    print_record(
+                        "status_listener_binding",
+                        [
+                            ("listener", listener.listener_id.clone()),
+                            ("binding", binding.binding_name.clone()),
+                            ("transport", binding.transport.clone()),
+                            ("listen", binding.listen_addr.to_string()),
+                            (
+                                "protocols",
+                                if binding.protocols.is_empty() {
+                                    "-".to_string()
+                                } else {
+                                    binding.protocols.join(",")
+                                },
+                            ),
+                            (
+                                "advertise_alt_svc",
+                                binding
+                                    .advertise_alt_svc
+                                    .map(|value| value.to_string())
+                                    .unwrap_or_else(|| "-".to_string()),
+                            ),
+                            (
+                                "alt_svc_max_age_secs",
+                                binding
+                                    .alt_svc_max_age_secs
+                                    .map(|value| value.to_string())
+                                    .unwrap_or_else(|| "-".to_string()),
+                            ),
+                        ],
+                    );
+                }
+            }
+            for listener in &status.tls.listeners {
+                print_record(
+                    "status_tls_listener",
+                    [
+                        ("listener", listener.listener_name.clone()),
+                        ("listener_id", listener.listener_id.clone()),
+                        ("listen", listener.listen_addr.to_string()),
+                        ("tls", listener.tls_enabled.to_string()),
+                        ("http3_enabled", listener.http3_enabled.to_string()),
+                        (
+                            "http3_listen",
+                            listener
+                                .http3_listen_addr
+                                .map(|listen_addr| listen_addr.to_string())
+                                .unwrap_or_else(|| "-".to_string()),
+                        ),
+                        (
+                            "default_certificate",
+                            listener.default_certificate.clone().unwrap_or_else(|| "-".to_string()),
+                        ),
+                        (
+                            "tcp_versions",
+                            listener
+                                .versions
+                                .as_ref()
+                                .map(|versions| render_optional_string_list(Some(versions)))
+                                .unwrap_or_else(|| "-".to_string()),
+                        ),
+                        (
+                            "tcp_alpn_protocols",
+                            render_optional_string_list(Some(&listener.alpn_protocols)),
+                        ),
+                        (
+                            "http3_versions",
+                            render_optional_string_list(Some(&listener.http3_versions)),
+                        ),
+                        (
+                            "http3_alpn_protocols",
+                            render_optional_string_list(Some(&listener.http3_alpn_protocols)),
+                        ),
+                        ("sni_names", render_optional_string_list(Some(&listener.sni_names))),
+                        (
+                            "client_auth_mode",
+                            listener.client_auth_mode.clone().unwrap_or_else(|| "-".to_string()),
+                        ),
+                        (
+                            "client_auth_verify_depth",
+                            listener
+                                .client_auth_verify_depth
+                                .map(|value| value.to_string())
+                                .unwrap_or_else(|| "-".to_string()),
+                        ),
+                        (
+                            "client_auth_crl_configured",
+                            listener.client_auth_crl_configured.to_string(),
                         ),
                     ],
                 );

--- a/crates/rginx-app/src/main.rs
+++ b/crates/rginx-app/src/main.rs
@@ -54,8 +54,10 @@ fn main() -> anyhow::Result<()> {
                         config.listeners.first().map(|listener| listener.name.as_str()),
                     ),
                     listener_count: config.total_listener_count(),
+                    listener_binding_count: config.total_listener_binding_count(),
                     listeners: check_listener_summaries(&config),
                     tls_enabled: config.tls_enabled(),
+                    http3_enabled: config.http3_enabled(),
                     total_vhost_count: config.total_vhost_count(),
                     total_route_count: config.total_route_count(),
                     upstream_count: config.upstreams.len(),
@@ -79,8 +81,10 @@ fn main() -> anyhow::Result<()> {
                         config.listeners.first().map(|listener| listener.name.as_str()),
                     ),
                     listener_count: config.total_listener_count(),
+                    listener_binding_count: config.total_listener_binding_count(),
                     listeners: check_listener_summaries(&config),
                     tls_enabled: config.tls_enabled(),
+                    http3_enabled: config.http3_enabled(),
                     total_vhost_count: config.total_vhost_count(),
                     total_route_count: config.total_route_count(),
                     upstream_count: config.upstreams.len(),
@@ -129,8 +133,10 @@ fn build_runtime(worker_threads: Option<usize>) -> anyhow::Result<tokio::runtime
 struct CheckSummary {
     listener_model: &'static str,
     listener_count: usize,
+    listener_binding_count: usize,
     listeners: Vec<CheckListenerSummary>,
     tls_enabled: bool,
+    http3_enabled: bool,
     total_vhost_count: usize,
     total_route_count: usize,
     upstream_count: usize,
@@ -143,12 +149,24 @@ struct CheckListenerSummary {
     id: String,
     name: String,
     listen_addr: std::net::SocketAddr,
+    binding_count: usize,
+    http3_enabled: bool,
     tls_enabled: bool,
     proxy_protocol_enabled: bool,
     default_certificate: Option<String>,
     keep_alive: bool,
     max_connections: Option<usize>,
     access_log_format_configured: bool,
+    bindings: Vec<CheckListenerBindingSummary>,
+}
+
+struct CheckListenerBindingSummary {
+    binding_name: String,
+    transport: String,
+    listen_addr: std::net::SocketAddr,
+    protocols: Vec<String>,
+    advertise_alt_svc: Option<bool>,
+    alt_svc_max_age_secs: Option<u64>,
 }
 
 struct TlsCheckDetails {
@@ -160,6 +178,7 @@ struct TlsCheckDetails {
     expiring_certificates: Vec<String>,
     reloadable_fields: Vec<String>,
     restart_required_fields: Vec<String>,
+    listeners: Vec<rginx_http::TlsListenerStatusSnapshot>,
     certificates: Vec<rginx_http::TlsCertificateStatusSnapshot>,
     ocsp: Vec<rginx_http::TlsOcspStatusSnapshot>,
     vhost_bindings: Vec<rginx_http::TlsVhostBindingSnapshot>,
@@ -194,13 +213,31 @@ fn print_check_success(config_path: &Path, summary: CheckSummary) {
             .collect::<Vec<_>>()
             .join(",")
     };
+    let bind_addrs = if summary.listeners.is_empty() {
+        "-".to_string()
+    } else {
+        summary
+            .listeners
+            .iter()
+            .flat_map(|listener| {
+                listener
+                    .bindings
+                    .iter()
+                    .map(|binding| format!("{}://{}", binding.transport, binding.listen_addr))
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    };
     println!(
-        "configuration is valid: config={} listener_model={} listeners={} listen_addrs={} tls={} vhosts={} routes={} upstreams={} worker_threads={} accept_workers={}",
+        "configuration is valid: config={} listener_model={} listeners={} listener_bindings={} listen_addrs={} bind_addrs={} tls={} http3={} vhosts={} routes={} upstreams={} worker_threads={} accept_workers={}",
         config_path.display(),
         summary.listener_model,
         summary.listener_count,
+        summary.listener_binding_count,
         listen_addrs,
+        bind_addrs,
         if summary.tls_enabled { "enabled" } else { "disabled" },
+        if summary.http3_enabled { "enabled" } else { "disabled" },
         summary.total_vhost_count,
         summary.total_route_count,
         summary.upstream_count,
@@ -212,11 +249,13 @@ fn print_check_success(config_path: &Path, summary: CheckSummary) {
     );
     for listener in &summary.listeners {
         println!(
-            "check_listener id={} name={} listen={} tls={} proxy_protocol={} default_certificate={} keep_alive={} max_connections={} access_log_format_configured={}",
+            "check_listener id={} name={} listen={} transport_bindings={} tls={} http3={} proxy_protocol={} default_certificate={} keep_alive={} max_connections={} access_log_format_configured={}",
             listener.id,
             listener.name,
             listener.listen_addr,
+            listener.binding_count,
             if listener.tls_enabled { "enabled" } else { "disabled" },
+            if listener.http3_enabled { "enabled" } else { "disabled" },
             listener.proxy_protocol_enabled,
             listener.default_certificate.as_deref().unwrap_or("-"),
             listener.keep_alive,
@@ -226,6 +265,28 @@ fn print_check_success(config_path: &Path, summary: CheckSummary) {
                 .unwrap_or_else(|| "-".to_string()),
             listener.access_log_format_configured,
         );
+        for binding in &listener.bindings {
+            println!(
+                "check_listener_binding listener={} binding={} transport={} listen={} protocols={} advertise_alt_svc={} alt_svc_max_age_secs={}",
+                listener.id,
+                binding.binding_name,
+                binding.transport,
+                binding.listen_addr,
+                if binding.protocols.is_empty() {
+                    "-".to_string()
+                } else {
+                    binding.protocols.join(",")
+                },
+                binding
+                    .advertise_alt_svc
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                binding
+                    .alt_svc_max_age_secs
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+            );
+        }
     }
     println!("reload_requires_restart_for={}", summary.tls.restart_required_fields.join(","));
     println!(
@@ -245,6 +306,47 @@ fn print_check_success(config_path: &Path, summary: CheckSummary) {
         println!("tls_expiring_certificates={}", summary.tls.expiring_certificates.join(","));
     }
     println!("tls_restart_required_fields={}", summary.tls.restart_required_fields.join(","));
+    for listener in &summary.tls.listeners {
+        println!(
+            "tls_listener listener={} listener_id={} listen={} tls={} default_certificate={} tcp_versions={} tcp_alpn_protocols={} http3_enabled={} http3_listen={} http3_versions={} http3_alpn_protocols={} sni_names={}",
+            listener.listener_name,
+            listener.listener_id,
+            listener.listen_addr,
+            listener.tls_enabled,
+            listener.default_certificate.as_deref().unwrap_or("-"),
+            listener
+                .versions
+                .as_ref()
+                .filter(|versions| !versions.is_empty())
+                .map(|versions| versions.join(","))
+                .unwrap_or_else(|| "-".to_string()),
+            if listener.alpn_protocols.is_empty() {
+                "-".to_string()
+            } else {
+                listener.alpn_protocols.join(",")
+            },
+            listener.http3_enabled,
+            listener
+                .http3_listen_addr
+                .map(|listen_addr| listen_addr.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            if listener.http3_versions.is_empty() {
+                "-".to_string()
+            } else {
+                listener.http3_versions.join(",")
+            },
+            if listener.http3_alpn_protocols.is_empty() {
+                "-".to_string()
+            } else {
+                listener.http3_alpn_protocols.join(",")
+            },
+            if listener.sni_names.is_empty() {
+                "-".to_string()
+            } else {
+                listener.sni_names.join(",")
+            },
+        );
+    }
     for certificate in &summary.tls.certificates {
         println!(
             "tls_certificate scope={} sha256={} subject={:?} issuer={:?} serial={:?} chain_length={} diagnostics={} cert_path={}",
@@ -379,16 +481,38 @@ fn check_listener_summaries(config: &rginx_config::ConfigSnapshot) -> Vec<CheckL
     config
         .listeners
         .iter()
-        .map(|listener| CheckListenerSummary {
-            id: listener.id.clone(),
-            name: listener.name.clone(),
-            listen_addr: listener.server.listen_addr,
-            tls_enabled: listener.tls_enabled(),
-            proxy_protocol_enabled: listener.proxy_protocol_enabled,
-            default_certificate: listener.server.default_certificate.clone(),
-            keep_alive: listener.server.keep_alive,
-            max_connections: listener.server.max_connections,
-            access_log_format_configured: listener.server.access_log_format.is_some(),
+        .map(|listener| {
+            let bindings = listener
+                .transport_bindings()
+                .into_iter()
+                .map(|binding| CheckListenerBindingSummary {
+                    binding_name: binding.name.to_string(),
+                    transport: binding.kind.as_str().to_string(),
+                    listen_addr: binding.listen_addr,
+                    protocols: binding
+                        .protocols
+                        .into_iter()
+                        .map(|protocol| protocol.as_str().to_string())
+                        .collect(),
+                    advertise_alt_svc: binding.alt_svc_max_age.map(|_| binding.advertise_alt_svc),
+                    alt_svc_max_age_secs: binding.alt_svc_max_age.map(|max_age| max_age.as_secs()),
+                })
+                .collect::<Vec<_>>();
+
+            CheckListenerSummary {
+                id: listener.id.clone(),
+                name: listener.name.clone(),
+                listen_addr: listener.server.listen_addr,
+                binding_count: listener.binding_count(),
+                http3_enabled: listener.http3_enabled(),
+                tls_enabled: listener.tls_enabled(),
+                proxy_protocol_enabled: listener.proxy_protocol_enabled,
+                default_certificate: listener.server.default_certificate.clone(),
+                keep_alive: listener.server.keep_alive,
+                max_connections: listener.server.max_connections,
+                access_log_format_configured: listener.server.access_log_format.is_some(),
+                bindings,
+            }
         })
         .collect()
 }
@@ -485,6 +609,7 @@ fn tls_check_details(config: &rginx_config::ConfigSnapshot) -> TlsCheckDetails {
         expiring_certificates,
         reloadable_fields: tls.reload_boundary.reloadable_fields,
         restart_required_fields: tls.reload_boundary.restart_required_fields,
+        listeners: tls.listeners,
         vhost_bindings: tls.vhost_bindings,
         ocsp: tls.ocsp,
         certificates: tls.certificates,

--- a/crates/rginx-app/tests/admin/commands.rs
+++ b/crates/rginx-app/tests/admin/commands.rs
@@ -73,6 +73,52 @@ fn status_command_reports_explicit_listener_inventory() {
 }
 
 #[test]
+fn status_command_reports_http3_listener_bindings() {
+    let cert = generate_cert("localhost");
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-admin-status-http3",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| {
+            format!(
+                "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some(\"ok\\n\"),\n            ),\n        ),\n    ],\n)\n",
+                listen_addr.to_string(),
+                cert_path.display().to_string(),
+                key_path.display().to_string(),
+                ready_route = READY_ROUTE_CONFIG,
+            )
+        },
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+    let socket_path = admin_socket_path_for_config(server.config_path());
+    wait_for_admin_socket(&socket_path, Duration::from_secs(5));
+
+    let output = run_rginx(["--config", server.config_path().to_str().unwrap(), "status"]);
+    assert!(output.status.success(), "status command should succeed: {}", render_output(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("listener_bindings=2"));
+    assert!(stdout.contains("bind_addrs=tcp://"));
+    assert!(stdout.contains("udp://"));
+    assert!(stdout.contains("http3=enabled"));
+    assert!(stdout.contains("kind=status_listener"));
+    assert!(stdout.contains("transport_bindings=2"));
+    assert!(stdout.contains("kind=status_listener_binding"));
+    assert!(stdout.contains("binding=tcp"));
+    assert!(stdout.contains("binding=udp"));
+    assert!(stdout.contains("transport=udp"));
+    assert!(stdout.contains("protocols=http3"));
+    assert!(stdout.contains("advertise_alt_svc=true"));
+    assert!(stdout.contains("alt_svc_max_age_secs=7200"));
+    assert!(stdout.contains("kind=status_tls_listener"));
+    assert!(stdout.contains("http3_enabled=true"));
+    assert!(stdout.contains("http3_versions=TLS1.3"));
+    assert!(stdout.contains("http3_alpn_protocols=h3"));
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[test]
 fn counters_command_reports_local_connection_and_response_counters() {
     let listen_addr = reserve_loopback_addr();
     let mut server = ServerHarness::spawn("rginx-admin-counters", |_| return_config(listen_addr));

--- a/crates/rginx-app/tests/admin/snapshot.rs
+++ b/crates/rginx-app/tests/admin/snapshot.rs
@@ -40,7 +40,7 @@ fn snapshot_command_returns_aggregate_json_snapshot() {
     let AdminResponse::Snapshot(snapshot) = response else {
         panic!("admin socket should return aggregate snapshot");
     };
-    assert_eq!(snapshot.schema_version, 11);
+    assert_eq!(snapshot.schema_version, 12);
     assert!(snapshot.captured_at_unix_ms > 0);
     assert!(snapshot.pid > 0);
     assert_eq!(snapshot.binary_version, env!("CARGO_PKG_VERSION"));
@@ -65,7 +65,7 @@ fn snapshot_command_returns_aggregate_json_snapshot() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let snapshot: serde_json::Value =
         serde_json::from_str(&stdout).expect("snapshot command should print valid JSON");
-    assert_eq!(snapshot["schema_version"], serde_json::Value::from(11));
+    assert_eq!(snapshot["schema_version"], serde_json::Value::from(12));
     assert!(snapshot["captured_at_unix_ms"].as_u64().unwrap_or(0) > 0);
     assert!(snapshot["pid"].as_u64().unwrap_or(0) > 0);
     assert_eq!(snapshot["binary_version"], serde_json::Value::from(env!("CARGO_PKG_VERSION")));
@@ -79,6 +79,96 @@ fn snapshot_command_returns_aggregate_json_snapshot() {
     assert_eq!(snapshot["traffic"]["listeners"].as_array().map(Vec::len), Some(1));
     assert_eq!(snapshot["peer_health"].as_array().map(Vec::len), Some(1));
     assert_eq!(snapshot["upstreams"].as_array().map(Vec::len), Some(1));
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[test]
+fn snapshot_reports_http3_listener_bindings() {
+    let cert = generate_cert("localhost");
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-admin-http3-snapshot",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| {
+            format!(
+                "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some(\"ok\\n\"),\n            ),\n        ),\n    ],\n)\n",
+                listen_addr.to_string(),
+                cert_path.display().to_string(),
+                key_path.display().to_string(),
+                ready_route = READY_ROUTE_CONFIG,
+            )
+        },
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+    let socket_path = admin_socket_path_for_config(server.config_path());
+    wait_for_admin_socket(&socket_path, Duration::from_secs(5));
+
+    let response = query_admin_socket(
+        &socket_path,
+        AdminRequest::GetSnapshot { include: None, window_secs: None },
+    )
+    .expect("admin socket should return aggregate snapshot");
+    let AdminResponse::Snapshot(snapshot) = response else {
+        panic!("admin socket should return aggregate snapshot");
+    };
+
+    let listener = snapshot
+        .status
+        .as_ref()
+        .and_then(|status| status.listeners.first())
+        .expect("snapshot should include one listener");
+    assert_eq!(listener.binding_count, 2);
+    assert!(listener.http3_enabled);
+    assert_eq!(listener.bindings.len(), 2);
+    assert_eq!(listener.bindings[0].transport, "tcp");
+    assert_eq!(listener.bindings[1].transport, "udp");
+    assert_eq!(listener.bindings[1].protocols, vec!["http3".to_string()]);
+    assert_eq!(listener.bindings[1].advertise_alt_svc, Some(true));
+    assert_eq!(listener.bindings[1].alt_svc_max_age_secs, Some(7200));
+    let tls_listener = snapshot
+        .status
+        .as_ref()
+        .and_then(|status| status.tls.listeners.first())
+        .expect("snapshot should include one tls listener");
+    assert!(tls_listener.http3_enabled);
+    assert_eq!(tls_listener.http3_listen_addr, Some(listen_addr));
+    assert_eq!(tls_listener.http3_versions, vec!["TLS1.3".to_string()]);
+    assert_eq!(tls_listener.http3_alpn_protocols, vec!["h3".to_string()]);
+
+    let output = run_rginx(["--config", server.config_path().to_str().unwrap(), "snapshot"]);
+    assert!(output.status.success(), "snapshot command should succeed: {}", render_output(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let snapshot: serde_json::Value =
+        serde_json::from_str(&stdout).expect("snapshot command should print valid JSON");
+    assert_eq!(snapshot["status"]["listeners"][0]["binding_count"], serde_json::Value::from(2));
+    assert_eq!(snapshot["status"]["listeners"][0]["http3_enabled"], serde_json::Value::from(true));
+    assert_eq!(
+        snapshot["status"]["listeners"][0]["bindings"][1]["transport"],
+        serde_json::Value::from("udp")
+    );
+    assert_eq!(
+        snapshot["status"]["listeners"][0]["bindings"][1]["protocols"][0],
+        serde_json::Value::from("http3")
+    );
+    assert_eq!(
+        snapshot["status"]["tls"]["listeners"][0]["http3_enabled"],
+        serde_json::Value::from(true)
+    );
+    assert_eq!(
+        snapshot["status"]["tls"]["listeners"][0]["http3_listen_addr"],
+        serde_json::Value::from(listen_addr.to_string())
+    );
+    assert_eq!(
+        snapshot["status"]["tls"]["listeners"][0]["http3_versions"][0],
+        serde_json::Value::from("TLS1.3")
+    );
+    assert_eq!(
+        snapshot["status"]["tls"]["listeners"][0]["http3_alpn_protocols"][0],
+        serde_json::Value::from("h3")
+    );
 
     server.shutdown_and_wait(Duration::from_secs(5));
 }

--- a/crates/rginx-app/tests/admin/snapshot.rs
+++ b/crates/rginx-app/tests/admin/snapshot.rs
@@ -123,11 +123,14 @@ fn snapshot_reports_http3_listener_bindings() {
     assert_eq!(listener.binding_count, 2);
     assert!(listener.http3_enabled);
     assert_eq!(listener.bindings.len(), 2);
-    assert_eq!(listener.bindings[0].transport, "tcp");
-    assert_eq!(listener.bindings[1].transport, "udp");
-    assert_eq!(listener.bindings[1].protocols, vec!["http3".to_string()]);
-    assert_eq!(listener.bindings[1].advertise_alt_svc, Some(true));
-    assert_eq!(listener.bindings[1].alt_svc_max_age_secs, Some(7200));
+    let udp_binding = listener
+        .bindings
+        .iter()
+        .find(|binding| binding.transport == "udp")
+        .expect("snapshot should include udp binding");
+    assert_eq!(udp_binding.protocols, vec!["http3".to_string()]);
+    assert_eq!(udp_binding.advertise_alt_svc, Some(true));
+    assert_eq!(udp_binding.alt_svc_max_age_secs, Some(7200));
     let tls_listener = snapshot
         .status
         .as_ref()
@@ -145,14 +148,13 @@ fn snapshot_reports_http3_listener_bindings() {
         serde_json::from_str(&stdout).expect("snapshot command should print valid JSON");
     assert_eq!(snapshot["status"]["listeners"][0]["binding_count"], serde_json::Value::from(2));
     assert_eq!(snapshot["status"]["listeners"][0]["http3_enabled"], serde_json::Value::from(true));
-    assert_eq!(
-        snapshot["status"]["listeners"][0]["bindings"][1]["transport"],
-        serde_json::Value::from("udp")
-    );
-    assert_eq!(
-        snapshot["status"]["listeners"][0]["bindings"][1]["protocols"][0],
-        serde_json::Value::from("http3")
-    );
+    let udp_json = snapshot["status"]["listeners"][0]["bindings"]
+        .as_array()
+        .and_then(|bindings| {
+            bindings.iter().find(|binding| binding["transport"].as_str() == Some("udp"))
+        })
+        .expect("snapshot JSON should include udp binding");
+    assert_eq!(udp_json["protocols"][0], serde_json::Value::from("http3"));
     assert_eq!(
         snapshot["status"]["tls"]["listeners"][0]["http3_enabled"],
         serde_json::Value::from(true)

--- a/crates/rginx-app/tests/check.rs
+++ b/crates/rginx-app/tests/check.rs
@@ -38,10 +38,10 @@ fn check_succeeds_without_binding_listener() {
     assert!(stdout.contains("worker_threads=auto"));
     assert!(stdout.contains("accept_workers=1"));
     assert!(stdout.contains(
-        "reload_requires_restart_for=listen,listeners[].listen,runtime.worker_threads,runtime.accept_workers"
+        "reload_requires_restart_for=listen,server.http3.listen,listeners[].listen,listeners[].http3.listen,runtime.worker_threads,runtime.accept_workers"
     ));
     assert!(stdout.contains(
-        "reload_tls_updates=server.tls,listeners[].tls,servers[].tls,upstreams[].tls,upstreams[].server_name,upstreams[].server_name_override"
+        "reload_tls_updates=server.tls,server.http3.advertise_alt_svc,server.http3.alt_svc_max_age_secs,listeners[].tls,listeners[].http3.advertise_alt_svc,listeners[].http3.alt_svc_max_age_secs,servers[].tls,upstreams[].tls,upstreams[].server_name,upstreams[].server_name_override"
     ));
     assert!(stdout.contains("tls_expiring_certificates=-"));
 
@@ -207,11 +207,57 @@ fn check_reports_explicit_listener_summary_and_reload_boundary() {
     assert!(stdout.contains("worker_threads=3"));
     assert!(stdout.contains("accept_workers=2"));
     assert!(stdout.contains(
-        "reload_requires_restart_for=listen,listeners[].listen,runtime.worker_threads,runtime.accept_workers"
+        "reload_requires_restart_for=listen,server.http3.listen,listeners[].listen,listeners[].http3.listen,runtime.worker_threads,runtime.accept_workers"
     ));
     assert!(stdout.contains(
-        "tls_restart_required_fields=listen,listeners[].listen,runtime.worker_threads,runtime.accept_workers"
+        "tls_restart_required_fields=listen,server.http3.listen,listeners[].listen,listeners[].http3.listen,runtime.worker_threads,runtime.accept_workers"
     ));
+
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+#[test]
+fn check_reports_http3_listener_bindings() {
+    let temp_dir = temp_dir("rginx-check-http3-listener");
+    fs::create_dir_all(&temp_dir).expect("temp test dir should be created");
+    let config_path = temp_dir.join("http3-listener.ron");
+    let listen_addr: SocketAddr = "127.0.0.1:18443".parse().unwrap();
+
+    let cert = generate_cert("localhost");
+    let cert_path = temp_dir.join("server.crt");
+    let key_path = temp_dir.join("server.key");
+    fs::write(&cert_path, cert.cert.pem()).expect("server cert should be written");
+    fs::write(&key_path, cert.signing_key.serialize_pem()).expect("server key should be written");
+
+    fs::write(
+        &config_path,
+        format!(
+            "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [],\n    locations: [\n        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some(\"checked\\n\"),\n            ),\n        ),\n    ],\n)\n",
+            listen_addr.to_string(),
+            cert_path.display().to_string(),
+            key_path.display().to_string(),
+        ),
+    )
+    .expect("http3 listener config should be written");
+
+    let output = run_rginx(["check", "--config", config_path.to_str().unwrap()]);
+
+    assert!(output.status.success(), "check should succeed: {}", render_output(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("listener_bindings=2"));
+    assert!(stdout.contains("bind_addrs=tcp://127.0.0.1:18443,udp://127.0.0.1:18443"));
+    assert!(stdout.contains("http3=enabled"));
+    assert!(stdout.contains("transport_bindings=2"));
+    assert!(stdout.contains("check_listener_binding listener=default binding=tcp transport=tcp"));
+    assert!(stdout.contains("check_listener_binding listener=default binding=udp transport=udp"));
+    assert!(stdout.contains("protocols=http3"));
+    assert!(stdout.contains("advertise_alt_svc=true"));
+    assert!(stdout.contains("alt_svc_max_age_secs=7200"));
+    assert!(stdout.contains("tls_listener listener=default"));
+    assert!(stdout.contains("http3_enabled=true"));
+    assert!(stdout.contains(&format!("http3_listen={listen_addr}")));
+    assert!(stdout.contains("http3_versions=TLS1.3"));
+    assert!(stdout.contains("http3_alpn_protocols=h3"));
 
     let _ = fs::remove_dir_all(temp_dir);
 }
@@ -257,7 +303,7 @@ fn check_reports_tls_diagnostics_for_listener_and_vhost_certificates() {
         "tls_details=listener_profiles=1 vhost_overrides=1 sni_names=2 certificate_bundles=2"
     ));
     assert!(stdout.contains(
-        "reload_tls_updates=server.tls,listeners[].tls,servers[].tls,upstreams[].tls,upstreams[].server_name,upstreams[].server_name_override"
+        "reload_tls_updates=server.tls,server.http3.advertise_alt_svc,server.http3.alt_svc_max_age_secs,listeners[].tls,listeners[].http3.advertise_alt_svc,listeners[].http3.alt_svc_max_age_secs,servers[].tls,upstreams[].tls,upstreams[].server_name,upstreams[].server_name_override"
     ));
     assert!(stdout.contains("tls_default_certificates=default=api.example.com"));
     assert!(stdout.contains("tls_expiring_certificates=-"));
@@ -397,9 +443,9 @@ fn check_succeeds_for_repository_default_config() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("listen=0.0.0.0:80"));
-    assert!(stdout.contains("routes=5"));
+    assert!(stdout.contains("routes=4"));
     assert!(stdout.contains("vhosts=2"));
-    assert!(stdout.contains("upstreams=1"));
+    assert!(stdout.contains("upstreams=0"));
 }
 
 fn run_rginx(args: impl IntoIterator<Item = impl AsRef<str>>) -> Output {

--- a/crates/rginx-app/tests/downstream_mtls.rs
+++ b/crates/rginx-app/tests/downstream_mtls.rs
@@ -26,6 +26,8 @@ use rginx_runtime::admin::{AdminRequest, AdminResponse, admin_socket_path_for_co
 #[allow(unused_imports)]
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 #[allow(unused_imports)]
+use rustls::pki_types::pem::PemObject;
+#[allow(unused_imports)]
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 #[allow(unused_imports)]
 use rustls::{ClientConfig, ClientConnection, DigitallySignedStruct, SignatureScheme, StreamOwned};
@@ -262,21 +264,15 @@ fn fetch_https_text_response(
 }
 
 fn load_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, String> {
-    let file = std::fs::File::open(path)
-        .map_err(|error| format!("failed to open cert `{}`: {error}", path.display()))?;
-    let mut reader = std::io::BufReader::new(file);
-    rustls_pemfile::certs(&mut reader)
+    CertificateDer::pem_file_iter(path)
+        .map_err(|error| format!("failed to open cert `{}`: {error}", path.display()))?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| format!("failed to parse cert `{}`: {error}", path.display()))
 }
 
 fn load_private_key(path: &Path) -> Result<rustls::pki_types::PrivateKeyDer<'static>, String> {
-    let file = std::fs::File::open(path)
-        .map_err(|error| format!("failed to open key `{}`: {error}", path.display()))?;
-    let mut reader = std::io::BufReader::new(file);
-    rustls_pemfile::private_key(&mut reader)
-        .map_err(|error| format!("failed to parse key `{}`: {error}", path.display()))?
-        .ok_or_else(|| format!("no private key found in `{}`", path.display()))
+    rustls::pki_types::PrivateKeyDer::from_pem_file(path)
+        .map_err(|error| format!("failed to parse key `{}`: {error}", path.display()))
 }
 
 fn required_client_auth_config(

--- a/crates/rginx-app/tests/grpc_http3.rs
+++ b/crates/rginx-app/tests/grpc_http3.rs
@@ -1,0 +1,635 @@
+use std::env;
+use std::fs;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use bytes::{Buf, Bytes, BytesMut};
+use h3::client;
+use h3::server::Connection as H3Connection;
+use h3_quinn::quinn;
+use hyper::http::HeaderMap;
+use hyper::http::header::{CONTENT_TYPE, HeaderValue, TE};
+use hyper::http::{Request, Response, StatusCode};
+use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::{ClientConfig, RootCertStore};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+mod support;
+
+use support::{READY_ROUTE_CONFIG, ServerHarness, reserve_loopback_addr};
+
+const GRPC_METHOD_PATH: &str = "/grpc.health.v1.Health/Check";
+const GRPC_REQUEST_FRAME: &[u8] = b"\x00\x00\x00\x00\x02hi";
+const GRPC_RESPONSE_FRAME: &[u8] = b"\x00\x00\x00\x00\x02ok";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn proxies_basic_grpc_over_http3_to_http3_upstreams_with_response_trailers() {
+    let cert = generate_cert("localhost");
+    let shared_dir = temp_dir("rginx-grpc-http3-shared");
+    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
+    let server_cert_path = shared_dir.join("server.crt");
+    let server_key_path = shared_dir.join("server.key");
+    fs::write(&server_cert_path, cert.cert.pem()).expect("server cert should be written");
+    fs::write(&server_key_path, cert.signing_key.serialize_pem())
+        .expect("server key should be written");
+
+    let (upstream_addr, observed_rx, upstream_task, upstream_temp_dir) =
+        spawn_h3_grpc_upstream(&server_cert_path, &server_key_path, UpstreamMode::Immediate).await;
+
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-grpc-http3-upstream",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| {
+            grpc_http3_proxy_config(listen_addr, upstream_addr, cert_path, key_path)
+        },
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+    let response = h3_request(
+        listen_addr,
+        "localhost",
+        "POST",
+        GRPC_METHOD_PATH,
+        &[(CONTENT_TYPE.as_str(), "application/grpc"), (TE.as_str(), "trailers")],
+        Some(Bytes::from_static(GRPC_REQUEST_FRAME)),
+        &cert.cert.pem(),
+    )
+    .await
+    .expect("grpc over http3 request should succeed");
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(
+        response.headers.get(CONTENT_TYPE.as_str()).map(String::as_str),
+        Some("application/grpc")
+    );
+    assert_eq!(
+        response.body,
+        Bytes::from_static(GRPC_RESPONSE_FRAME),
+        "response headers={:?} trailers={:?}\nlogs:\n{}",
+        response.headers,
+        response.trailers,
+        server.combined_output()
+    );
+    assert_eq!(
+        response
+            .trailers
+            .as_ref()
+            .and_then(|trailers| trailers.get("grpc-status"))
+            .and_then(|value| value.to_str().ok()),
+        Some("0")
+    );
+    assert_eq!(
+        response
+            .trailers
+            .as_ref()
+            .and_then(|trailers| trailers.get("grpc-message"))
+            .and_then(|value| value.to_str().ok()),
+        Some("ok")
+    );
+
+    let observed = tokio::time::timeout(Duration::from_secs(5), observed_rx)
+        .await
+        .expect("upstream request should be observed before timeout")
+        .expect("upstream observation channel should complete");
+    assert_eq!(observed.path, GRPC_METHOD_PATH);
+    assert_eq!(observed.content_type.as_deref(), Some("application/grpc"));
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+    upstream_task.await.expect("upstream h3 grpc task should finish");
+    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
+    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn proxies_grpc_web_binary_over_http3_to_http3_upstreams() {
+    let cert = generate_cert("localhost");
+    let shared_dir = temp_dir("rginx-grpc-web-http3-shared");
+    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
+    let server_cert_path = shared_dir.join("server.crt");
+    let server_key_path = shared_dir.join("server.key");
+    fs::write(&server_cert_path, cert.cert.pem()).expect("server cert should be written");
+    fs::write(&server_key_path, cert.signing_key.serialize_pem())
+        .expect("server key should be written");
+
+    let (upstream_addr, _observed_rx, upstream_task, upstream_temp_dir) =
+        spawn_h3_grpc_upstream(&server_cert_path, &server_key_path, UpstreamMode::Immediate).await;
+
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-grpc-web-http3-upstream",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| {
+            grpc_http3_proxy_config(listen_addr, upstream_addr, cert_path, key_path)
+        },
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+    let response = h3_request(
+        listen_addr,
+        "localhost",
+        "POST",
+        GRPC_METHOD_PATH,
+        &[(CONTENT_TYPE.as_str(), "application/grpc-web+proto"), ("x-grpc-web", "1")],
+        Some(Bytes::from_static(GRPC_REQUEST_FRAME)),
+        &cert.cert.pem(),
+    )
+    .await
+    .expect("grpc-web over http3 request should succeed");
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(
+        response.headers.get(CONTENT_TYPE.as_str()).map(String::as_str),
+        Some("application/grpc-web+proto")
+    );
+    let (frames, trailers) = decode_grpc_web_response(response.body.as_ref());
+    assert_eq!(frames, vec![Bytes::copy_from_slice(&GRPC_RESPONSE_FRAME[5..])]);
+    assert_eq!(trailers.get("grpc-status").and_then(|value| value.to_str().ok()), Some("0"));
+    assert_eq!(trailers.get("grpc-message").and_then(|value| value.to_str().ok()), Some("ok"));
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+    upstream_task.await.expect("upstream h3 grpc task should finish");
+    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
+    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn grpc_timeout_over_http3_upstream_returns_deadline_exceeded() {
+    let cert = generate_cert("localhost");
+    let shared_dir = temp_dir("rginx-grpc-http3-timeout-shared");
+    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
+    let server_cert_path = shared_dir.join("server.crt");
+    let server_key_path = shared_dir.join("server.key");
+    fs::write(&server_cert_path, cert.cert.pem()).expect("server cert should be written");
+    fs::write(&server_key_path, cert.signing_key.serialize_pem())
+        .expect("server key should be written");
+
+    let (upstream_addr, _observed_rx, upstream_task, upstream_temp_dir) = spawn_h3_grpc_upstream(
+        &server_cert_path,
+        &server_key_path,
+        UpstreamMode::DelayHeaders(Duration::from_secs(2)),
+    )
+    .await;
+
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-grpc-http3-timeout",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| {
+            grpc_http3_proxy_config_with_timeout(listen_addr, upstream_addr, cert_path, key_path, 1)
+        },
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+    let response = h3_request(
+        listen_addr,
+        "localhost",
+        "POST",
+        GRPC_METHOD_PATH,
+        &[(CONTENT_TYPE.as_str(), "application/grpc"), (TE.as_str(), "trailers")],
+        Some(Bytes::from_static(GRPC_REQUEST_FRAME)),
+        &cert.cert.pem(),
+    )
+    .await
+    .expect("grpc timeout request should succeed");
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.headers.get("grpc-status").map(String::as_str), Some("4"));
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+    upstream_task.abort();
+    let _ = upstream_task.await;
+    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
+    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn active_grpc_health_checks_can_target_http3_upstreams() {
+    let cert = generate_cert("localhost");
+    let shared_dir = temp_dir("rginx-grpc-http3-health-shared");
+    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
+    let server_cert_path = shared_dir.join("server.crt");
+    let server_key_path = shared_dir.join("server.key");
+    fs::write(&server_cert_path, cert.cert.pem()).expect("server cert should be written");
+    fs::write(&server_key_path, cert.signing_key.serialize_pem())
+        .expect("server key should be written");
+
+    let (upstream_addr, health_seen_rx, upstream_task, upstream_temp_dir) =
+        spawn_h3_grpc_health_upstream(&server_cert_path, &server_key_path).await;
+
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn("rginx-grpc-http3-health", |_| {
+        grpc_http3_health_config(listen_addr, upstream_addr)
+    });
+    server.wait_for_http_ready(listen_addr, Duration::from_secs(5));
+
+    tokio::time::timeout(Duration::from_secs(5), health_seen_rx)
+        .await
+        .expect("health probe should arrive before timeout")
+        .expect("health probe channel should complete");
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+    upstream_task.abort();
+    let _ = upstream_task.await;
+    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
+    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObservedGrpcRequest {
+    path: String,
+    content_type: Option<String>,
+}
+
+#[derive(Debug)]
+struct H3Response {
+    status: StatusCode,
+    headers: std::collections::HashMap<String, String>,
+    body: Bytes,
+    trailers: Option<HeaderMap>,
+}
+
+#[derive(Clone, Copy)]
+enum UpstreamMode {
+    Immediate,
+    DelayHeaders(Duration),
+}
+
+async fn h3_request(
+    listen_addr: SocketAddr,
+    server_name: &str,
+    method: &str,
+    path: &str,
+    headers: &[(&str, &str)],
+    body: Option<Bytes>,
+    cert_pem: &str,
+) -> Result<H3Response, String> {
+    let roots = root_store_from_pem(cert_pem)?;
+    let mut client_crypto = ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .map_err(|error| format!("failed to constrain TLS versions for http3 client: {error}"))?
+    .with_root_certificates(roots)
+    .with_no_client_auth();
+    client_crypto.alpn_protocols = vec![b"h3".to_vec()];
+
+    let client_config = quinn::ClientConfig::new(Arc::new(
+        QuicClientConfig::try_from(client_crypto)
+            .map_err(|error| format!("failed to build quic client config: {error}"))?,
+    ));
+    let mut endpoint = quinn::Endpoint::client("127.0.0.1:0".parse().unwrap())
+        .map_err(|error| error.to_string())?;
+    endpoint.set_default_client_config(client_config);
+
+    let connection = endpoint
+        .connect(listen_addr, server_name)
+        .map_err(|error| format!("failed to start quic connect: {error}"))?
+        .await
+        .map_err(|error| format!("quic connect failed: {error}"))?;
+
+    let (mut driver, mut send_request) =
+        client::new(h3_quinn::Connection::new(connection))
+            .await
+            .map_err(|error| format!("failed to initialize http3 client: {error}"))?;
+    let driver_task = tokio::spawn(async move {
+        let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
+    });
+
+    let mut request_builder = Request::builder()
+        .method(method)
+        .uri(format!("https://{server_name}:{}{path}", listen_addr.port()));
+    for (name, value) in headers {
+        request_builder = request_builder.header(*name, *value);
+    }
+    let mut request_stream = send_request
+        .send_request(request_builder.body(()).expect("http3 request should build"))
+        .await
+        .map_err(|error| format!("failed to send http3 request: {error}"))?;
+    if let Some(body) = body {
+        request_stream
+            .send_data(body)
+            .await
+            .map_err(|error| format!("failed to send http3 request body: {error}"))?;
+    }
+    request_stream
+        .finish()
+        .await
+        .map_err(|error| format!("failed to finish http3 request: {error}"))?;
+
+    let response = request_stream
+        .recv_response()
+        .await
+        .map_err(|error| format!("failed to receive http3 response headers: {error}"))?;
+    let status = response.status();
+    let headers = response
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            value.to_str().ok().map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut response_body = BytesMut::new();
+    while let Some(mut chunk) = request_stream
+        .recv_data()
+        .await
+        .map_err(|error| format!("failed to receive http3 response body: {error}"))?
+    {
+        response_body.extend_from_slice(chunk.copy_to_bytes(chunk.remaining()).as_ref());
+    }
+    let trailers = request_stream
+        .recv_trailers()
+        .await
+        .map_err(|error| format!("failed to receive http3 response trailers: {error}"))?;
+
+    driver_task.abort();
+    endpoint.close(quinn::VarInt::from_u32(0), b"done");
+
+    Ok(H3Response { status, headers, body: response_body.freeze(), trailers })
+}
+
+async fn spawn_h3_grpc_upstream(
+    cert_path: &Path,
+    key_path: &Path,
+    mode: UpstreamMode,
+) -> (SocketAddr, oneshot::Receiver<ObservedGrpcRequest>, JoinHandle<()>, PathBuf) {
+    let temp_dir = temp_dir("rginx-grpc-http3-upstream");
+    fs::create_dir_all(&temp_dir).expect("upstream temp dir should be created");
+
+    let mut server_crypto = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .expect("server TLS1.3 builder should succeed")
+    .with_no_client_auth()
+    .with_single_cert(load_certs(cert_path), load_private_key(key_path))
+    .expect("test upstream TLS config should build");
+    server_crypto.alpn_protocols = vec![b"h3".to_vec()];
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(
+        QuicServerConfig::try_from(server_crypto).expect("quic server config should build"),
+    ));
+    let endpoint = quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap()).unwrap();
+    let listen_addr = endpoint.local_addr().expect("upstream h3 addr should exist");
+    let (observed_tx, observed_rx) = oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        let incoming = endpoint.accept().await.expect("upstream h3 connection should arrive");
+        let connection = incoming.await.expect("upstream h3 connection should establish");
+        let mut h3 = H3Connection::new(h3_quinn::Connection::new(connection))
+            .await
+            .expect("upstream h3 should initialize");
+        let resolver = h3
+            .accept()
+            .await
+            .expect("upstream h3 should accept request")
+            .expect("request should exist");
+        let (request, mut stream) =
+            resolver.resolve_request().await.expect("upstream h3 should resolve request");
+        let _ = observed_tx.send(ObservedGrpcRequest {
+            path: request.uri().path().to_string(),
+            content_type: request
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string),
+        });
+        while let Some(mut chunk) =
+            stream.recv_data().await.expect("upstream h3 should read request body")
+        {
+            let _ = chunk.copy_to_bytes(chunk.remaining());
+        }
+        let _ = stream.recv_trailers().await.expect("upstream h3 should read request trailers");
+
+        if let UpstreamMode::DelayHeaders(delay) = mode {
+            tokio::time::sleep(delay).await;
+        }
+
+        stream
+            .send_response(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "application/grpc")
+                    .body(())
+                    .expect("response should build"),
+            )
+            .await
+            .expect("upstream h3 should send response");
+        stream
+            .send_data(Bytes::from_static(GRPC_RESPONSE_FRAME))
+            .await
+            .expect("upstream h3 should send body");
+        let mut trailers = HeaderMap::new();
+        trailers.insert("grpc-status", HeaderValue::from_static("0"));
+        trailers.insert("grpc-message", HeaderValue::from_static("ok"));
+        stream.send_trailers(trailers).await.expect("upstream h3 should send trailers");
+        stream.finish().await.expect("upstream h3 should finish response");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    });
+
+    (listen_addr, observed_rx, task, temp_dir)
+}
+
+async fn spawn_h3_grpc_health_upstream(
+    cert_path: &Path,
+    key_path: &Path,
+) -> (SocketAddr, oneshot::Receiver<()>, JoinHandle<()>, PathBuf) {
+    let temp_dir = temp_dir("rginx-grpc-http3-health-upstream");
+    fs::create_dir_all(&temp_dir).expect("upstream temp dir should be created");
+
+    let mut server_crypto = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .expect("server TLS1.3 builder should succeed")
+    .with_no_client_auth()
+    .with_single_cert(load_certs(cert_path), load_private_key(key_path))
+    .expect("test upstream TLS config should build");
+    server_crypto.alpn_protocols = vec![b"h3".to_vec()];
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(
+        QuicServerConfig::try_from(server_crypto).expect("quic server config should build"),
+    ));
+    let endpoint = quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap()).unwrap();
+    let listen_addr = endpoint.local_addr().expect("upstream h3 addr should exist");
+    let (health_seen_tx, health_seen_rx) = oneshot::channel();
+    let health_seen_tx = Arc::new(Mutex::new(Some(health_seen_tx)));
+
+    let task = tokio::spawn(async move {
+        let incoming = endpoint.accept().await.expect("upstream h3 connection should arrive");
+        let connection = incoming.await.expect("upstream h3 connection should establish");
+        let mut h3 = H3Connection::new(h3_quinn::Connection::new(connection))
+            .await
+            .expect("upstream h3 should initialize");
+        let resolver = h3
+            .accept()
+            .await
+            .expect("upstream h3 should accept request")
+            .expect("request should exist");
+        let (request, mut stream) =
+            resolver.resolve_request().await.expect("upstream h3 should resolve request");
+        assert_eq!(request.uri().path(), "/grpc.health.v1.Health/Check");
+        while let Some(mut chunk) =
+            stream.recv_data().await.expect("upstream h3 should read health body")
+        {
+            let _ = chunk.copy_to_bytes(chunk.remaining());
+        }
+        let _ = stream.recv_trailers().await.expect("upstream h3 should read health trailers");
+        if let Some(sender) =
+            health_seen_tx.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).take()
+        {
+            let _ = sender.send(());
+        }
+
+        let mut body = BytesMut::new();
+        body.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x02]);
+        body.extend_from_slice(b"\x08\x01");
+        stream
+            .send_response(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "application/grpc")
+                    .body(())
+                    .expect("response should build"),
+            )
+            .await
+            .expect("upstream h3 should send response");
+        stream
+            .send_data(body.freeze())
+            .await
+            .expect("upstream h3 should send health response body");
+        let mut trailers = HeaderMap::new();
+        trailers.insert("grpc-status", HeaderValue::from_static("0"));
+        stream.send_trailers(trailers).await.expect("upstream h3 should send health trailers");
+        stream.finish().await.expect("upstream h3 should finish response");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    });
+
+    (listen_addr, health_seen_rx, task, temp_dir)
+}
+
+fn grpc_http3_proxy_config(
+    listen_addr: SocketAddr,
+    upstream_addr: SocketAddr,
+    cert_path: &Path,
+    key_path: &Path,
+) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [\n        UpstreamConfig(\n            name: \"backend\",\n            peers: [UpstreamPeerConfig(url: {:?})],\n            tls: Some(Insecure),\n            protocol: Http3,\n            server_name_override: Some(\"localhost\"),\n        ),\n    ],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Prefix(\"/grpc.health.v1.Health\"),\n            handler: Proxy(\n                upstream: \"backend\",\n            ),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        cert_path.display().to_string(),
+        key_path.display().to_string(),
+        format!("https://127.0.0.1:{}", upstream_addr.port()),
+        ready_route = READY_ROUTE_CONFIG,
+    )
+}
+
+fn grpc_http3_proxy_config_with_timeout(
+    listen_addr: SocketAddr,
+    upstream_addr: SocketAddr,
+    cert_path: &Path,
+    key_path: &Path,
+    timeout_secs: u64,
+) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [\n        UpstreamConfig(\n            name: \"backend\",\n            peers: [UpstreamPeerConfig(url: {:?})],\n            tls: Some(Insecure),\n            protocol: Http3,\n            request_timeout_secs: Some({timeout_secs}),\n            server_name_override: Some(\"localhost\"),\n        ),\n    ],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Prefix(\"/grpc.health.v1.Health\"),\n            handler: Proxy(\n                upstream: \"backend\",\n            ),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        cert_path.display().to_string(),
+        key_path.display().to_string(),
+        format!("https://127.0.0.1:{}", upstream_addr.port()),
+        timeout_secs = timeout_secs,
+        ready_route = READY_ROUTE_CONFIG,
+    )
+}
+
+fn grpc_http3_health_config(listen_addr: SocketAddr, upstream_addr: SocketAddr) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n    ),\n    upstreams: [\n        UpstreamConfig(\n            name: \"backend\",\n            peers: [UpstreamPeerConfig(url: {:?})],\n            tls: Some(Insecure),\n            protocol: Http3,\n            server_name_override: Some(\"localhost\"),\n            health_check_grpc_service: Some(\"grpc.health.v1.Health\"),\n            health_check_interval_secs: Some(1),\n            health_check_timeout_secs: Some(1),\n            healthy_successes_required: Some(1),\n        ),\n    ],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some(\"ok\\n\"),\n            ),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        format!("https://127.0.0.1:{}", upstream_addr.port()),
+        ready_route = READY_ROUTE_CONFIG,
+    )
+}
+
+fn root_store_from_pem(cert_pem: &str) -> Result<RootCertStore, String> {
+    let cert = CertificateDer::pem_slice_iter(cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to parse certificate PEM: {error}"))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| "certificate PEM did not contain a certificate".to_string())?;
+    let mut roots = RootCertStore::empty();
+    roots.add(cert).map_err(|error| format!("failed to add root certificate: {error}"))?;
+    Ok(roots)
+}
+
+fn load_certs(path: &Path) -> Vec<CertificateDer<'static>> {
+    CertificateDer::pem_file_iter(path)
+        .expect("certificate file should open")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("certificate PEM should parse")
+}
+
+fn load_private_key(path: &Path) -> PrivateKeyDer<'static> {
+    PrivateKeyDer::from_pem_file(path).expect("private key PEM should parse")
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    env::temp_dir().join(format!("{prefix}-{unique}-{id}"))
+}
+
+fn generate_cert(hostname: &str) -> rcgen::CertifiedKey<rcgen::KeyPair> {
+    rcgen::generate_simple_self_signed(vec![hostname.to_string()])
+        .expect("self-signed certificate should generate")
+}
+
+fn decode_grpc_web_response(body: &[u8]) -> (Vec<Bytes>, HeaderMap) {
+    let mut frames = Vec::new();
+    let mut trailers = HeaderMap::new();
+    let mut cursor = body;
+
+    while cursor.len() >= 5 {
+        let flags = cursor[0];
+        let len = u32::from_be_bytes([cursor[1], cursor[2], cursor[3], cursor[4]]) as usize;
+        let frame_len = 5 + len;
+        let frame = &cursor[..frame_len];
+        let payload = &frame[5..];
+        if flags & 0x80 == 0 {
+            frames.push(Bytes::copy_from_slice(payload));
+        } else {
+            for line in payload.split(|byte| *byte == b'\n') {
+                let line = line.strip_suffix(b"\r").unwrap_or(line);
+                if line.is_empty() {
+                    continue;
+                }
+                let separator = line
+                    .iter()
+                    .position(|byte| *byte == b':')
+                    .expect("trailer line should contain ':'");
+                let (name, value) = line.split_at(separator);
+                trailers.append(
+                    hyper::http::header::HeaderName::from_bytes(name)
+                        .expect("trailer name should parse"),
+                    HeaderValue::from_bytes(value[1..].trim_ascii())
+                        .expect("trailer value should parse"),
+                );
+            }
+        }
+        cursor = &cursor[frame_len..];
+    }
+
+    (frames, trailers)
+}

--- a/crates/rginx-app/tests/grpc_http3.rs
+++ b/crates/rginx-app/tests/grpc_http3.rs
@@ -31,15 +31,14 @@ const GRPC_RESPONSE_FRAME: &[u8] = b"\x00\x00\x00\x00\x02ok";
 #[tokio::test(flavor = "multi_thread")]
 async fn proxies_basic_grpc_over_http3_to_http3_upstreams_with_response_trailers() {
     let cert = generate_cert("localhost");
-    let shared_dir = temp_dir("rginx-grpc-http3-shared");
-    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
-    let server_cert_path = shared_dir.join("server.crt");
-    let server_key_path = shared_dir.join("server.key");
+    let shared_dir = TempDirGuard::new("rginx-grpc-http3-shared");
+    let server_cert_path = shared_dir.path().join("server.crt");
+    let server_key_path = shared_dir.path().join("server.key");
     fs::write(&server_cert_path, cert.cert.pem()).expect("server cert should be written");
     fs::write(&server_key_path, cert.signing_key.serialize_pem())
         .expect("server key should be written");
 
-    let (upstream_addr, observed_rx, upstream_task, upstream_temp_dir) =
+    let (upstream_addr, observed_rx, upstream_task, _upstream_temp_dir) =
         spawn_h3_grpc_upstream(&server_cert_path, &server_key_path, UpstreamMode::Immediate).await;
 
     let listen_addr = reserve_loopback_addr();
@@ -104,22 +103,19 @@ async fn proxies_basic_grpc_over_http3_to_http3_upstreams_with_response_trailers
 
     server.shutdown_and_wait(Duration::from_secs(5));
     upstream_task.await.expect("upstream h3 grpc task should finish");
-    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
-    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn proxies_grpc_web_binary_over_http3_to_http3_upstreams() {
     let cert = generate_cert("localhost");
-    let shared_dir = temp_dir("rginx-grpc-web-http3-shared");
-    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
-    let server_cert_path = shared_dir.join("server.crt");
-    let server_key_path = shared_dir.join("server.key");
+    let shared_dir = TempDirGuard::new("rginx-grpc-web-http3-shared");
+    let server_cert_path = shared_dir.path().join("server.crt");
+    let server_key_path = shared_dir.path().join("server.key");
     fs::write(&server_cert_path, cert.cert.pem()).expect("server cert should be written");
     fs::write(&server_key_path, cert.signing_key.serialize_pem())
         .expect("server key should be written");
 
-    let (upstream_addr, _observed_rx, upstream_task, upstream_temp_dir) =
+    let (upstream_addr, _observed_rx, upstream_task, _upstream_temp_dir) =
         spawn_h3_grpc_upstream(&server_cert_path, &server_key_path, UpstreamMode::Immediate).await;
 
     let listen_addr = reserve_loopback_addr();
@@ -157,22 +153,19 @@ async fn proxies_grpc_web_binary_over_http3_to_http3_upstreams() {
 
     server.shutdown_and_wait(Duration::from_secs(5));
     upstream_task.await.expect("upstream h3 grpc task should finish");
-    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
-    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn grpc_timeout_over_http3_upstream_returns_deadline_exceeded() {
     let cert = generate_cert("localhost");
-    let shared_dir = temp_dir("rginx-grpc-http3-timeout-shared");
-    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
-    let server_cert_path = shared_dir.join("server.crt");
-    let server_key_path = shared_dir.join("server.key");
+    let shared_dir = TempDirGuard::new("rginx-grpc-http3-timeout-shared");
+    let server_cert_path = shared_dir.path().join("server.crt");
+    let server_key_path = shared_dir.path().join("server.key");
     fs::write(&server_cert_path, cert.cert.pem()).expect("server cert should be written");
     fs::write(&server_key_path, cert.signing_key.serialize_pem())
         .expect("server key should be written");
 
-    let (upstream_addr, _observed_rx, upstream_task, upstream_temp_dir) = spawn_h3_grpc_upstream(
+    let (upstream_addr, _observed_rx, upstream_task, _upstream_temp_dir) = spawn_h3_grpc_upstream(
         &server_cert_path,
         &server_key_path,
         UpstreamMode::DelayHeaders(Duration::from_secs(2)),
@@ -208,22 +201,19 @@ async fn grpc_timeout_over_http3_upstream_returns_deadline_exceeded() {
     server.shutdown_and_wait(Duration::from_secs(5));
     upstream_task.abort();
     let _ = upstream_task.await;
-    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
-    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn active_grpc_health_checks_can_target_http3_upstreams() {
     let cert = generate_cert("localhost");
-    let shared_dir = temp_dir("rginx-grpc-http3-health-shared");
-    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
-    let server_cert_path = shared_dir.join("server.crt");
-    let server_key_path = shared_dir.join("server.key");
+    let shared_dir = TempDirGuard::new("rginx-grpc-http3-health-shared");
+    let server_cert_path = shared_dir.path().join("server.crt");
+    let server_key_path = shared_dir.path().join("server.key");
     fs::write(&server_cert_path, cert.cert.pem()).expect("server cert should be written");
     fs::write(&server_key_path, cert.signing_key.serialize_pem())
         .expect("server key should be written");
 
-    let (upstream_addr, health_seen_rx, upstream_task, upstream_temp_dir) =
+    let (upstream_addr, health_seen_rx, upstream_task, _upstream_temp_dir) =
         spawn_h3_grpc_health_upstream(&server_cert_path, &server_key_path).await;
 
     let listen_addr = reserve_loopback_addr();
@@ -240,14 +230,35 @@ async fn active_grpc_health_checks_can_target_http3_upstreams() {
     server.shutdown_and_wait(Duration::from_secs(5));
     upstream_task.abort();
     let _ = upstream_task.await;
-    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
-    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ObservedGrpcRequest {
     path: String,
     content_type: Option<String>,
+}
+
+#[derive(Debug)]
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    fn new(prefix: &str) -> Self {
+        let path = temp_dir(prefix);
+        fs::create_dir_all(&path).expect("shared temp dir should be created");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
 }
 
 #[derive(Debug)]
@@ -301,7 +312,7 @@ async fn h3_request(
         client::new(h3_quinn::Connection::new(connection))
             .await
             .map_err(|error| format!("failed to initialize http3 client: {error}"))?;
-    let driver_task = tokio::spawn(async move {
+    let mut driver_task = tokio::spawn(async move {
         let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
     });
 
@@ -351,7 +362,10 @@ async fn h3_request(
         .await
         .map_err(|error| format!("failed to receive http3 response trailers: {error}"))?;
 
-    driver_task.abort();
+    if tokio::time::timeout(Duration::from_millis(50), &mut driver_task).await.is_err() {
+        driver_task.abort();
+        let _ = driver_task.await;
+    }
     endpoint.close(quinn::VarInt::from_u32(0), b"done");
 
     Ok(H3Response { status, headers, body: response_body.freeze(), trailers })
@@ -361,9 +375,8 @@ async fn spawn_h3_grpc_upstream(
     cert_path: &Path,
     key_path: &Path,
     mode: UpstreamMode,
-) -> (SocketAddr, oneshot::Receiver<ObservedGrpcRequest>, JoinHandle<()>, PathBuf) {
-    let temp_dir = temp_dir("rginx-grpc-http3-upstream");
-    fs::create_dir_all(&temp_dir).expect("upstream temp dir should be created");
+) -> (SocketAddr, oneshot::Receiver<ObservedGrpcRequest>, JoinHandle<()>, TempDirGuard) {
+    let temp_dir = TempDirGuard::new("rginx-grpc-http3-upstream");
 
     let mut server_crypto = rustls::ServerConfig::builder_with_provider(Arc::new(
         rustls::crypto::aws_lc_rs::default_provider(),
@@ -441,9 +454,8 @@ async fn spawn_h3_grpc_upstream(
 async fn spawn_h3_grpc_health_upstream(
     cert_path: &Path,
     key_path: &Path,
-) -> (SocketAddr, oneshot::Receiver<()>, JoinHandle<()>, PathBuf) {
-    let temp_dir = temp_dir("rginx-grpc-http3-health-upstream");
-    fs::create_dir_all(&temp_dir).expect("upstream temp dir should be created");
+) -> (SocketAddr, oneshot::Receiver<()>, JoinHandle<()>, TempDirGuard) {
+    let temp_dir = TempDirGuard::new("rginx-grpc-http3-health-upstream");
 
     let mut server_crypto = rustls::ServerConfig::builder_with_provider(Arc::new(
         rustls::crypto::aws_lc_rs::default_provider(),

--- a/crates/rginx-app/tests/grpc_proxy.rs
+++ b/crates/rginx-app/tests/grpc_proxy.rs
@@ -1,11 +1,9 @@
 #[allow(unused_imports)]
 use std::convert::Infallible;
 #[allow(unused_imports)]
-use std::fs::{self, File};
+use std::fs;
 #[allow(unused_imports)]
 use std::future::Future;
-#[allow(unused_imports)]
-use std::io::BufReader;
 #[allow(unused_imports)]
 use std::net::SocketAddr;
 #[allow(unused_imports)]
@@ -49,6 +47,8 @@ use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 #[allow(unused_imports)]
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+#[allow(unused_imports)]
+use rustls::pki_types::pem::PemObject;
 #[allow(unused_imports)]
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
 #[allow(unused_imports)]
@@ -905,19 +905,14 @@ fn plain_grpc_service_method_routing_config(
 }
 
 fn load_certs(path: &Path) -> Vec<CertificateDer<'static>> {
-    let file = File::open(path).expect("certificate file should open");
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::certs(&mut reader)
+    CertificateDer::pem_file_iter(path)
+        .expect("certificate file should open")
         .collect::<Result<Vec<_>, _>>()
         .expect("certificate PEM should parse")
 }
 
 fn load_private_key(path: &Path) -> PrivateKeyDer<'static> {
-    let file = File::open(path).expect("private key file should open");
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::private_key(&mut reader)
-        .expect("private key PEM should parse")
-        .expect("private key PEM should include at least one key")
+    PrivateKeyDer::from_pem_file(path).expect("private key PEM should parse")
 }
 
 fn temp_dir(prefix: &str) -> PathBuf {

--- a/crates/rginx-app/tests/http3.rs
+++ b/crates/rginx-app/tests/http3.rs
@@ -1,0 +1,505 @@
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use bytes::{Buf, Bytes, BytesMut};
+use flate2::read::GzDecoder;
+use h3::client;
+use http_body_util::Empty;
+use hyper::http::{Request, StatusCode};
+use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
+use quinn::crypto::rustls::QuicClientConfig;
+use rustls::pki_types::{CertificateDer, pem::PemObject};
+use rustls::{ClientConfig, RootCertStore};
+
+mod support;
+
+use support::{READY_ROUTE_CONFIG, ServerHarness, reserve_loopback_addr};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn serves_return_handler_over_http3() {
+    let cert = generate_cert("localhost");
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-http3-return",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| http3_return_config(listen_addr, cert_path, key_path),
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+    let response = http3_get(listen_addr, "localhost", "/v3", &cert.cert.pem())
+        .await
+        .expect("http3 request should succeed");
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(body_text(&response), "http3 return\n");
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn proxies_basic_http_requests_over_http3_to_http11_upstreams() {
+    let upstream_listener =
+        TcpListener::bind(("127.0.0.1", 0)).expect("upstream listener should bind");
+    upstream_listener
+        .set_nonblocking(false)
+        .expect("upstream listener should support blocking mode");
+    let upstream_addr = upstream_listener.local_addr().expect("upstream addr should be available");
+    let upstream_task = thread::spawn(move || {
+        let (mut stream, _) =
+            upstream_listener.accept().expect("upstream connection should arrive");
+        let request = read_http_head_from_stream(&mut stream);
+        assert!(
+            request.starts_with("GET /demo HTTP/1.1\r\n"),
+            "unexpected upstream request: {request}"
+        );
+        let body = "http3 proxy ok\n";
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .expect("upstream response should write");
+        stream.flush().expect("upstream response should flush");
+    });
+
+    let cert = generate_cert("localhost");
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-http3-proxy",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| {
+            http3_proxy_config(listen_addr, upstream_addr, cert_path, key_path)
+        },
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+    let response = http3_get(listen_addr, "localhost", "/api/demo", &cert.cert.pem())
+        .await
+        .expect("http3 proxy request should succeed");
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(body_text(&response), "http3 proxy ok\n");
+
+    upstream_task.join().expect("upstream task should complete");
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn enforces_access_control_and_rate_limits_over_http3() {
+    let cert = generate_cert("localhost");
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-http3-policy",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| http3_policy_config(listen_addr, cert_path, key_path),
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+    let allowed = http3_get(listen_addr, "localhost", "/allow", &cert.cert.pem())
+        .await
+        .expect("allowed request should succeed");
+    assert_eq!(allowed.status, StatusCode::OK);
+    assert_eq!(body_text(&allowed), "allowed\n");
+
+    let denied = http3_get(listen_addr, "localhost", "/deny", &cert.cert.pem())
+        .await
+        .expect("denied request should receive a response");
+    assert_eq!(denied.status, StatusCode::FORBIDDEN);
+    assert_eq!(body_text(&denied), "forbidden\n");
+
+    let first = http3_get(listen_addr, "localhost", "/limited", &cert.cert.pem())
+        .await
+        .expect("first limited request should succeed");
+    assert_eq!(first.status, StatusCode::OK);
+    let second = http3_get(listen_addr, "localhost", "/limited", &cert.cert.pem())
+        .await
+        .expect("second limited request should respond");
+    assert_eq!(second.status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(body_text(&second), "hold your horses! too many requests\n");
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn compresses_large_http3_responses_and_preserves_request_id_and_access_log() {
+    let cert = generate_cert("localhost");
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-http3-compression",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| http3_compression_config(listen_addr, cert_path, key_path),
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+    let response = http3_request(
+        listen_addr,
+        "localhost",
+        "GET",
+        "/gzip",
+        &[("accept-encoding", "gzip"), ("x-request-id", "http3-log-42")],
+        None,
+        &cert.cert.pem(),
+    )
+    .await
+    .expect("compressed request should succeed");
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.header("content-encoding"), Some("gzip"));
+    assert_eq!(response.header("vary"), Some("Accept-Encoding"));
+    assert_eq!(response.header("x-request-id"), Some("http3-log-42"));
+    assert_eq!(decode_gzip(&response.body), "http3 gzip body\n".repeat(32).into_bytes());
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+    let logs = server.combined_output();
+    assert!(
+        logs.contains("H3 reqid=http3-log-42 version=HTTP/3.0 status=200"),
+        "expected HTTP/3 access log entry, got {logs:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn traffic_command_counts_http3_requests() {
+    let cert = generate_cert("localhost");
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-http3-traffic",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| http3_return_config(listen_addr, cert_path, key_path),
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+    wait_for_admin_socket(
+        &rginx_runtime::admin::admin_socket_path_for_config(server.config_path()),
+        Duration::from_secs(5),
+    );
+
+    let response = http3_get(listen_addr, "localhost", "/v3", &cert.cert.pem())
+        .await
+        .expect("http3 request should succeed");
+    assert_eq!(response.status, StatusCode::OK);
+
+    let output = run_rginx(["--config", server.config_path().to_str().unwrap(), "traffic"]);
+    assert!(output.status.success(), "traffic command should succeed: {}", render_output(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("kind=traffic_listener"));
+    assert!(stdout.contains("listener=default"));
+    assert!(stdout.contains("downstream_requests_total=1"));
+    assert!(stdout.contains("downstream_responses_total=1"));
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tls_responses_advertise_alt_svc_when_http3_is_enabled() {
+    let cert = generate_cert("localhost");
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-http3-alt-svc",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| http3_return_config(listen_addr, cert_path, key_path),
+    );
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+    let client = https_client(&cert.cert.pem());
+    let request = Request::builder()
+        .method("GET")
+        .uri(format!("https://localhost:{}/v3", listen_addr.port()))
+        .body(Empty::<Bytes>::new())
+        .expect("https request should build");
+    let response = client.request(request).await.expect("https request should succeed");
+    let expected_alt_svc = format!("h3=\":{}\"; ma=7200", listen_addr.port());
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(hyper::http::header::ALT_SVC).and_then(|value| value.to_str().ok()),
+        Some(expected_alt_svc.as_str())
+    );
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+struct Http3Response {
+    status: StatusCode,
+    headers: std::collections::HashMap<String, String>,
+    body: Vec<u8>,
+}
+
+async fn http3_get(
+    listen_addr: SocketAddr,
+    server_name: &str,
+    path: &str,
+    cert_pem: &str,
+) -> Result<Http3Response, String> {
+    http3_request(listen_addr, server_name, "GET", path, &[], None, cert_pem).await
+}
+
+async fn http3_request(
+    listen_addr: SocketAddr,
+    server_name: &str,
+    method: &str,
+    path: &str,
+    headers: &[(&str, &str)],
+    body: Option<Bytes>,
+    cert_pem: &str,
+) -> Result<Http3Response, String> {
+    let roots = root_store_from_pem(cert_pem)?;
+    let mut client_crypto = ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .map_err(|error| format!("failed to constrain TLS versions for http3 client: {error}"))?
+    .with_root_certificates(roots)
+    .with_no_client_auth();
+    client_crypto.alpn_protocols = vec![b"h3".to_vec()];
+
+    let client_config = quinn::ClientConfig::new(Arc::new(
+        QuicClientConfig::try_from(client_crypto)
+            .map_err(|error| format!("failed to build quic client config: {error}"))?,
+    ));
+    let mut endpoint = quinn::Endpoint::client("127.0.0.1:0".parse().unwrap())
+        .map_err(|error| error.to_string())?;
+    endpoint.set_default_client_config(client_config);
+
+    let connection = endpoint
+        .connect(listen_addr, server_name)
+        .map_err(|error| format!("failed to start quic connect: {error}"))?
+        .await
+        .map_err(|error| format!("quic connect failed: {error}"))?;
+
+    let (mut driver, mut send_request) =
+        client::new(h3_quinn::Connection::new(connection))
+            .await
+            .map_err(|error| format!("failed to initialize http3 client: {error}"))?;
+    let driver_task = tokio::spawn(async move {
+        let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
+    });
+
+    let mut request_builder = Request::builder()
+        .method(method)
+        .uri(format!("https://{server_name}:{}{path}", listen_addr.port()));
+    for (name, value) in headers {
+        request_builder = request_builder.header(*name, *value);
+    }
+    let mut request_stream = send_request
+        .send_request(request_builder.body(()).expect("http3 request should build"))
+        .await
+        .map_err(|error| format!("failed to send http3 request: {error}"))?;
+    if let Some(body) = body {
+        request_stream
+            .send_data(body)
+            .await
+            .map_err(|error| format!("failed to send http3 request body: {error}"))?;
+    }
+    request_stream
+        .finish()
+        .await
+        .map_err(|error| format!("failed to finish http3 request: {error}"))?;
+
+    let response = request_stream
+        .recv_response()
+        .await
+        .map_err(|error| format!("failed to receive http3 response headers: {error}"))?;
+    let status = response.status();
+    let headers = response
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            value.to_str().ok().map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut body = BytesMut::new();
+    while let Some(chunk) = request_stream
+        .recv_data()
+        .await
+        .map_err(|error| format!("failed to receive http3 response body: {error}"))?
+    {
+        body.extend_from_slice(chunk.chunk());
+    }
+    let _ = request_stream
+        .recv_trailers()
+        .await
+        .map_err(|error| format!("failed to receive http3 response trailers: {error}"))?;
+
+    driver_task.abort();
+    endpoint.close(quinn::VarInt::from_u32(0), b"done");
+
+    Ok(Http3Response { status, headers, body: body.to_vec() })
+}
+
+fn https_client(
+    cert_pem: &str,
+) -> Client<
+    hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+    Empty<Bytes>,
+> {
+    let roots = root_store_from_pem(cert_pem).expect("root store should build");
+    let client_config = ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("https client should support default protocol versions")
+    .with_root_certificates(roots)
+    .with_no_client_auth();
+    let connector = HttpsConnectorBuilder::new()
+        .with_tls_config(client_config)
+        .https_only()
+        .enable_all_versions()
+        .build();
+    Client::builder(TokioExecutor::new()).build(connector)
+}
+
+fn root_store_from_pem(cert_pem: &str) -> Result<RootCertStore, String> {
+    let cert = CertificateDer::pem_slice_iter(cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to parse certificate PEM: {error}"))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| "certificate PEM did not contain a certificate".to_string())?;
+    let mut roots = RootCertStore::empty();
+    roots.add(cert).map_err(|error| format!("failed to add root certificate: {error}"))?;
+    Ok(roots)
+}
+
+fn http3_return_config(
+    listen_addr: SocketAddr,
+    cert_path: &std::path::Path,
+    key_path: &std::path::Path,
+) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some(\"fallback\\n\"),\n            ),\n        ),\n    ],\n    servers: [\n        VirtualHostConfig(\n            server_names: [\"localhost\"],\n            locations: [\n                LocationConfig(\n                    matcher: Exact(\"/v3\"),\n                    handler: Return(\n                        status: 200,\n                        location: \"\",\n                        body: Some(\"http3 return\\n\"),\n                    ),\n                ),\n            ],\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        cert_path.display().to_string(),
+        key_path.display().to_string(),
+        ready_route = READY_ROUTE_CONFIG,
+    )
+}
+
+fn http3_policy_config(
+    listen_addr: SocketAddr,
+    cert_path: &std::path::Path,
+    key_path: &std::path::Path,
+) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/allow\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some(\"allowed\\n\"),\n            ),\n            allow_cidrs: [\"127.0.0.1/32\", \"::1/128\"],\n        ),\n        LocationConfig(\n            matcher: Exact(\"/deny\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some(\"denied\\n\"),\n            ),\n            deny_cidrs: [\"127.0.0.1/32\", \"::1/128\"],\n        ),\n        LocationConfig(\n            matcher: Exact(\"/limited\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some(\"limited\\n\"),\n            ),\n            requests_per_sec: Some(1),\n            burst: Some(0),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        cert_path.display().to_string(),
+        key_path.display().to_string(),
+        ready_route = READY_ROUTE_CONFIG,
+    )
+}
+
+fn http3_compression_config(
+    listen_addr: SocketAddr,
+    cert_path: &std::path::Path,
+    key_path: &std::path::Path,
+) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        access_log_format: Some(\"H3 reqid=$request_id version=$http_version status=$status\"),\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/gzip\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some({:?}),\n            ),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        cert_path.display().to_string(),
+        key_path.display().to_string(),
+        "http3 gzip body\n".repeat(32),
+        ready_route = READY_ROUTE_CONFIG,
+    )
+}
+
+fn http3_proxy_config(
+    listen_addr: SocketAddr,
+    upstream_addr: SocketAddr,
+    cert_path: &std::path::Path,
+    key_path: &std::path::Path,
+) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [\n        UpstreamConfig(\n            name: \"backend\",\n            peers: [UpstreamPeerConfig(url: {:?})],\n        ),\n    ],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Prefix(\"/api\"),\n            handler: Proxy(\n                upstream: \"backend\",\n                preserve_host: Some(false),\n                strip_prefix: Some(\"/api\"),\n            ),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        cert_path.display().to_string(),
+        key_path.display().to_string(),
+        format!("http://{upstream_addr}"),
+        ready_route = READY_ROUTE_CONFIG,
+    )
+}
+
+fn generate_cert(hostname: &str) -> rcgen::CertifiedKey<rcgen::KeyPair> {
+    rcgen::generate_simple_self_signed(vec![hostname.to_string()])
+        .expect("self-signed certificate should generate")
+}
+
+fn decode_gzip(bytes: &[u8]) -> Vec<u8> {
+    let mut decoder = GzDecoder::new(bytes);
+    let mut decoded = Vec::new();
+    decoder.read_to_end(&mut decoded).expect("gzip body should decode");
+    decoded
+}
+
+fn body_text(response: &Http3Response) -> String {
+    String::from_utf8(response.body.clone()).expect("response body should be valid UTF-8")
+}
+
+impl Http3Response {
+    fn header(&self, name: &str) -> Option<&str> {
+        self.headers.get(&name.to_ascii_lowercase()).map(String::as_str)
+    }
+}
+
+fn wait_for_admin_socket(path: &Path, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if path.exists() && UnixStream::connect(path).is_ok() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    panic!("timed out waiting for admin socket {}", path.display());
+}
+
+fn run_rginx(args: impl IntoIterator<Item = impl AsRef<str>>) -> std::process::Output {
+    let mut command = std::process::Command::new(binary_path());
+    for arg in args {
+        command.arg(arg.as_ref());
+    }
+    command.output().expect("rginx command should run")
+}
+
+fn binary_path() -> std::path::PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_rginx")
+        .map(std::path::PathBuf::from)
+        .expect("cargo should expose the rginx test binary path")
+}
+
+fn render_output(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn read_http_head_from_stream(stream: &mut std::net::TcpStream) -> String {
+    let mut buffer = Vec::new();
+    let mut chunk = [0u8; 256];
+
+    loop {
+        let read = stream.read(&mut chunk).expect("HTTP head should be readable");
+        assert!(read > 0, "stream closed before HTTP head was complete");
+        buffer.extend_from_slice(&chunk[..read]);
+
+        if let Some(head_end) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+            return String::from_utf8(buffer[..head_end + 4].to_vec())
+                .expect("HTTP head should be valid UTF-8");
+        }
+    }
+}

--- a/crates/rginx-app/tests/http3.rs
+++ b/crates/rginx-app/tests/http3.rs
@@ -283,7 +283,7 @@ async fn http3_request(
         client::new(h3_quinn::Connection::new(connection))
             .await
             .map_err(|error| format!("failed to initialize http3 client: {error}"))?;
-    let driver_task = tokio::spawn(async move {
+    let mut driver_task = tokio::spawn(async move {
         let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
     });
 
@@ -333,7 +333,10 @@ async fn http3_request(
         .await
         .map_err(|error| format!("failed to receive http3 response trailers: {error}"))?;
 
-    driver_task.abort();
+    if tokio::time::timeout(Duration::from_millis(50), &mut driver_task).await.is_err() {
+        driver_task.abort();
+        let _ = driver_task.await;
+    }
     endpoint.close(quinn::VarInt::from_u32(0), b"done");
 
     Ok(Http3Response { status, headers, body: body.to_vec() })

--- a/crates/rginx-app/tests/ocsp.rs
+++ b/crates/rginx-app/tests/ocsp.rs
@@ -214,6 +214,176 @@ fn expired_ocsp_cache_is_cleared_when_refresh_fails() {
     server.shutdown_and_wait(Duration::from_secs(5));
 }
 
+#[test]
+fn valid_ocsp_cache_is_retained_when_refresh_fails() {
+    let ocsp_requests = Arc::new(AtomicUsize::new(0));
+    let ocsp_response_body = Arc::new(Mutex::new(b"dummy-ocsp-response".to_vec()));
+    let expected_cache = Arc::new(Mutex::new(Vec::new()));
+    let responder_addr = spawn_ocsp_responder(ocsp_requests.clone(), ocsp_response_body);
+    let listen_addr = reserve_loopback_addr();
+
+    let mut server = ServerHarness::spawn("rginx-ocsp-valid-cache-retained", {
+        let expected_cache = expected_cache.clone();
+        move |temp_dir| {
+            let cert_path = temp_dir.join("server-chain.pem");
+            let key_path = temp_dir.join("server.key");
+            let ocsp_path = temp_dir.join("server.ocsp");
+
+            let ca = generate_ca_cert("rginx-ocsp-test-ca");
+            let leaf = generate_leaf_cert_with_ocsp_aia(
+                "localhost",
+                &ca,
+                &format!("http://127.0.0.1:{}/ocsp", responder_addr.port()),
+            );
+            fs::write(&cert_path, format!("{}{}", leaf.cert.pem(), ca.cert.pem()))
+                .expect("certificate chain should be written");
+            fs::write(&key_path, leaf.signing_key.serialize_pem())
+                .expect("private key should be written");
+
+            let valid_response = build_ocsp_response_for_certificate(&cert_path, &ca);
+            fs::write(&ocsp_path, &valid_response)
+                .expect("valid OCSP cache file should be written");
+            *expected_cache.lock().expect("expected cache mutex should lock") = valid_response;
+
+            dynamic_ocsp_config(
+                listen_addr,
+                &cert_path,
+                &key_path,
+                &ocsp_path,
+                "cache survives refresh failure\n",
+            )
+        }
+    });
+    server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+    let config_path = server.config_path().to_path_buf();
+    let ocsp_path =
+        config_path.parent().expect("config path should have parent").join("server.ocsp");
+
+    let status_stdout =
+        wait_for_command_output(&config_path, &["status"], Duration::from_secs(10), |stdout| {
+            stdout.contains("kind=status_tls_ocsp scope=listener:default")
+                && stdout.contains("cache_loaded=true")
+                && !stdout.contains("failures_total=0")
+                && !stdout.contains("last_error=-")
+        });
+    assert!(status_stdout.contains("failed to parse OCSP response"));
+    assert!(ocsp_requests.load(Ordering::Relaxed) >= 1);
+    assert_eq!(
+        fs::read(&ocsp_path).expect("OCSP cache file should remain readable"),
+        expected_cache.lock().expect("expected cache mutex should lock").clone(),
+        "valid cached OCSP staple should be retained after refresh failure"
+    );
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[test]
+fn dynamic_ocsp_refresh_recovers_after_reload() {
+    let ocsp_requests = Arc::new(AtomicUsize::new(0));
+    let ocsp_response_body = Arc::new(Mutex::new(b"dummy-ocsp-response".to_vec()));
+    let valid_response = Arc::new(Mutex::new(Vec::new()));
+    let responder_addr = spawn_ocsp_responder(ocsp_requests.clone(), ocsp_response_body.clone());
+    let listen_addr = reserve_loopback_addr();
+
+    let mut server = ServerHarness::spawn("rginx-ocsp-refresh-reload-recovery", {
+        let valid_response = valid_response.clone();
+        move |temp_dir| {
+            let cert_path = temp_dir.join("server-chain.pem");
+            let key_path = temp_dir.join("server.key");
+            let ocsp_path = temp_dir.join("server.ocsp");
+
+            let ca = generate_ca_cert("rginx-ocsp-test-ca");
+            let leaf = generate_leaf_cert_with_ocsp_aia(
+                "localhost",
+                &ca,
+                &format!("http://127.0.0.1:{}/ocsp", responder_addr.port()),
+            );
+            fs::write(&cert_path, format!("{}{}", leaf.cert.pem(), ca.cert.pem()))
+                .expect("certificate chain should be written");
+            fs::write(&key_path, leaf.signing_key.serialize_pem())
+                .expect("private key should be written");
+            fs::write(&ocsp_path, b"").expect("empty OCSP cache file should be written");
+
+            *valid_response.lock().expect("valid response mutex should lock") =
+                build_ocsp_response_for_certificate(&cert_path, &ca);
+
+            dynamic_ocsp_config(
+                listen_addr,
+                &cert_path,
+                &key_path,
+                &ocsp_path,
+                "before OCSP reload recovery\n",
+            )
+        }
+    });
+    server.wait_for_https_text_response(
+        listen_addr,
+        &listen_addr.to_string(),
+        "/",
+        "localhost",
+        200,
+        "before OCSP reload recovery\n",
+        Duration::from_secs(5),
+    );
+    let config_path = server.config_path().to_path_buf();
+    let config_dir = config_path.parent().expect("config path should have parent");
+    let cert_path = config_dir.join("server-chain.pem");
+    let key_path = config_dir.join("server.key");
+    let ocsp_path = config_dir.join("server.ocsp");
+
+    let first_status =
+        wait_for_command_output(&config_path, &["status"], Duration::from_secs(10), |stdout| {
+            stdout.contains("kind=status_tls_ocsp scope=listener:default")
+                && stdout.contains("cache_loaded=false")
+                && !stdout.contains("failures_total=0")
+                && !stdout.contains("last_error=-")
+        });
+    assert!(first_status.contains("failed to parse OCSP response"));
+
+    *ocsp_response_body.lock().expect("OCSP response body mutex should lock") =
+        valid_response.lock().expect("valid response mutex should lock").clone();
+    fs::write(
+        &config_path,
+        dynamic_ocsp_config(
+            listen_addr,
+            &cert_path,
+            &key_path,
+            &ocsp_path,
+            "after OCSP reload recovery\n",
+        ),
+    )
+    .expect("reloaded config should be written");
+    server.send_signal(libc::SIGHUP);
+
+    server.wait_for_https_text_response(
+        listen_addr,
+        &listen_addr.to_string(),
+        "/",
+        "localhost",
+        200,
+        "after OCSP reload recovery\n",
+        Duration::from_secs(5),
+    );
+
+    let second_status =
+        wait_for_command_output(&config_path, &["status"], Duration::from_secs(10), |stdout| {
+            stdout.contains("kind=status_tls_ocsp scope=listener:default")
+                && stdout.contains("cache_loaded=true")
+                && stdout.contains("refreshes_total=1")
+                && !stdout.contains("failures_total=0")
+                && stdout.contains("last_error=-")
+        });
+    assert!(second_status.contains("cache_loaded=true"));
+    assert!(ocsp_requests.load(Ordering::Relaxed) >= 3);
+    assert_eq!(
+        fs::read(&ocsp_path).expect("recovered OCSP cache file should be readable"),
+        valid_response.lock().expect("valid response mutex should lock").clone(),
+        "reload-triggered OCSP refresh should persist the recovered staple"
+    );
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
 fn spawn_ocsp_responder(requests: Arc<AtomicUsize>, body: Arc<Mutex<Vec<u8>>>) -> SocketAddr {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("OCSP responder should bind");
     let listen_addr = listener.local_addr().expect("OCSP responder addr should be available");
@@ -277,6 +447,24 @@ fn render_output(output: &Output) -> String {
         "stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn dynamic_ocsp_config(
+    listen_addr: SocketAddr,
+    cert_path: &Path,
+    key_path: &Path,
+    ocsp_path: &Path,
+    body: &str,
+) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n            ocsp_staple_path: Some({:?}),\n        )),\n    ),\n    upstreams: [],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some({body:?}),\n            ),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        cert_path.display().to_string(),
+        key_path.display().to_string(),
+        ocsp_path.display().to_string(),
+        ready_route = READY_ROUTE_CONFIG,
+        body = body,
     )
 }
 

--- a/crates/rginx-app/tests/reload/reload_flow.rs
+++ b/crates/rginx-app/tests/reload/reload_flow.rs
@@ -309,7 +309,7 @@ async fn http3_get_body(
         client::new(h3_quinn::Connection::new(connection))
             .await
             .map_err(|error| format!("failed to initialize http3 client: {error}"))?;
-    let driver_task = tokio::spawn(async move {
+    let mut driver_task = tokio::spawn(async move {
         let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
     });
 
@@ -348,7 +348,10 @@ async fn http3_get_body(
         .await
         .map_err(|error| format!("failed to receive http3 response trailers: {error}"))?;
 
-    driver_task.abort();
+    if tokio::time::timeout(Duration::from_millis(50), &mut driver_task).await.is_err() {
+        driver_task.abort();
+        let _ = driver_task.await;
+    }
     endpoint.close(quinn::VarInt::from_u32(0), b"done");
     String::from_utf8(body.to_vec()).map_err(|error| format!("http3 body was not utf-8: {error}"))
 }

--- a/crates/rginx-app/tests/reload/reload_flow.rs
+++ b/crates/rginx-app/tests/reload/reload_flow.rs
@@ -1,4 +1,12 @@
 use super::*;
+use std::sync::Arc;
+
+use bytes::{Buf, BytesMut};
+use h3::client;
+use hyper::http::Request;
+use quinn::crypto::rustls::QuicClientConfig;
+use rustls::pki_types::{CertificateDer, pem::PemObject};
+use rustls::{ClientConfig, RootCertStore};
 
 #[test]
 fn sighup_reload_applies_updated_routes() {
@@ -130,4 +138,256 @@ fn removed_listener_drains_in_flight_request_before_going_unreachable() {
 
     assert_unreachable(drain_addr, Duration::from_secs(2));
     server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[test]
+fn removed_http3_listener_drains_in_flight_request_before_going_unreachable() {
+    let _guard = test_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let cert = generate_cert("localhost");
+    let http_addr = reserve_loopback_addr();
+    let h3_addr = reserve_loopback_addr();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let upstream_addr =
+        spawn_delayed_response_server(Duration::from_millis(300), "draining\n", Some(ready_tx));
+    let mut server = ServerHarness::spawn_with_tls(
+        "rginx-reload-drain-http3-listener",
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+        |_, cert_path, key_path| {
+            explicit_http3_listener_proxy_config(
+                http_addr,
+                Some((h3_addr, cert_path, key_path)),
+                upstream_addr,
+            )
+        },
+    );
+
+    server.wait_for_http_ready(http_addr, Duration::from_secs(5));
+    server.wait_for_https_ready(h3_addr, Duration::from_secs(5));
+    wait_for_http3_body(
+        h3_addr,
+        "localhost",
+        "/-/ready",
+        &cert.cert.pem(),
+        "ready\n",
+        Duration::from_secs(5),
+    );
+    while ready_rx.try_recv().is_ok() {}
+
+    let (tx, rx) = mpsc::channel();
+    let cert_pem = cert.cert.pem();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let result =
+            runtime.block_on(async { http3_get_body(h3_addr, "localhost", "/", &cert_pem).await });
+        tx.send(result).expect("result channel should remain available");
+    });
+    ready_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("in-flight http3 request should reach upstream");
+
+    fs::write(
+        server.config_path(),
+        explicit_http3_listener_proxy_config(http_addr, None, upstream_addr),
+    )
+    .expect("reloaded config should be written");
+    server.send_signal(libc::SIGHUP);
+
+    server.wait_for_http_text_response(
+        http_addr,
+        &http_addr.to_string(),
+        "/",
+        200,
+        "draining\n",
+        Duration::from_secs(5),
+    );
+    let result =
+        rx.recv_timeout(Duration::from_secs(5)).expect("in-flight http3 request should finish");
+    let body = result.expect("in-flight http3 request should succeed");
+    assert_eq!(body, "draining\n");
+
+    assert_http3_unreachable(
+        h3_addr,
+        "localhost",
+        "/-/ready",
+        &cert.cert.pem(),
+        Duration::from_secs(3),
+    );
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+fn wait_for_http3_body(
+    listen_addr: SocketAddr,
+    server_name: &str,
+    path: &str,
+    cert_pem: &str,
+    expected: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    let mut last_error = String::new();
+
+    while Instant::now() < deadline {
+        match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build")
+            .block_on(async { http3_get_body(listen_addr, server_name, path, cert_pem).await })
+        {
+            Ok(body) if body == expected => return,
+            Ok(body) => last_error = format!("unexpected body {body:?}"),
+            Err(error) => last_error = error,
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    panic!(
+        "timed out waiting for expected http3 response on {}; expected body {:?}; last error: {}",
+        listen_addr, expected, last_error
+    );
+}
+
+fn assert_http3_unreachable(
+    listen_addr: SocketAddr,
+    server_name: &str,
+    path: &str,
+    cert_pem: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+
+    while Instant::now() < deadline {
+        let result = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build")
+            .block_on(async { http3_get_body(listen_addr, server_name, path, cert_pem).await });
+        if let Ok(body) = result {
+            panic!(
+                "expected http3 listener {} to stay unreachable, got body {:?}",
+                listen_addr, body
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+async fn http3_get_body(
+    listen_addr: SocketAddr,
+    server_name: &str,
+    path: &str,
+    cert_pem: &str,
+) -> Result<String, String> {
+    let roots = root_store_from_pem(cert_pem)?;
+    let mut client_crypto = ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .map_err(|error| format!("failed to constrain TLS versions for http3 client: {error}"))?
+    .with_root_certificates(roots)
+    .with_no_client_auth();
+    client_crypto.alpn_protocols = vec![b"h3".to_vec()];
+
+    let client_config = quinn::ClientConfig::new(Arc::new(
+        QuicClientConfig::try_from(client_crypto)
+            .map_err(|error| format!("failed to build quic client config: {error}"))?,
+    ));
+    let mut endpoint = quinn::Endpoint::client("127.0.0.1:0".parse().unwrap())
+        .map_err(|error| error.to_string())?;
+    endpoint.set_default_client_config(client_config);
+
+    let connection = endpoint
+        .connect(listen_addr, server_name)
+        .map_err(|error| format!("failed to start quic connect: {error}"))?
+        .await
+        .map_err(|error| format!("quic connect failed: {error}"))?;
+
+    let (mut driver, mut send_request) =
+        client::new(h3_quinn::Connection::new(connection))
+            .await
+            .map_err(|error| format!("failed to initialize http3 client: {error}"))?;
+    let driver_task = tokio::spawn(async move {
+        let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
+    });
+
+    let request = Request::builder()
+        .method("GET")
+        .uri(format!("https://{server_name}:{}{path}", listen_addr.port()))
+        .body(())
+        .expect("http3 request should build");
+    let mut request_stream = send_request
+        .send_request(request)
+        .await
+        .map_err(|error| format!("failed to send http3 request: {error}"))?;
+    request_stream
+        .finish()
+        .await
+        .map_err(|error| format!("failed to finish http3 request: {error}"))?;
+
+    let response = request_stream
+        .recv_response()
+        .await
+        .map_err(|error| format!("failed to receive http3 response headers: {error}"))?;
+    if response.status().as_u16() != 200 {
+        return Err(format!("unexpected http3 status {}", response.status().as_u16()));
+    }
+
+    let mut body = BytesMut::new();
+    while let Some(chunk) = request_stream
+        .recv_data()
+        .await
+        .map_err(|error| format!("failed to receive http3 response body: {error}"))?
+    {
+        body.extend_from_slice(chunk.chunk());
+    }
+    let _ = request_stream
+        .recv_trailers()
+        .await
+        .map_err(|error| format!("failed to receive http3 response trailers: {error}"))?;
+
+    driver_task.abort();
+    endpoint.close(quinn::VarInt::from_u32(0), b"done");
+    String::from_utf8(body.to_vec()).map_err(|error| format!("http3 body was not utf-8: {error}"))
+}
+
+fn root_store_from_pem(cert_pem: &str) -> Result<RootCertStore, String> {
+    let cert = CertificateDer::pem_slice_iter(cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to parse certificate PEM: {error}"))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| "certificate PEM did not contain a certificate".to_string())?;
+    let mut roots = RootCertStore::empty();
+    roots.add(cert).map_err(|error| format!("failed to add root certificate: {error}"))?;
+    Ok(roots)
+}
+
+fn explicit_http3_listener_proxy_config(
+    http_addr: SocketAddr,
+    http3: Option<(SocketAddr, &Path, &Path)>,
+    upstream_addr: SocketAddr,
+) -> String {
+    let mut listeners = vec![format!(
+        "        ListenerConfig(\n            name: \"http\",\n            listen: {:?},\n        )",
+        http_addr.to_string()
+    )];
+    if let Some((http3_addr, cert_path, key_path)) = http3 {
+        listeners.push(format!(
+            "        ListenerConfig(\n            name: \"https\",\n            listen: {:?},\n            tls: Some(ServerTlsConfig(\n                cert_path: {:?},\n                key_path: {:?},\n            )),\n            http3: Some(Http3Config(\n                advertise_alt_svc: Some(true),\n                alt_svc_max_age_secs: Some(7200),\n            )),\n        )",
+            http3_addr.to_string(),
+            cert_path.display().to_string(),
+            key_path.display().to_string(),
+        ));
+    }
+    let listeners = listeners.join(",\n");
+
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    listeners: [\n{listeners}\n    ],\n    server: ServerConfig(\n        server_names: [\"localhost\"],\n    ),\n    upstreams: [\n        UpstreamConfig(\n            name: \"backend\",\n            peers: [\n                UpstreamPeerConfig(\n                    url: {upstream:?},\n                ),\n            ],\n            request_timeout_secs: Some(3),\n        ),\n    ],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Proxy(\n                upstream: \"backend\",\n            ),\n        ),\n    ],\n)\n",
+        listeners = listeners,
+        upstream = format!("http://{upstream_addr}"),
+        ready_route = READY_ROUTE_CONFIG,
+    )
 }

--- a/crates/rginx-app/tests/reload/restart_flow.rs
+++ b/crates/rginx-app/tests/reload/restart_flow.rs
@@ -1,4 +1,12 @@
 use super::*;
+use std::sync::Arc;
+
+use bytes::{Buf, BytesMut};
+use h3::client;
+use hyper::http::Request;
+use quinn::crypto::rustls::QuicClientConfig;
+use rustls::pki_types::{CertificateDer, pem::PemObject};
+use rustls::{ClientConfig, RootCertStore};
 
 #[test]
 fn nginx_style_restart_command_applies_listen_address_changes() {
@@ -141,4 +149,174 @@ fn sighup_status_reports_tls_certificate_changes_after_rotation() {
     );
 
     server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[test]
+fn nginx_style_restart_command_keeps_http3_listener_available() {
+    let _guard = test_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime should build")
+        .block_on(async {
+            let cert = generate_cert("localhost");
+            let listen_addr = reserve_loopback_addr();
+            let mut server = ServerHarness::spawn_with_tls(
+                "rginx-restart-http3",
+                &cert.cert.pem(),
+                &cert.signing_key.serialize_pem(),
+                |_, cert_path, key_path| {
+                    http3_return_config(listen_addr, cert_path, key_path, "before restart\n")
+                },
+            );
+            server.wait_for_https_ready(listen_addr, Duration::from_secs(5));
+
+            let response = http3_get_body(listen_addr, "localhost", "/", &cert.cert.pem())
+                .await
+                .expect("http3 request before restart should succeed");
+            assert_eq!(response, "before restart\n");
+
+            let old_pid = read_pid_file(&server.config_path().with_extension("pid"));
+            let cert_path = server.temp_dir().join("server.crt");
+            let key_path = server.temp_dir().join("server.key");
+            fs::write(
+                server.config_path(),
+                http3_return_config(listen_addr, &cert_path, &key_path, "after restart\n"),
+            )
+            .expect("updated http3 config should be written");
+
+            let output = run_cli_command(server.config_path(), ["-s", "restart"]);
+            assert!(
+                output.status.success(),
+                "rginx -s restart should succeed for http3 listeners: {}",
+                render_output(&output)
+            );
+
+            let new_pid = wait_for_pid_change(
+                &server.config_path().with_extension("pid"),
+                old_pid,
+                Duration::from_secs(10),
+            );
+            let status = server.wait_for_exit(Duration::from_secs(10));
+            assert!(status.success(), "old process should exit cleanly after restart: {status}");
+
+            let response = http3_get_body(listen_addr, "localhost", "/", &cert.cert.pem())
+                .await
+                .expect("http3 request after restart should succeed");
+            assert_eq!(response, "after restart\n");
+
+            let quit = run_cli_command(server.config_path(), ["-s", "quit"]);
+            assert!(
+                quit.status.success(),
+                "rginx -s quit should stop replacement process: {}",
+                render_output(&quit)
+            );
+            wait_for_process_exit(new_pid, Duration::from_secs(10));
+        });
+}
+
+async fn http3_get_body(
+    listen_addr: SocketAddr,
+    server_name: &str,
+    path: &str,
+    cert_pem: &str,
+) -> Result<String, String> {
+    let roots = root_store_from_pem(cert_pem)?;
+    let mut client_crypto = ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .map_err(|error| format!("failed to constrain TLS versions for http3 client: {error}"))?
+    .with_root_certificates(roots)
+    .with_no_client_auth();
+    client_crypto.alpn_protocols = vec![b"h3".to_vec()];
+
+    let client_config = quinn::ClientConfig::new(Arc::new(
+        QuicClientConfig::try_from(client_crypto)
+            .map_err(|error| format!("failed to build quic client config: {error}"))?,
+    ));
+    let mut endpoint = quinn::Endpoint::client("127.0.0.1:0".parse().unwrap())
+        .map_err(|error| error.to_string())?;
+    endpoint.set_default_client_config(client_config);
+
+    let connection = endpoint
+        .connect(listen_addr, server_name)
+        .map_err(|error| format!("failed to start quic connect: {error}"))?
+        .await
+        .map_err(|error| format!("quic connect failed: {error}"))?;
+
+    let (mut driver, mut send_request) =
+        client::new(h3_quinn::Connection::new(connection))
+            .await
+            .map_err(|error| format!("failed to initialize http3 client: {error}"))?;
+    let driver_task = tokio::spawn(async move {
+        let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
+    });
+
+    let request = Request::builder()
+        .method("GET")
+        .uri(format!("https://{server_name}:{}{path}", listen_addr.port()))
+        .body(())
+        .expect("http3 request should build");
+    let mut request_stream = send_request
+        .send_request(request)
+        .await
+        .map_err(|error| format!("failed to send http3 request: {error}"))?;
+    request_stream
+        .finish()
+        .await
+        .map_err(|error| format!("failed to finish http3 request: {error}"))?;
+
+    let response = request_stream
+        .recv_response()
+        .await
+        .map_err(|error| format!("failed to receive http3 response headers: {error}"))?;
+    if response.status().as_u16() != 200 {
+        return Err(format!("unexpected http3 status {}", response.status().as_u16()));
+    }
+
+    let mut body = BytesMut::new();
+    while let Some(chunk) = request_stream
+        .recv_data()
+        .await
+        .map_err(|error| format!("failed to receive http3 response body: {error}"))?
+    {
+        body.extend_from_slice(chunk.chunk());
+    }
+    let _ = request_stream
+        .recv_trailers()
+        .await
+        .map_err(|error| format!("failed to receive http3 response trailers: {error}"))?;
+
+    driver_task.abort();
+    endpoint.close(quinn::VarInt::from_u32(0), b"done");
+    String::from_utf8(body.to_vec()).map_err(|error| format!("http3 body was not utf-8: {error}"))
+}
+
+fn root_store_from_pem(cert_pem: &str) -> Result<RootCertStore, String> {
+    let cert = CertificateDer::pem_slice_iter(cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to parse certificate PEM: {error}"))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| "certificate PEM did not contain a certificate".to_string())?;
+    let mut roots = RootCertStore::empty();
+    roots.add(cert).map_err(|error| format!("failed to add root certificate: {error}"))?;
+    Ok(roots)
+}
+
+fn http3_return_config(
+    listen_addr: SocketAddr,
+    cert_path: &Path,
+    key_path: &Path,
+    body: &str,
+) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n        server_names: [\"localhost\"],\n        tls: Some(ServerTlsConfig(\n            cert_path: {:?},\n            key_path: {:?},\n        )),\n        http3: Some(Http3Config(\n            advertise_alt_svc: Some(true),\n            alt_svc_max_age_secs: Some(7200),\n        )),\n    ),\n    upstreams: [],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some({body:?}),\n            ),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        cert_path.display().to_string(),
+        key_path.display().to_string(),
+        ready_route = READY_ROUTE_CONFIG,
+        body = body,
+    )
 }

--- a/crates/rginx-app/tests/reload/restart_flow.rs
+++ b/crates/rginx-app/tests/reload/restart_flow.rs
@@ -249,7 +249,7 @@ async fn http3_get_body(
         client::new(h3_quinn::Connection::new(connection))
             .await
             .map_err(|error| format!("failed to initialize http3 client: {error}"))?;
-    let driver_task = tokio::spawn(async move {
+    let mut driver_task = tokio::spawn(async move {
         let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
     });
 
@@ -288,7 +288,10 @@ async fn http3_get_body(
         .await
         .map_err(|error| format!("failed to receive http3 response trailers: {error}"))?;
 
-    driver_task.abort();
+    if tokio::time::timeout(Duration::from_millis(50), &mut driver_task).await.is_err() {
+        driver_task.abort();
+        let _ = driver_task.await;
+    }
     endpoint.close(quinn::VarInt::from_u32(0), b"done");
     String::from_utf8(body.to_vec()).map_err(|error| format!("http3 body was not utf-8: {error}"))
 }

--- a/crates/rginx-app/tests/upstream_http2.rs
+++ b/crates/rginx-app/tests/upstream_http2.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 use std::env;
-use std::fs::{self, File};
-use std::io::{BufReader, Read, Write};
+use std::fs;
+use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -15,6 +15,7 @@ use hyper::server::conn::http2;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode, Version};
 use hyper_util::rt::{TokioExecutor, TokioIo};
+use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -141,19 +142,14 @@ fn proxy_config(listen_addr: SocketAddr, upstream_addr: SocketAddr) -> String {
 }
 
 fn load_certs(path: &Path) -> Vec<CertificateDer<'static>> {
-    let file = File::open(path).expect("certificate file should open");
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::certs(&mut reader)
+    CertificateDer::pem_file_iter(path)
+        .expect("certificate file should open")
         .collect::<Result<Vec<_>, _>>()
         .expect("certificate PEM should parse")
 }
 
 fn load_private_key(path: &Path) -> PrivateKeyDer<'static> {
-    let file = File::open(path).expect("private key file should open");
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::private_key(&mut reader)
-        .expect("private key PEM should parse")
-        .expect("private key PEM should include at least one key")
+    PrivateKeyDer::from_pem_file(path).expect("private key PEM should parse")
 }
 
 fn fetch_text_response(listen_addr: SocketAddr, path: &str) -> Result<(u16, String), String> {

--- a/crates/rginx-app/tests/upstream_http3.rs
+++ b/crates/rginx-app/tests/upstream_http3.rs
@@ -16,10 +16,13 @@ use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair};
 use rustls::crypto::aws_lc_rs;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::WebPkiClientVerifier;
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::server::{ClientHello, ResolvesServerCert};
 use rustls::sign::CertifiedKey;
-use rustls::{DigitallySignedStruct, DistinguishedName, ProtocolVersion, SignatureScheme};
+use rustls::{
+    DigitallySignedStruct, DistinguishedName, ProtocolVersion, RootCertStore, SignatureScheme,
+};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -47,7 +50,7 @@ async fn proxies_plain_http_requests_to_http3_upstreams() {
         .expect("server key should be written");
 
     let (upstream_addr, observed_rx, upstream_task, upstream_temp_dir) =
-        spawn_http3_upstream(&server_cert_path, &server_key_path, None, None, false).await;
+        spawn_http3_upstream(&server_cert_path, &server_key_path, None, false).await;
 
     let listen_addr = reserve_loopback_addr();
     let mut server = ServerHarness::spawn("rginx-upstream-http3-basic", |_| {
@@ -102,14 +105,8 @@ async fn upstream_http3_honors_server_name_override_and_client_identity() {
     fs::write(&client_key_path, client.signing_key.serialize_pem())
         .expect("client key should be written");
 
-    let (upstream_addr, observed_rx, upstream_task, upstream_temp_dir) = spawn_http3_upstream(
-        &server_cert_path,
-        &server_key_path,
-        Some("localhost"),
-        Some(&ca_path),
-        true,
-    )
-    .await;
+    let (upstream_addr, observed_rx, upstream_task, upstream_temp_dir) =
+        spawn_http3_upstream(&server_cert_path, &server_key_path, Some(&ca_path), true).await;
 
     let listen_addr = reserve_loopback_addr();
     let mut server = ServerHarness::spawn("rginx-upstream-http3-mtls", |_| {
@@ -144,8 +141,7 @@ async fn upstream_http3_honors_server_name_override_and_client_identity() {
 async fn spawn_http3_upstream(
     cert_path: &Path,
     key_path: &Path,
-    default_server_name: Option<&str>,
-    _client_ca_path: Option<&Path>,
+    client_ca_path: Option<&Path>,
     require_client_cert: bool,
 ) -> (SocketAddr, oneshot::Receiver<ObservedHttp3Request>, JoinHandle<()>, PathBuf) {
     let temp_dir = temp_dir("rginx-upstream-http3-server");
@@ -153,11 +149,8 @@ async fn spawn_http3_upstream(
 
     let certified_key = Arc::new(load_certified_key(cert_path, key_path));
     let observed_sni = Arc::new(Mutex::new(None::<String>));
-    let resolver = Arc::new(CapturingResolver {
-        certified_key,
-        default_server_name: default_server_name.map(str::to_string),
-        observed_sni: observed_sni.clone(),
-    });
+    let resolver =
+        Arc::new(CapturingResolver { certified_key, observed_sni: observed_sni.clone() });
     let client_cert_seen = Arc::new(AtomicBool::new(false));
 
     let builder = rustls::ServerConfig::builder_with_provider(Arc::new(
@@ -166,7 +159,10 @@ async fn spawn_http3_upstream(
     .with_protocol_versions(&[&rustls::version::TLS13])
     .expect("server TLS1.3 builder should succeed");
     let mut server_crypto = if require_client_cert {
-        let verifier = Arc::new(RequireAnyClientCertVerifier::new(client_cert_seen.clone()));
+        let verifier = Arc::new(RequireTrustedClientCertVerifier::new(
+            client_ca_path.expect("client CA should be provided when client certs are required"),
+            client_cert_seen.clone(),
+        ));
         builder.with_client_cert_verifier(verifier).with_cert_resolver(resolver)
     } else {
         builder.with_no_client_auth().with_cert_resolver(resolver)
@@ -275,7 +271,6 @@ fn temp_dir(prefix: &str) -> PathBuf {
 
 struct CapturingResolver {
     certified_key: Arc<CertifiedKey>,
-    default_server_name: Option<String>,
     observed_sni: Arc<Mutex<Option<String>>>,
 }
 
@@ -287,69 +282,69 @@ impl fmt::Debug for CapturingResolver {
 
 impl ResolvesServerCert for CapturingResolver {
     fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
-        let observed = client_hello
-            .server_name()
-            .map(str::to_string)
-            .or_else(|| self.default_server_name.clone());
-        *self.observed_sni.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = observed;
+        if let Some(server_name) = client_hello.server_name() {
+            *self.observed_sni.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                Some(server_name.to_string());
+        }
         Some(self.certified_key.clone())
     }
 }
 
 #[derive(Debug)]
-struct RequireAnyClientCertVerifier {
-    root_hints: Vec<DistinguishedName>,
-    supported_schemes: Vec<SignatureScheme>,
+struct RequireTrustedClientCertVerifier {
+    inner: Arc<dyn ClientCertVerifier>,
     client_cert_seen: Arc<AtomicBool>,
 }
 
-impl RequireAnyClientCertVerifier {
-    fn new(client_cert_seen: Arc<AtomicBool>) -> Self {
-        Self {
-            root_hints: Vec::new(),
-            supported_schemes: rustls::crypto::aws_lc_rs::default_provider()
-                .signature_verification_algorithms
-                .supported_schemes(),
-            client_cert_seen,
+impl RequireTrustedClientCertVerifier {
+    fn new(ca_path: &Path, client_cert_seen: Arc<AtomicBool>) -> Self {
+        let mut roots = RootCertStore::empty();
+        for cert in load_certs(ca_path) {
+            roots.add(cert).expect("client CA certificate should load into root store");
         }
+        let inner = WebPkiClientVerifier::builder(roots.into())
+            .build()
+            .expect("client verifier should build");
+        Self { inner, client_cert_seen }
     }
 }
 
-impl ClientCertVerifier for RequireAnyClientCertVerifier {
+impl ClientCertVerifier for RequireTrustedClientCertVerifier {
     fn root_hint_subjects(&self) -> &[DistinguishedName] {
-        &self.root_hints
+        self.inner.root_hint_subjects()
     }
 
     fn verify_client_cert(
         &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _now: rustls::pki_types::UnixTime,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        now: rustls::pki_types::UnixTime,
     ) -> Result<ClientCertVerified, rustls::Error> {
+        let verified = self.inner.verify_client_cert(end_entity, intermediates, now)?;
         self.client_cert_seen.store(true, Ordering::Relaxed);
-        Ok(ClientCertVerified::assertion())
+        Ok(verified)
     }
 
     fn verify_tls12_signature(
         &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        self.inner.verify_tls12_signature(message, cert, dss)
     }
 
     fn verify_tls13_signature(
         &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        self.inner.verify_tls13_signature(message, cert, dss)
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        self.supported_schemes.clone()
+        self.inner.supported_verify_schemes()
     }
 }
 

--- a/crates/rginx-app/tests/upstream_http3.rs
+++ b/crates/rginx-app/tests/upstream_http3.rs
@@ -1,0 +1,394 @@
+use std::env;
+use std::fmt;
+use std::fs;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use bytes::Bytes;
+use h3::server::Connection as H3Connection;
+use h3_quinn::quinn;
+use hyper::{Response, StatusCode};
+use quinn::crypto::rustls::QuicServerConfig;
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair};
+use rustls::crypto::aws_lc_rs;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
+use rustls::server::{ClientHello, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
+use rustls::{DigitallySignedStruct, DistinguishedName, ProtocolVersion, SignatureScheme};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+mod support;
+
+use support::{READY_ROUTE_CONFIG, ServerHarness, reserve_loopback_addr};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObservedHttp3Request {
+    sni: Option<String>,
+    peer_certificates_present: bool,
+    protocol_version: Option<ProtocolVersion>,
+    path: String,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn proxies_plain_http_requests_to_http3_upstreams() {
+    let cert = generate_cert("localhost");
+    let shared_dir = temp_dir("rginx-upstream-h3-basic");
+    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
+    let server_cert_path = shared_dir.join("server.pem");
+    let server_key_path = shared_dir.join("server.key");
+    fs::write(&server_cert_path, cert.cert.pem()).expect("server cert should be written");
+    fs::write(&server_key_path, cert.signing_key.serialize_pem())
+        .expect("server key should be written");
+
+    let (upstream_addr, observed_rx, upstream_task, upstream_temp_dir) =
+        spawn_http3_upstream(&server_cert_path, &server_key_path, None, None, false).await;
+
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn("rginx-upstream-http3-basic", |_| {
+        basic_proxy_config(listen_addr, upstream_addr)
+    });
+    server.wait_for_http_ready(listen_addr, Duration::from_secs(5));
+
+    server.wait_for_http_text_response(
+        listen_addr,
+        &listen_addr.to_string(),
+        "/",
+        200,
+        "upstream http3 ok\n",
+        Duration::from_secs(5),
+    );
+
+    let observed = tokio::time::timeout(Duration::from_secs(5), observed_rx)
+        .await
+        .expect("upstream request should be observed before timeout")
+        .expect("upstream observation channel should complete");
+    assert_eq!(observed.path, "/");
+    assert_eq!(observed.sni, None);
+    assert!(!observed.peer_certificates_present);
+    assert_eq!(observed.protocol_version, Some(ProtocolVersion::TLSv1_3));
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+    upstream_task.await.expect("upstream h3 task should finish");
+    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
+    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upstream_http3_honors_server_name_override_and_client_identity() {
+    let shared_dir = temp_dir("rginx-upstream-h3-mtls");
+    fs::create_dir_all(&shared_dir).expect("shared temp dir should be created");
+
+    let ca = generate_ca_cert("upstream-h3-ca");
+    let server = generate_cert_signed_by_ca("localhost", &ca);
+    let client = generate_cert_signed_by_ca("upstream-h3-client", &ca);
+
+    let ca_path = shared_dir.join("ca.pem");
+    let server_cert_path = shared_dir.join("server.crt");
+    let server_key_path = shared_dir.join("server.key");
+    let client_cert_path = shared_dir.join("client.crt");
+    let client_key_path = shared_dir.join("client.key");
+
+    fs::write(&ca_path, ca.cert.pem()).expect("ca cert should be written");
+    fs::write(&server_cert_path, server.cert.pem()).expect("server cert should be written");
+    fs::write(&server_key_path, server.signing_key.serialize_pem())
+        .expect("server key should be written");
+    fs::write(&client_cert_path, client.cert.pem()).expect("client cert should be written");
+    fs::write(&client_key_path, client.signing_key.serialize_pem())
+        .expect("client key should be written");
+
+    let (upstream_addr, observed_rx, upstream_task, upstream_temp_dir) = spawn_http3_upstream(
+        &server_cert_path,
+        &server_key_path,
+        Some("localhost"),
+        Some(&ca_path),
+        true,
+    )
+    .await;
+
+    let listen_addr = reserve_loopback_addr();
+    let mut server = ServerHarness::spawn("rginx-upstream-http3-mtls", |_| {
+        mtls_proxy_config(listen_addr, upstream_addr, &ca_path, &client_cert_path, &client_key_path)
+    });
+    server.wait_for_http_ready(listen_addr, Duration::from_secs(5));
+
+    server.wait_for_http_text_response(
+        listen_addr,
+        &listen_addr.to_string(),
+        "/",
+        200,
+        "upstream http3 ok\n",
+        Duration::from_secs(5),
+    );
+
+    let observed = tokio::time::timeout(Duration::from_secs(5), observed_rx)
+        .await
+        .expect("upstream request should be observed before timeout")
+        .expect("upstream observation channel should complete");
+    assert_eq!(observed.path, "/");
+    assert_eq!(observed.sni.as_deref(), Some("localhost"));
+    assert!(observed.peer_certificates_present);
+    assert_eq!(observed.protocol_version, Some(ProtocolVersion::TLSv1_3));
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+    upstream_task.await.expect("upstream h3 task should finish");
+    fs::remove_dir_all(upstream_temp_dir).expect("upstream temp dir should be removed");
+    fs::remove_dir_all(shared_dir).expect("shared temp dir should be removed");
+}
+
+async fn spawn_http3_upstream(
+    cert_path: &Path,
+    key_path: &Path,
+    default_server_name: Option<&str>,
+    _client_ca_path: Option<&Path>,
+    require_client_cert: bool,
+) -> (SocketAddr, oneshot::Receiver<ObservedHttp3Request>, JoinHandle<()>, PathBuf) {
+    let temp_dir = temp_dir("rginx-upstream-http3-server");
+    fs::create_dir_all(&temp_dir).expect("upstream temp dir should be created");
+
+    let certified_key = Arc::new(load_certified_key(cert_path, key_path));
+    let observed_sni = Arc::new(Mutex::new(None::<String>));
+    let resolver = Arc::new(CapturingResolver {
+        certified_key,
+        default_server_name: default_server_name.map(str::to_string),
+        observed_sni: observed_sni.clone(),
+    });
+    let client_cert_seen = Arc::new(AtomicBool::new(false));
+
+    let builder = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .expect("server TLS1.3 builder should succeed");
+    let mut server_crypto = if require_client_cert {
+        let verifier = Arc::new(RequireAnyClientCertVerifier::new(client_cert_seen.clone()));
+        builder.with_client_cert_verifier(verifier).with_cert_resolver(resolver)
+    } else {
+        builder.with_no_client_auth().with_cert_resolver(resolver)
+    };
+    server_crypto.alpn_protocols = vec![b"h3".to_vec()];
+
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(
+        QuicServerConfig::try_from(server_crypto).expect("quic server config should build"),
+    ));
+    let endpoint = quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap()).unwrap();
+    let listen_addr = endpoint.local_addr().expect("upstream h3 addr should be available");
+    let (observed_tx, observed_rx) = oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        let incoming = endpoint.accept().await.expect("upstream h3 connection should arrive");
+        let connection = incoming.await.expect("upstream h3 connection should establish");
+        let protocol_version = Some(ProtocolVersion::TLSv1_3);
+        let mut h3 = H3Connection::new(h3_quinn::Connection::new(connection))
+            .await
+            .expect("upstream h3 server should initialize");
+        let resolver = h3
+            .accept()
+            .await
+            .expect("upstream h3 should accept request")
+            .expect("request should exist");
+        let (request, mut stream) =
+            resolver.resolve_request().await.expect("upstream h3 should resolve request");
+        let observed = ObservedHttp3Request {
+            sni: observed_sni.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).clone(),
+            peer_certificates_present: client_cert_seen.load(Ordering::Relaxed),
+            protocol_version,
+            path: request.uri().path().to_string(),
+        };
+        let _ = observed_tx.send(observed);
+
+        stream
+            .send_response(
+                Response::builder().status(StatusCode::OK).body(()).expect("response should build"),
+            )
+            .await
+            .expect("upstream h3 should send response");
+        stream
+            .send_data(Bytes::from_static(b"upstream http3 ok\n"))
+            .await
+            .expect("upstream h3 should send body");
+        stream.finish().await.expect("upstream h3 should finish response");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    });
+
+    (listen_addr, observed_rx, task, temp_dir)
+}
+
+fn basic_proxy_config(listen_addr: SocketAddr, upstream_addr: SocketAddr) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n    ),\n    upstreams: [\n        UpstreamConfig(\n            name: \"backend\",\n            peers: [\n                UpstreamPeerConfig(\n                    url: {:?},\n                ),\n            ],\n            tls: Some(Insecure),\n            protocol: Http3,\n        ),\n    ],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Proxy(\n                upstream: \"backend\",\n            ),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        format!("https://127.0.0.1:{}", upstream_addr.port()),
+        ready_route = READY_ROUTE_CONFIG,
+    )
+}
+
+fn mtls_proxy_config(
+    listen_addr: SocketAddr,
+    upstream_addr: SocketAddr,
+    ca_path: &Path,
+    client_cert_path: &Path,
+    client_key_path: &Path,
+) -> String {
+    format!(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    server: ServerConfig(\n        listen: {:?},\n    ),\n    upstreams: [\n        UpstreamConfig(\n            name: \"backend\",\n            peers: [\n                UpstreamPeerConfig(\n                    url: {:?},\n                ),\n            ],\n            tls: Some(UpstreamTlsConfig(\n                verify: CustomCa(ca_cert_path: {:?}),\n                versions: Some([Tls13]),\n                client_cert_path: Some({:?}),\n                client_key_path: Some({:?}),\n            )),\n            protocol: Http3,\n            server_name_override: Some(\"localhost\"),\n        ),\n    ],\n    locations: [\n{ready_route}        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Proxy(\n                upstream: \"backend\",\n            ),\n        ),\n    ],\n)\n",
+        listen_addr.to_string(),
+        format!("https://127.0.0.1:{}", upstream_addr.port()),
+        ca_path.display().to_string(),
+        client_cert_path.display().to_string(),
+        client_key_path.display().to_string(),
+        ready_route = READY_ROUTE_CONFIG,
+    )
+}
+
+fn load_certified_key(cert_path: &Path, key_path: &Path) -> CertifiedKey {
+    let provider = aws_lc_rs::default_provider();
+    CertifiedKey::from_der(load_certs(cert_path), load_private_key(key_path), &provider)
+        .expect("test certified key should build")
+}
+
+fn load_certs(path: &Path) -> Vec<CertificateDer<'static>> {
+    CertificateDer::pem_file_iter(path)
+        .expect("certificate file should open")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("certificate PEM should parse")
+}
+
+fn load_private_key(path: &Path) -> PrivateKeyDer<'static> {
+    PrivateKeyDer::from_pem_file(path).expect("private key PEM should parse")
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    env::temp_dir().join(format!("{prefix}-{unique}-{id}"))
+}
+
+struct CapturingResolver {
+    certified_key: Arc<CertifiedKey>,
+    default_server_name: Option<String>,
+    observed_sni: Arc<Mutex<Option<String>>>,
+}
+
+impl fmt::Debug for CapturingResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CapturingResolver").finish_non_exhaustive()
+    }
+}
+
+impl ResolvesServerCert for CapturingResolver {
+    fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        let observed = client_hello
+            .server_name()
+            .map(str::to_string)
+            .or_else(|| self.default_server_name.clone());
+        *self.observed_sni.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = observed;
+        Some(self.certified_key.clone())
+    }
+}
+
+#[derive(Debug)]
+struct RequireAnyClientCertVerifier {
+    root_hints: Vec<DistinguishedName>,
+    supported_schemes: Vec<SignatureScheme>,
+    client_cert_seen: Arc<AtomicBool>,
+}
+
+impl RequireAnyClientCertVerifier {
+    fn new(client_cert_seen: Arc<AtomicBool>) -> Self {
+        Self {
+            root_hints: Vec::new(),
+            supported_schemes: rustls::crypto::aws_lc_rs::default_provider()
+                .signature_verification_algorithms
+                .supported_schemes(),
+            client_cert_seen,
+        }
+    }
+}
+
+impl ClientCertVerifier for RequireAnyClientCertVerifier {
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
+        &self.root_hints
+    }
+
+    fn verify_client_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<ClientCertVerified, rustls::Error> {
+        self.client_cert_seen.store(true, Ordering::Relaxed);
+        Ok(ClientCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.supported_schemes.clone()
+    }
+}
+
+struct TestCertifiedKey {
+    cert: rcgen::Certificate,
+    signing_key: KeyPair,
+    params: CertificateParams,
+}
+
+impl TestCertifiedKey {
+    fn issuer(&self) -> Issuer<'_, &KeyPair> {
+        Issuer::from_params(&self.params, &self.signing_key)
+    }
+}
+
+fn generate_ca_cert(common_name: &str) -> TestCertifiedKey {
+    let mut params =
+        CertificateParams::new(vec![common_name.to_string()]).expect("CA params should build");
+    params.distinguished_name.push(DnType::CommonName, common_name);
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let signing_key = KeyPair::generate().expect("CA keypair should generate");
+    let cert = params.self_signed(&signing_key).expect("CA certificate should self-sign");
+    TestCertifiedKey { cert, signing_key, params }
+}
+
+fn generate_cert(hostname: &str) -> TestCertifiedKey {
+    let params =
+        CertificateParams::new(vec![hostname.to_string()]).expect("leaf params should build");
+    let signing_key = KeyPair::generate().expect("leaf key should generate");
+    let cert = params.self_signed(&signing_key).expect("self-signed cert should generate");
+    TestCertifiedKey { cert, signing_key, params }
+}
+
+fn generate_cert_signed_by_ca(hostname: &str, ca: &TestCertifiedKey) -> TestCertifiedKey {
+    let mut params =
+        CertificateParams::new(vec![hostname.to_string()]).expect("leaf params should build");
+    params.distinguished_name.push(DnType::CommonName, hostname);
+    let signing_key = KeyPair::generate().expect("leaf key should generate");
+    let cert =
+        params.signed_by(&signing_key, &ca.issuer()).expect("leaf cert should be signed by ca");
+    TestCertifiedKey { cert, signing_key, params }
+}

--- a/crates/rginx-app/tests/upstream_mtls.rs
+++ b/crates/rginx-app/tests/upstream_mtls.rs
@@ -1,7 +1,6 @@
 use std::convert::Infallible;
 use std::env;
-use std::fs::{self, File};
-use std::io::BufReader;
+use std::fs;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -15,6 +14,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::{DigitallySignedStruct, DistinguishedName, ProtocolVersion, SignatureScheme};
@@ -160,19 +160,14 @@ fn proxy_config(
 }
 
 fn load_certs(path: &Path) -> Vec<CertificateDer<'static>> {
-    let file = File::open(path).expect("certificate file should open");
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::certs(&mut reader)
+    CertificateDer::pem_file_iter(path)
+        .expect("certificate file should open")
         .collect::<Result<Vec<_>, _>>()
         .expect("certificate PEM should parse")
 }
 
 fn load_private_key(path: &Path) -> PrivateKeyDer<'static> {
-    let file = File::open(path).expect("private key file should open");
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::private_key(&mut reader)
-        .expect("private key PEM should parse")
-        .expect("private key PEM should include at least one key")
+    PrivateKeyDer::from_pem_file(path).expect("private key PEM should parse")
 }
 
 fn temp_dir(prefix: &str) -> PathBuf {

--- a/crates/rginx-app/tests/upstream_server_name.rs
+++ b/crates/rginx-app/tests/upstream_server_name.rs
@@ -1,8 +1,7 @@
 use std::convert::Infallible;
 use std::env;
 use std::fmt;
-use std::fs::{self, File};
-use std::io::BufReader;
+use std::fs;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -17,6 +16,7 @@ use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use rustls::crypto::aws_lc_rs;
+use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::{ClientHello, ResolvesServerCert};
 use rustls::sign::CertifiedKey;
@@ -169,19 +169,14 @@ fn load_certified_key(cert_path: &Path, key_path: &Path) -> CertifiedKey {
 }
 
 fn load_certs(path: &Path) -> Vec<CertificateDer<'static>> {
-    let file = File::open(path).expect("certificate file should open");
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::certs(&mut reader)
+    CertificateDer::pem_file_iter(path)
+        .expect("certificate file should open")
         .collect::<Result<Vec<_>, _>>()
         .expect("certificate PEM should parse")
 }
 
 fn load_private_key(path: &Path) -> PrivateKeyDer<'static> {
-    let file = File::open(path).expect("private key file should open");
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::private_key(&mut reader)
-        .expect("private key PEM should parse")
-        .expect("private key PEM should include at least one key")
+    PrivateKeyDer::from_pem_file(path).expect("private key PEM should parse")
 }
 
 fn temp_dir(prefix: &str) -> PathBuf {

--- a/crates/rginx-config/src/compile/server.rs
+++ b/crates/rginx-config/src/compile/server.rs
@@ -4,15 +4,17 @@ use std::time::Duration;
 
 use ipnet::IpNet;
 use rginx_core::{
-    AccessLogFormat, Error, Listener, OcspConfig, OcspNonceMode, OcspResponderPolicy, Result,
-    Server, ServerCertificateBundle, ServerClientAuthMode, ServerClientAuthPolicy, ServerTls,
-    TlsCipherSuite, TlsKeyExchangeGroup, TlsVersion, VirtualHostTls,
+    AccessLogFormat, Error, Listener, ListenerHttp3, OcspConfig, OcspNonceMode,
+    OcspResponderPolicy, Result, Server, ServerCertificateBundle, ServerClientAuthMode,
+    ServerClientAuthPolicy, ServerTls, TlsCipherSuite, TlsKeyExchangeGroup, TlsVersion,
+    VirtualHostTls,
 };
 
 use crate::model::{
-    ListenerConfig, OcspConfig as RawOcspConfig, OcspNonceModeConfig, OcspResponderPolicyConfig,
-    ServerCertificateBundleConfig, ServerClientAuthModeConfig, ServerConfig, ServerTlsConfig,
-    TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig, TlsVersionConfig, VirtualHostTlsConfig,
+    Http3Config, ListenerConfig, OcspConfig as RawOcspConfig, OcspNonceModeConfig,
+    OcspResponderPolicyConfig, ServerCertificateBundleConfig, ServerClientAuthModeConfig,
+    ServerConfig, ServerTlsConfig, TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig,
+    TlsVersionConfig, VirtualHostTlsConfig,
 };
 
 pub(super) struct CompiledServer {
@@ -40,6 +42,7 @@ pub(super) fn compile_legacy_server(
         response_write_timeout_secs,
         access_log_format,
         tls,
+        http3,
     } = server;
 
     let listen = listen.expect("legacy server listen should be validated before compile");
@@ -60,6 +63,11 @@ pub(super) fn compile_legacy_server(
         },
         base_dir,
     )?;
+    let http3 = compile_http3(
+        http3,
+        compiled.server.listen_addr,
+        compiled.server_tls.is_some() || any_vhost_tls,
+    )?;
 
     Ok(CompiledServer {
         listener: Listener {
@@ -68,6 +76,7 @@ pub(super) fn compile_legacy_server(
             server: compiled.server,
             tls_termination_enabled: compiled.server_tls.is_some() || any_vhost_tls,
             proxy_protocol_enabled: proxy_protocol.unwrap_or(false),
+            http3,
         },
         server_names,
     })
@@ -95,6 +104,7 @@ pub(super) fn compile_listeners(
                 response_write_timeout_secs,
                 access_log_format,
                 tls,
+                http3,
             } = listener;
 
             let compiled = compile_server_fields(
@@ -114,6 +124,8 @@ pub(super) fn compile_listeners(
                 },
                 base_dir,
             )?;
+            let http3 =
+                compile_http3(http3, compiled.server.listen_addr, compiled.server_tls.is_some())?;
 
             Ok(Listener {
                 id: explicit_listener_id(&name),
@@ -121,6 +133,7 @@ pub(super) fn compile_listeners(
                 server: compiled.server,
                 tls_termination_enabled: compiled.server_tls.is_some(),
                 proxy_protocol_enabled: proxy_protocol.unwrap_or(false),
+                http3,
             })
         })
         .collect()
@@ -350,6 +363,33 @@ fn compile_max_connections(max_connections: Option<u64>) -> Result<Option<usize>
 
 fn compile_access_log_format(access_log_format: Option<String>) -> Result<Option<AccessLogFormat>> {
     access_log_format.map(AccessLogFormat::parse).transpose()
+}
+
+fn compile_http3(
+    http3: Option<Http3Config>,
+    tcp_listen_addr: std::net::SocketAddr,
+    tls_enabled: bool,
+) -> Result<Option<ListenerHttp3>> {
+    let Some(http3) = http3 else {
+        return Ok(None);
+    };
+
+    if !tls_enabled {
+        return Err(Error::Config(
+            "http3 requires tls to be configured on the same listener".to_string(),
+        ));
+    }
+
+    let listen_addr = match http3.listen {
+        Some(listen) => listen.parse()?,
+        None => tcp_listen_addr,
+    };
+
+    Ok(Some(ListenerHttp3 {
+        listen_addr,
+        advertise_alt_svc: http3.advertise_alt_svc.unwrap_or(true),
+        alt_svc_max_age: Duration::from_secs(http3.alt_svc_max_age_secs.unwrap_or(86_400)),
+    }))
 }
 
 fn compile_tls_versions(versions: Option<Vec<TlsVersionConfig>>) -> Option<Vec<TlsVersion>> {

--- a/crates/rginx-config/src/compile/tests.rs
+++ b/crates/rginx-config/src/compile/tests.rs
@@ -2,10 +2,10 @@ use std::fs;
 use std::time::Duration;
 
 use crate::model::{
-    Config, HandlerConfig, ListenerConfig, LocationConfig, MatcherConfig, RuntimeConfig,
-    ServerConfig, ServerTlsConfig, TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig, UpstreamConfig,
-    UpstreamLoadBalanceConfig, UpstreamPeerConfig, UpstreamProtocolConfig, UpstreamTlsConfig,
-    VirtualHostConfig,
+    Config, HandlerConfig, Http3Config, ListenerConfig, LocationConfig, MatcherConfig,
+    RuntimeConfig, ServerConfig, ServerTlsConfig, TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig,
+    UpstreamConfig, UpstreamLoadBalanceConfig, UpstreamPeerConfig, UpstreamProtocolConfig,
+    UpstreamTlsConfig, VirtualHostConfig,
 };
 use tempfile::TempDir;
 
@@ -53,6 +53,7 @@ fn compile_accepts_https_upstreams() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "secure-backend".to_string(),
@@ -168,6 +169,7 @@ fn compile_defaults_grpc_health_check_path_when_service_is_set() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "grpc-backend".to_string(),
@@ -261,6 +263,7 @@ fn compile_applies_granular_upstream_transport_settings() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "backend".to_string(),
@@ -359,6 +362,7 @@ fn compile_accepts_least_conn_load_balance() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "backend".to_string(),
@@ -453,6 +457,7 @@ fn compile_applies_peer_weights() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "backend".to_string(),
@@ -562,6 +567,7 @@ fn compile_accepts_backup_peers() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "backend".to_string(),
@@ -671,6 +677,7 @@ fn compile_uses_legacy_request_timeout_fallbacks_and_disables_pool_idle_timeout(
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "backend".to_string(),
@@ -767,6 +774,7 @@ fn compile_uses_default_pool_idle_timeout() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "backend".to_string(),
@@ -861,6 +869,7 @@ fn compile_resolves_custom_ca_relative_to_config_base() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "dev-backend".to_string(),
@@ -954,6 +963,92 @@ fn compile_resolves_custom_ca_relative_to_config_base() {
 }
 
 #[test]
+fn compile_accepts_https_http3_upstreams() {
+    let config = Config {
+        runtime: RuntimeConfig {
+            shutdown_timeout_secs: 10,
+            worker_threads: None,
+            accept_workers: None,
+        },
+        listeners: Vec::new(),
+        server: ServerConfig {
+            listen: Some("127.0.0.1:8080".to_string()),
+            proxy_protocol: None,
+            default_certificate: None,
+            server_names: Vec::new(),
+            trusted_proxies: Vec::new(),
+            keep_alive: None,
+            max_headers: None,
+            max_request_body_bytes: None,
+            max_connections: None,
+            header_read_timeout_secs: None,
+            request_body_read_timeout_secs: None,
+            response_write_timeout_secs: None,
+            access_log_format: None,
+            tls: None,
+            http3: None,
+        },
+        upstreams: vec![UpstreamConfig {
+            name: "h3-backend".to_string(),
+            peers: vec![UpstreamPeerConfig {
+                url: "https://example.com:443".to_string(),
+                weight: 1,
+                backup: false,
+            }],
+            tls: None,
+            protocol: UpstreamProtocolConfig::Http3,
+            load_balance: UpstreamLoadBalanceConfig::RoundRobin,
+            server_name: None,
+            server_name_override: Some("example.com".to_string()),
+            request_timeout_secs: None,
+            connect_timeout_secs: None,
+            read_timeout_secs: None,
+            write_timeout_secs: None,
+            idle_timeout_secs: None,
+            pool_idle_timeout_secs: None,
+            pool_max_idle_per_host: None,
+            tcp_keepalive_secs: None,
+            tcp_nodelay: None,
+            http2_keep_alive_interval_secs: None,
+            http2_keep_alive_timeout_secs: None,
+            http2_keep_alive_while_idle: None,
+            max_replayable_request_body_bytes: None,
+            unhealthy_after_failures: None,
+            unhealthy_cooldown_secs: None,
+            health_check_path: None,
+            health_check_grpc_service: None,
+            health_check_interval_secs: None,
+            health_check_timeout_secs: None,
+            healthy_successes_required: None,
+        }],
+        locations: vec![LocationConfig {
+            matcher: MatcherConfig::Prefix("/".to_string()),
+            handler: HandlerConfig::Proxy {
+                upstream: "h3-backend".to_string(),
+                preserve_host: None,
+                strip_prefix: None,
+                proxy_set_headers: std::collections::HashMap::new(),
+            },
+            grpc_service: None,
+            grpc_method: None,
+            allow_cidrs: Vec::new(),
+            deny_cidrs: Vec::new(),
+            requests_per_sec: None,
+            burst: None,
+        }],
+        servers: Vec::new(),
+    };
+
+    let snapshot = compile(config).expect("http3 upstream should compile");
+    let proxy = match &snapshot.default_vhost.routes[0].action {
+        rginx_core::RouteAction::Proxy(proxy) => proxy,
+        _ => panic!("expected proxy route"),
+    };
+    assert_eq!(proxy.upstream.protocol, rginx_core::UpstreamProtocol::Http3);
+    assert_eq!(proxy.upstream.server_name_override.as_deref(), Some("example.com"));
+}
+
+#[test]
 fn compile_resolves_upstream_mtls_identity_and_tls_versions_relative_to_config_base() {
     let base_dir = temp_base_dir("rginx-upstream-mtls-config-test-");
     let ca_path = base_dir.path().join("upstream-ca.pem");
@@ -985,6 +1080,7 @@ fn compile_resolves_upstream_mtls_identity_and_tls_versions_relative_to_config_b
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "mtls-backend".to_string(),
@@ -1091,6 +1187,7 @@ fn compile_normalizes_server_name_override() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "secure-backend".to_string(),
@@ -1178,6 +1275,7 @@ fn compile_preserves_upstream_server_name_toggle() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "secure-backend".to_string(),
@@ -1271,6 +1369,7 @@ fn compile_rejects_invalid_server_name_override() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "secure-backend".to_string(),
@@ -1353,6 +1452,7 @@ fn compile_attaches_route_access_control() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -1403,6 +1503,7 @@ fn compile_attaches_route_rate_limit() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -1455,6 +1556,7 @@ fn compile_generates_distinct_route_and_vhost_ids() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -1550,6 +1652,7 @@ fn compile_resolves_server_tls_paths_relative_to_config_base() {
                 session_ticket_count: None,
                 client_auth: None,
             }),
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -1623,6 +1726,7 @@ fn compile_preserves_server_tls_policy_fields() {
                 session_ticket_count: None,
                 client_auth: None,
             }),
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -1705,6 +1809,7 @@ fn compile_preserves_server_tls_ocsp_policy_fields() {
                 session_ticket_count: None,
                 client_auth: None,
             }),
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -1755,6 +1860,7 @@ fn compile_normalizes_trusted_proxy_ips_and_cidrs() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -1806,6 +1912,7 @@ fn compile_attaches_server_hardening_settings() {
             response_write_timeout_secs: Some(5),
             access_log_format: Some("$request_id $status $request".to_string()),
             tls: None,
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -1877,6 +1984,7 @@ fn compile_prioritizes_grpc_constrained_routes_with_same_path_matcher() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![
@@ -1951,6 +2059,7 @@ fn compile_rejects_invalid_server_access_log_format() {
             response_write_timeout_secs: None,
             access_log_format: Some("$trace_id $status".to_string()),
             tls: None,
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -2000,6 +2109,7 @@ fn compile_supports_explicit_multi_listener_configs() {
                 response_write_timeout_secs: None,
                 access_log_format: None,
                 tls: None,
+                http3: None,
             },
             ListenerConfig {
                 name: "https".to_string(),
@@ -2016,6 +2126,7 @@ fn compile_supports_explicit_multi_listener_configs() {
                 response_write_timeout_secs: None,
                 access_log_format: None,
                 tls: None,
+                http3: None,
             },
         ],
         server: ServerConfig {
@@ -2033,6 +2144,7 @@ fn compile_supports_explicit_multi_listener_configs() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
@@ -2059,4 +2171,81 @@ fn compile_supports_explicit_multi_listener_configs() {
     assert_eq!(snapshot.listeners[0].name, "http");
     assert_eq!(snapshot.listeners[1].name, "https");
     assert_eq!(snapshot.listeners[1].server.max_connections, Some(20));
+}
+
+#[test]
+fn compile_http3_listener_defaults_to_tcp_listen_addr_and_default_alt_svc_policy() {
+    let base_dir = temp_base_dir("rginx-http3-compile-test");
+    let cert_path = base_dir.path().join("server.crt");
+    let key_path = base_dir.path().join("server.key");
+    fs::write(&cert_path, "placeholder cert").expect("cert file should be written");
+    fs::write(&key_path, "placeholder key").expect("key file should be written");
+
+    let config = Config {
+        runtime: RuntimeConfig {
+            shutdown_timeout_secs: 10,
+            worker_threads: None,
+            accept_workers: None,
+        },
+        listeners: Vec::new(),
+        server: ServerConfig {
+            listen: Some("127.0.0.1:8443".to_string()),
+            proxy_protocol: None,
+            default_certificate: None,
+            server_names: vec!["localhost".to_string()],
+            trusted_proxies: Vec::new(),
+            keep_alive: None,
+            max_headers: None,
+            max_request_body_bytes: None,
+            max_connections: None,
+            header_read_timeout_secs: None,
+            request_body_read_timeout_secs: None,
+            response_write_timeout_secs: None,
+            access_log_format: None,
+            tls: Some(ServerTlsConfig {
+                cert_path: cert_path.display().to_string(),
+                key_path: key_path.display().to_string(),
+                additional_certificates: None,
+                versions: None,
+                cipher_suites: None,
+                key_exchange_groups: None,
+                alpn_protocols: None,
+                ocsp_staple_path: None,
+                ocsp: None,
+                session_resumption: None,
+                session_tickets: None,
+                session_cache_size: None,
+                session_ticket_count: None,
+                client_auth: None,
+            }),
+            http3: Some(Http3Config {
+                listen: None,
+                advertise_alt_svc: None,
+                alt_svc_max_age_secs: None,
+            }),
+        },
+        upstreams: Vec::new(),
+        locations: vec![LocationConfig {
+            matcher: MatcherConfig::Exact("/".to_string()),
+            handler: HandlerConfig::Return {
+                status: 200,
+                location: String::new(),
+                body: Some("ok\n".to_string()),
+            },
+            grpc_service: None,
+            grpc_method: None,
+            allow_cidrs: Vec::new(),
+            deny_cidrs: Vec::new(),
+            requests_per_sec: None,
+            burst: None,
+        }],
+        servers: Vec::new(),
+    };
+
+    let snapshot = compile_with_base(config, base_dir.path()).expect("http3 config should compile");
+    let listener = snapshot.listeners.first().expect("snapshot should have one listener");
+    let http3 = listener.http3.as_ref().expect("listener should compile http3 metadata");
+    assert_eq!(http3.listen_addr, "127.0.0.1:8443".parse().unwrap());
+    assert!(http3.advertise_alt_svc);
+    assert_eq!(http3.alt_svc_max_age.as_secs(), 86_400);
 }

--- a/crates/rginx-config/src/compile/upstream.rs
+++ b/crates/rginx-config/src/compile/upstream.rs
@@ -347,6 +347,15 @@ fn compile_protocol(
 
             Ok(UpstreamProtocol::Http2)
         }
+        UpstreamProtocolConfig::Http3 => {
+            if peers.iter().any(|peer| peer.scheme != "https") {
+                return Err(Error::Config(format!(
+                    "upstream `{upstream_name}` protocol `Http3` currently requires all peers to use `https://`; cleartext upstreams are not supported"
+                )));
+            }
+
+            Ok(UpstreamProtocol::Http3)
+        }
     }
 }
 

--- a/crates/rginx-config/src/model.rs
+++ b/crates/rginx-config/src/model.rs
@@ -24,6 +24,16 @@ pub struct RuntimeConfig {
     pub accept_workers: Option<u64>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct Http3Config {
+    #[serde(default)]
+    pub listen: Option<String>,
+    #[serde(default)]
+    pub advertise_alt_svc: Option<bool>,
+    #[serde(default)]
+    pub alt_svc_max_age_secs: Option<u64>,
+}
+
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub listen: Option<String>,
@@ -40,6 +50,7 @@ pub struct ServerConfig {
     pub response_write_timeout_secs: Option<u64>,
     pub access_log_format: Option<String>,
     pub tls: Option<ServerTlsConfig>,
+    pub http3: Option<Http3Config>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -70,6 +81,8 @@ pub struct ListenerConfig {
     pub access_log_format: Option<String>,
     #[serde(default)]
     pub tls: Option<ServerTlsConfig>,
+    #[serde(default)]
+    pub http3: Option<Http3Config>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -282,6 +295,7 @@ pub enum UpstreamProtocolConfig {
     Auto,
     Http1,
     Http2,
+    Http3,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -380,6 +394,8 @@ impl<'de> Deserialize<'de> for ServerConfig {
             access_log_format: Option<String>,
             #[serde(default)]
             tls: Option<ServerTlsConfig>,
+            #[serde(default)]
+            http3: Option<Http3Config>,
         }
 
         let server = ServerConfigDe::deserialize(deserializer)?;
@@ -398,6 +414,7 @@ impl<'de> Deserialize<'de> for ServerConfig {
             response_write_timeout_secs: server.response_write_timeout_secs,
             access_log_format: server.access_log_format,
             tls: server.tls,
+            http3: server.http3,
         })
     }
 }

--- a/crates/rginx-config/src/validate/server.rs
+++ b/crates/rginx-config/src/validate/server.rs
@@ -5,9 +5,9 @@ use ipnet::IpNet;
 use rginx_core::{Error, Result};
 
 use crate::model::{
-    ListenerConfig, ServerCertificateBundleConfig, ServerClientAuthConfig, ServerConfig,
-    ServerTlsConfig, TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig, TlsVersionConfig,
-    VirtualHostConfig,
+    Http3Config, ListenerConfig, ServerCertificateBundleConfig, ServerClientAuthConfig,
+    ServerConfig, ServerTlsConfig, TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig,
+    TlsVersionConfig, VirtualHostConfig,
 };
 
 pub(super) fn validate_server(server: &ServerConfig) -> Result<()> {
@@ -25,6 +25,7 @@ pub(super) fn validate_server(server: &ServerConfig) -> Result<()> {
         response_write_timeout_secs: server.response_write_timeout_secs,
         access_log_format: server.access_log_format.as_deref(),
         tls: server.tls.as_ref(),
+        http3: server.http3.as_ref(),
         require_listen: false,
     })?;
 
@@ -53,6 +54,7 @@ pub(super) fn validate_listeners(
     }
 
     let mut all_listener_names = HashSet::new();
+    let mut all_listener_bindings = HashSet::new();
     for (index, listener) in listeners.iter().enumerate() {
         let owner = format!("listeners[{index}]");
         let normalized_name = listener.name.trim().to_ascii_lowercase();
@@ -80,8 +82,35 @@ pub(super) fn validate_listeners(
             response_write_timeout_secs: listener.response_write_timeout_secs,
             access_log_format: listener.access_log_format.as_deref(),
             tls: listener.tls.as_ref(),
+            http3: listener.http3.as_ref(),
             require_listen: true,
         })?;
+
+        let tcp_listen_addr = listener.listen.parse::<std::net::SocketAddr>().map_err(|error| {
+            Error::Config(format!("{owner} listen `{}` is invalid: {error}", listener.listen))
+        })?;
+        if !all_listener_bindings.insert((rginx_core::ListenerTransportKind::Tcp, tcp_listen_addr))
+        {
+            return Err(Error::Config(format!(
+                "duplicate tcp listener bind `{tcp_listen_addr}` across listeners"
+            )));
+        }
+
+        if let Some(http3) = listener.http3.as_ref() {
+            let udp_listen_addr = match http3.listen.as_deref() {
+                Some(listen) => listen.parse::<std::net::SocketAddr>().map_err(|error| {
+                    Error::Config(format!("{owner} http3 listen `{listen}` is invalid: {error}"))
+                })?,
+                None => tcp_listen_addr,
+            };
+            if !all_listener_bindings
+                .insert((rginx_core::ListenerTransportKind::Udp, udp_listen_addr))
+            {
+                return Err(Error::Config(format!(
+                    "duplicate udp listener bind `{udp_listen_addr}` across listeners"
+                )));
+            }
+        }
     }
 
     let any_listener_tls = listeners.iter().any(|listener| listener.tls.is_some());
@@ -146,6 +175,7 @@ struct ListenerLikeRef<'a> {
     response_write_timeout_secs: Option<u64>,
     access_log_format: Option<&'a str>,
     tls: Option<&'a ServerTlsConfig>,
+    http3: Option<&'a Http3Config>,
     require_listen: bool,
 }
 
@@ -217,6 +247,10 @@ fn validate_listener_like(config: ListenerLikeRef<'_>) -> Result<()> {
             "{} access_log_format must not be empty",
             config.owner_label
         )));
+    }
+
+    if let Some(http3) = config.http3 {
+        validate_http3(config.owner_label, http3, config.tls)?;
     }
 
     if let Some(ServerTlsConfig {
@@ -312,6 +346,46 @@ fn validate_listener_like(config: ListenerLikeRef<'_>) -> Result<()> {
                 )));
             }
         }
+    }
+
+    Ok(())
+}
+
+fn validate_http3(
+    owner_label: &str,
+    http3: &Http3Config,
+    tls: Option<&ServerTlsConfig>,
+) -> Result<()> {
+    let Some(tls) = tls else {
+        return Err(Error::Config(format!(
+            "{owner_label} http3 requires tls to be configured on the same listener"
+        )));
+    };
+
+    if http3.listen.as_deref().is_some_and(|listen| listen.trim().is_empty()) {
+        return Err(Error::Config(format!(
+            "{owner_label} http3 listen must not be empty when provided"
+        )));
+    }
+
+    if http3.alt_svc_max_age_secs.is_some_and(|value| value == 0) {
+        return Err(Error::Config(format!(
+            "{owner_label} http3 alt_svc_max_age_secs must be greater than 0"
+        )));
+    }
+
+    if tls.client_auth.is_some() {
+        return Err(Error::Config(format!(
+            "{owner_label} http3 currently does not support tls.client_auth on the same listener"
+        )));
+    }
+
+    if let Some(versions) = tls.versions.as_deref()
+        && !versions.contains(&TlsVersionConfig::Tls13)
+    {
+        return Err(Error::Config(format!(
+            "{owner_label} http3 requires TLS1.3 to remain enabled on the same listener"
+        )));
     }
 
     Ok(())
@@ -516,7 +590,8 @@ fn legacy_server_listener_fields(server: &ServerConfig) -> Option<()> {
         || server.request_body_read_timeout_secs.is_some()
         || server.response_write_timeout_secs.is_some()
         || server.access_log_format.is_some()
-        || server.tls.is_some())
+        || server.tls.is_some()
+        || server.http3.is_some())
     .then_some(())
 }
 

--- a/crates/rginx-config/src/validate/tests.rs
+++ b/crates/rginx-config/src/validate/tests.rs
@@ -1,8 +1,8 @@
 use crate::model::{
-    Config, HandlerConfig, ListenerConfig, LocationConfig, MatcherConfig, RuntimeConfig,
-    ServerConfig, ServerTlsConfig, TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig, UpstreamConfig,
-    UpstreamLoadBalanceConfig, UpstreamPeerConfig, UpstreamProtocolConfig, VirtualHostConfig,
-    VirtualHostTlsConfig,
+    Config, HandlerConfig, Http3Config, ListenerConfig, LocationConfig, MatcherConfig,
+    RuntimeConfig, ServerConfig, ServerTlsConfig, TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig,
+    UpstreamConfig, UpstreamLoadBalanceConfig, UpstreamPeerConfig, UpstreamProtocolConfig,
+    VirtualHostConfig, VirtualHostTlsConfig,
 };
 
 use super::{DEFAULT_GRPC_HEALTH_CHECK_PATH, validate};
@@ -407,6 +407,19 @@ fn validate_rejects_empty_server_access_log_format() {
 }
 
 #[test]
+fn validate_rejects_http3_without_tls_on_same_listener() {
+    let mut config = base_config();
+    config.server.http3 = Some(Http3Config {
+        listen: None,
+        advertise_alt_svc: Some(true),
+        alt_svc_max_age_secs: Some(3600),
+    });
+
+    let error = validate(&config).expect_err("http3 should require tls on the same listener");
+    assert!(error.to_string().contains("http3 requires tls to be configured on the same listener"));
+}
+
+#[test]
 fn validate_rejects_zero_server_max_headers() {
     let mut config = base_config();
     config.server.max_headers = Some(0);
@@ -699,6 +712,20 @@ fn validate_rejects_http2_upstream_protocol_for_cleartext_peers() {
 }
 
 #[test]
+fn validate_rejects_http3_upstream_protocol_for_cleartext_peers() {
+    let mut config = base_config();
+    config.upstreams[0].protocol = UpstreamProtocolConfig::Http3;
+
+    let error =
+        validate(&config).expect_err("cleartext peers should be rejected for upstream http3");
+    assert!(
+        error
+            .to_string()
+            .contains("protocol `Http3` currently requires all peers to use `https://`")
+    );
+}
+
+#[test]
 fn validate_rejects_invalid_http2_upstream_peer_uri() {
     let mut config = base_config();
     config.upstreams[0].protocol = UpstreamProtocolConfig::Http2;
@@ -798,6 +825,7 @@ fn validate_accepts_explicit_listeners_when_legacy_listener_fields_are_empty() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         ListenerConfig {
             name: "https".to_string(),
@@ -829,6 +857,7 @@ fn validate_accepts_explicit_listeners_when_legacy_listener_fields_are_empty() {
                 session_ticket_count: None,
                 client_auth: None,
             }),
+            http3: None,
         },
     ];
 
@@ -855,6 +884,7 @@ fn validate_rejects_duplicate_listener_names_after_ascii_normalization() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         ListenerConfig {
             name: "http".to_string(),
@@ -871,6 +901,7 @@ fn validate_rejects_duplicate_listener_names_after_ascii_normalization() {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
     ];
 
@@ -896,6 +927,7 @@ fn validate_rejects_mixing_legacy_listener_fields_with_explicit_listeners() {
         response_write_timeout_secs: None,
         access_log_format: None,
         tls: None,
+        http3: None,
     }];
 
     let error = validate(&config).expect_err("mixed legacy and explicit listeners should fail");
@@ -921,6 +953,7 @@ fn validate_rejects_vhost_tls_without_any_tls_listener() {
         response_write_timeout_secs: None,
         access_log_format: None,
         tls: None,
+        http3: None,
     }];
     config.servers = vec![VirtualHostConfig {
         server_names: vec!["api.example.com".to_string()],
@@ -974,6 +1007,7 @@ fn base_config() -> Config {
             response_write_timeout_secs: None,
             access_log_format: None,
             tls: None,
+            http3: None,
         },
         upstreams: vec![UpstreamConfig {
             name: "backend".to_string(),

--- a/crates/rginx-config/src/validate/upstream.rs
+++ b/crates/rginx-config/src/validate/upstream.rs
@@ -112,7 +112,10 @@ pub(super) fn validate_upstreams(upstreams: &[UpstreamConfig]) -> Result<HashSet
             )));
         }
 
-        if matches!(upstream.protocol, UpstreamProtocolConfig::Http2) {
+        if matches!(
+            upstream.protocol,
+            UpstreamProtocolConfig::Http2 | UpstreamProtocolConfig::Http3
+        ) {
             for peer in &upstream.peers {
                 let uri = peer.url.parse::<http::Uri>().map_err(|error| {
                     Error::Config(format!(
@@ -123,8 +126,13 @@ pub(super) fn validate_upstreams(upstreams: &[UpstreamConfig]) -> Result<HashSet
 
                 if uri.scheme_str() != Some("https") {
                     return Err(Error::Config(format!(
-                        "upstream `{}` protocol `Http2` currently requires all peers to use `https://`; cleartext h2c upstreams are not supported",
-                        upstream.name
+                        "upstream `{}` protocol `{}` currently requires all peers to use `https://`; cleartext upstreams are not supported",
+                        upstream.name,
+                        match upstream.protocol {
+                            UpstreamProtocolConfig::Http2 => "Http2",
+                            UpstreamProtocolConfig::Http3 => "Http3",
+                            _ => unreachable!("guarded by matches!"),
+                        }
                     )));
                 }
             }

--- a/crates/rginx-core/src/config.rs
+++ b/crates/rginx-core/src/config.rs
@@ -63,13 +63,70 @@ impl ConfigSnapshot {
         self.listeners.len()
     }
 
+    pub fn total_listener_binding_count(&self) -> usize {
+        self.listeners.iter().map(Listener::binding_count).sum()
+    }
+
     pub fn tls_enabled(&self) -> bool {
         self.listeners.iter().any(Listener::tls_enabled)
+    }
+
+    pub fn http3_enabled(&self) -> bool {
+        self.listeners.iter().any(Listener::http3_enabled)
     }
 
     pub fn listener(&self, id: &str) -> Option<&Listener> {
         self.listeners.iter().find(|listener| listener.id == id)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ListenerTransportKind {
+    Tcp,
+    Udp,
+}
+
+impl ListenerTransportKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Tcp => "tcp",
+            Self::Udp => "udp",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ListenerApplicationProtocol {
+    Http1,
+    Http2,
+    Http3,
+}
+
+impl ListenerApplicationProtocol {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Http1 => "http1",
+            Self::Http2 => "http2",
+            Self::Http3 => "http3",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ListenerHttp3 {
+    pub listen_addr: SocketAddr,
+    pub advertise_alt_svc: bool,
+    pub alt_svc_max_age: Duration,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListenerTransportBinding {
+    pub name: &'static str,
+    pub kind: ListenerTransportKind,
+    pub listen_addr: SocketAddr,
+    pub protocols: Vec<ListenerApplicationProtocol>,
+    pub advertise_alt_svc: bool,
+    pub alt_svc_max_age: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]
@@ -79,11 +136,48 @@ pub struct Listener {
     pub server: Server,
     pub tls_termination_enabled: bool,
     pub proxy_protocol_enabled: bool,
+    pub http3: Option<ListenerHttp3>,
 }
 
 impl Listener {
     pub fn tls_enabled(&self) -> bool {
         self.tls_termination_enabled
+    }
+
+    pub fn http3_enabled(&self) -> bool {
+        self.http3.is_some()
+    }
+
+    pub fn binding_count(&self) -> usize {
+        1 + usize::from(self.http3.is_some())
+    }
+
+    pub fn transport_bindings(&self) -> Vec<ListenerTransportBinding> {
+        let mut bindings = vec![ListenerTransportBinding {
+            name: "tcp",
+            kind: ListenerTransportKind::Tcp,
+            listen_addr: self.server.listen_addr,
+            protocols: if self.tls_enabled() {
+                vec![ListenerApplicationProtocol::Http1, ListenerApplicationProtocol::Http2]
+            } else {
+                vec![ListenerApplicationProtocol::Http1]
+            },
+            advertise_alt_svc: false,
+            alt_svc_max_age: None,
+        }];
+
+        if let Some(http3) = &self.http3 {
+            bindings.push(ListenerTransportBinding {
+                name: "udp",
+                kind: ListenerTransportKind::Udp,
+                listen_addr: http3.listen_addr,
+                protocols: vec![ListenerApplicationProtocol::Http3],
+                advertise_alt_svc: http3.advertise_alt_svc,
+                alt_svc_max_age: Some(http3.alt_svc_max_age),
+            });
+        }
+
+        bindings
     }
 }
 

--- a/crates/rginx-core/src/config/tests.rs
+++ b/crates/rginx-core/src/config/tests.rs
@@ -5,9 +5,9 @@ use std::time::Duration;
 use http::StatusCode;
 
 use super::{
-    AccessLogFormat, AccessLogValues, ConfigSnapshot, Listener, ReturnAction, Route,
-    RouteAccessControl, RouteAction, RouteMatcher, RuntimeSettings, Server, VirtualHost,
-    match_server_name,
+    AccessLogFormat, AccessLogValues, ConfigSnapshot, Listener, ListenerApplicationProtocol,
+    ListenerHttp3, ListenerTransportKind, ReturnAction, Route, RouteAccessControl, RouteAction,
+    RouteMatcher, RuntimeSettings, Server, VirtualHost, match_server_name,
 };
 
 #[test]
@@ -89,6 +89,7 @@ fn config_snapshot_counts_routes_across_all_vhosts() {
             server,
             tls_termination_enabled: false,
             proxy_protocol_enabled: false,
+            http3: None,
         }],
         default_vhost: VirtualHost {
             id: "server".to_string(),
@@ -115,6 +116,51 @@ fn config_snapshot_counts_routes_across_all_vhosts() {
 
     assert_eq!(snapshot.total_vhost_count(), 3);
     assert_eq!(snapshot.total_route_count(), 4);
+    assert_eq!(snapshot.total_listener_binding_count(), 1);
+    assert!(!snapshot.http3_enabled());
+}
+
+#[test]
+fn listener_transport_bindings_include_udp_http3_binding_when_configured() {
+    let listener = Listener {
+        id: "default".to_string(),
+        name: "default".to_string(),
+        server: Server {
+            listen_addr: "127.0.0.1:443".parse().unwrap(),
+            default_certificate: None,
+            trusted_proxies: Vec::new(),
+            keep_alive: true,
+            max_headers: None,
+            max_request_body_bytes: None,
+            max_connections: None,
+            header_read_timeout: None,
+            request_body_read_timeout: None,
+            response_write_timeout: None,
+            access_log_format: None,
+            tls: None,
+        },
+        tls_termination_enabled: true,
+        proxy_protocol_enabled: false,
+        http3: Some(ListenerHttp3 {
+            listen_addr: "127.0.0.1:443".parse().unwrap(),
+            advertise_alt_svc: true,
+            alt_svc_max_age: Duration::from_secs(3600),
+        }),
+    };
+
+    let bindings = listener.transport_bindings();
+    assert_eq!(listener.binding_count(), 2);
+    assert!(listener.http3_enabled());
+    assert_eq!(bindings.len(), 2);
+    assert_eq!(bindings[0].kind, ListenerTransportKind::Tcp);
+    assert_eq!(
+        bindings[0].protocols,
+        vec![ListenerApplicationProtocol::Http1, ListenerApplicationProtocol::Http2]
+    );
+    assert_eq!(bindings[1].kind, ListenerTransportKind::Udp);
+    assert_eq!(bindings[1].protocols, vec![ListenerApplicationProtocol::Http3]);
+    assert!(bindings[1].advertise_alt_svc);
+    assert_eq!(bindings[1].alt_svc_max_age.map(|value| value.as_secs()), Some(3600));
 }
 
 #[test]

--- a/crates/rginx-core/src/config/upstream.rs
+++ b/crates/rginx-core/src/config/upstream.rs
@@ -19,6 +19,7 @@ pub enum UpstreamProtocol {
     Auto,
     Http1,
     Http2,
+    Http3,
 }
 
 impl UpstreamProtocol {
@@ -27,6 +28,7 @@ impl UpstreamProtocol {
             Self::Auto => "auto",
             Self::Http1 => "http1",
             Self::Http2 => "http2",
+            Self::Http3 => "http3",
         }
     }
 }

--- a/crates/rginx-core/src/lib.rs
+++ b/crates/rginx-core/src/lib.rs
@@ -6,7 +6,8 @@ pub mod types;
 
 pub use config::{
     AccessLogFormat, AccessLogValues, ActiveHealthCheck, ClientIdentity, ConfigSnapshot,
-    GrpcRouteMatch, Listener, OcspConfig, OcspNonceMode, OcspResponderPolicy, ProxyTarget,
+    GrpcRouteMatch, Listener, ListenerApplicationProtocol, ListenerHttp3, ListenerTransportBinding,
+    ListenerTransportKind, OcspConfig, OcspNonceMode, OcspResponderPolicy, ProxyTarget,
     ReturnAction, Route, RouteAccessControl, RouteAction, RouteMatcher, RouteRateLimit,
     RuntimeSettings, Server, ServerCertificateBundle, ServerClientAuthMode, ServerClientAuthPolicy,
     ServerNameMatch, ServerTls, TlsCipherSuite, TlsKeyExchangeGroup, TlsVersion, Upstream,

--- a/crates/rginx-http/Cargo.toml
+++ b/crates/rginx-http/Cargo.toml
@@ -20,19 +20,19 @@ flate2.workspace = true
 futures-util.workspace = true
 http.workspace = true
 http-body-util.workspace = true
+h3.workspace = true
+h3-quinn.workspace = true
 hyper.workspace = true
 hyper-rustls.workspace = true
 hyper-util.workspace = true
 pin-project-lite.workspace = true
-num-bigint = "0.4"
+quinn.workspace = true
 rasn = "0.28.11"
 rasn-ocsp = "0.28.11"
 rasn-pkix = "0.28.11"
-rginx-config = { path = "../rginx-config" }
 rginx-core = { path = "../rginx-core" }
 rustls.workspace = true
 rustls-native-certs.workspace = true
-rustls-pemfile.workspace = true
 serde.workspace = true
 sha1.workspace = true
 sha2.workspace = true

--- a/crates/rginx-http/src/handler/dispatch.rs
+++ b/crates/rginx-http/src/handler/dispatch.rs
@@ -24,7 +24,7 @@ pub(super) struct FinalizedDownstreamResponse {
 }
 
 pub async fn handle(
-    request: Request<Incoming>,
+    request: Request<HttpBody>,
     state: SharedState,
     connection: Arc<ConnectionPeerAddrs>,
     listener_id: &str,
@@ -67,6 +67,7 @@ pub async fn handle(
     let started = Instant::now();
     let tls_version = connection.tls_version.clone();
     let tls_alpn = connection.tls_alpn.clone();
+    let alt_svc_header = alt_svc_header_value(&listener, request_version);
     let client_address =
         resolve_client_address(request.headers(), &listener.server, connection.as_ref());
     let downstream_scheme = if listener.tls_enabled() { "https" } else { "http" };
@@ -142,6 +143,7 @@ pub async fn handle(
         request_id_header,
         response,
         grpc_request,
+        alt_svc_header,
     )
     .await;
     let status = finalized.status;
@@ -222,6 +224,7 @@ pub(super) async fn finalize_downstream_response(
     request_id_header: HeaderValue,
     mut response: HttpResponse,
     grpc_request: Option<GrpcRequestMetadata<'_>>,
+    alt_svc_header: Option<HeaderValue>,
 ) -> FinalizedDownstreamResponse {
     // The final response pipeline is intentionally explicit:
     // 1. Detect gRPC early from response headers.
@@ -235,6 +238,9 @@ pub(super) async fn finalize_downstream_response(
     }
     if *method == Method::HEAD {
         response = strip_response_body(response);
+    }
+    if let Some(alt_svc_header) = alt_svc_header {
+        response.headers_mut().insert(http::header::ALT_SVC, alt_svc_header);
     }
     response.headers_mut().insert("x-request-id", request_id_header);
 
@@ -363,7 +369,7 @@ pub(super) fn enforce_rate_limit(
 }
 
 async fn build_route_response(
-    request: Request<Incoming>,
+    request: Request<HttpBody>,
     state: SharedState,
     action: RouteAction,
     active: ActiveState,
@@ -416,4 +422,22 @@ async fn build_route_response(
 fn strip_response_body(response: HttpResponse) -> HttpResponse {
     let (parts, _body) = response.into_parts();
     Response::from_parts(parts, full_body(Bytes::new()))
+}
+
+fn alt_svc_header_value(
+    listener: &rginx_core::Listener,
+    request_version: Version,
+) -> Option<HeaderValue> {
+    if request_version == Version::HTTP_3 || !listener.tls_enabled() {
+        return None;
+    }
+
+    let http3 = listener.http3.as_ref()?;
+    if !http3.advertise_alt_svc {
+        return None;
+    }
+
+    let value =
+        format!("h3=\":{}\"; ma={}", http3.listen_addr.port(), http3.alt_svc_max_age.as_secs());
+    HeaderValue::from_str(&value).ok()
 }

--- a/crates/rginx-http/src/handler/mod.rs
+++ b/crates/rginx-http/src/handler/mod.rs
@@ -10,7 +10,7 @@ use http::header::{
 use http::{Method, StatusCode, Uri, Version};
 use http_body_util::BodyExt;
 use http_body_util::combinators::UnsyncBoxBody;
-use hyper::body::{Frame, Incoming, SizeHint};
+use hyper::body::{Body, Frame, SizeHint};
 use hyper::{Request, Response};
 use rginx_core::{
     AccessLogFormat, AccessLogValues, ConfigSnapshot, Route, RouteAction, VirtualHost,
@@ -32,6 +32,14 @@ mod response;
 pub use dispatch::handle;
 pub(crate) use grpc::{GrpcStatusCode, grpc_error_response};
 pub(crate) use response::{full_body, text_response};
+
+pub(crate) fn boxed_body<B>(body: B) -> HttpBody
+where
+    B: Body<Data = Bytes> + Send + 'static,
+    B::Error: Into<BoxError> + 'static,
+{
+    body.map_err(Into::into).boxed_unsync()
+}
 
 pub(crate) fn attach_connection_metadata<B>(
     request: &mut Request<B>,

--- a/crates/rginx-http/src/handler/tests.rs
+++ b/crates/rginx-http/src/handler/tests.rs
@@ -591,6 +591,7 @@ async fn finalize_downstream_response_compresses_plain_text_responses() {
             "hello compression pipeline\n".repeat(32),
         ),
         None,
+        None,
     )
     .await;
 
@@ -622,6 +623,7 @@ async fn finalize_downstream_response_skips_compression_for_grpc_responses() {
         HeaderValue::from_static("req-grpc"),
         text_response(StatusCode::OK, "application/grpc", "hello grpc pipeline\n".repeat(32)),
         grpc_request_metadata(&request_headers, "/grpc.health.v1.Health/Check"),
+        None,
     )
     .await;
 
@@ -648,6 +650,7 @@ async fn finalize_downstream_response_strips_head_body_after_final_transforms() 
             "hello head pipeline\n".repeat(32),
         ),
         None,
+        None,
     )
     .await;
 
@@ -671,6 +674,30 @@ async fn finalize_downstream_response_strips_head_body_after_final_transforms() 
         .to_bytes();
     assert!(content_length > 0);
     assert!(body.is_empty());
+}
+
+#[tokio::test]
+async fn finalize_downstream_response_injects_alt_svc_when_provided() {
+    let request_headers = HeaderMap::new();
+
+    let finalized = finalize_downstream_response(
+        &http::Method::GET,
+        &request_headers,
+        HeaderValue::from_static("req-alt-svc"),
+        text_response(StatusCode::OK, "text/plain; charset=utf-8", "hello"),
+        None,
+        Some(HeaderValue::from_static("h3=\":443\"; ma=7200")),
+    )
+    .await;
+
+    assert_eq!(
+        finalized
+            .response
+            .headers()
+            .get(http::header::ALT_SVC)
+            .and_then(|value| value.to_str().ok()),
+        Some("h3=\":443\"; ma=7200")
+    );
 }
 
 fn grpc_web_observability_body() -> Vec<u8> {
@@ -712,6 +739,7 @@ fn test_config(default_vhost: VirtualHost, vhosts: Vec<VirtualHost>) -> ConfigSn
             server,
             tls_termination_enabled: false,
             proxy_protocol_enabled: false,
+            http3: None,
         }],
         default_vhost,
         vhosts,

--- a/crates/rginx-http/src/lib.rs
+++ b/crates/rginx-http/src/lib.rs
@@ -19,13 +19,14 @@ pub use server::serve;
 pub use state::{
     GrpcTrafficSnapshot, HttpCountersSnapshot, ListenerStatsSnapshot, MtlsStatusSnapshot,
     ReloadOutcomeSnapshot, ReloadResultSnapshot, ReloadStatusSnapshot, RouteStatsSnapshot,
-    RuntimeListenerSnapshot, RuntimeStatusSnapshot, SharedState, SnapshotDeltaSnapshot,
-    SnapshotModule, TlsCertificateStatusSnapshot, TlsDefaultCertificateBindingSnapshot,
-    TlsListenerStatusSnapshot, TlsOcspRefreshSpec, TlsOcspStatusSnapshot,
-    TlsReloadBoundarySnapshot, TlsRuntimeSnapshot, TlsSniBindingSnapshot, TlsVhostBindingSnapshot,
-    TrafficStatsSnapshot, UpstreamPeerStatsSnapshot, UpstreamStatsSnapshot,
-    UpstreamTlsStatusSnapshot, VhostStatsSnapshot, tls_ocsp_refresh_specs_for_config,
-    tls_reloadable_fields, tls_restart_required_fields, tls_runtime_snapshot_for_config,
+    RuntimeListenerBindingSnapshot, RuntimeListenerSnapshot, RuntimeStatusSnapshot, SharedState,
+    SnapshotDeltaSnapshot, SnapshotModule, TlsCertificateStatusSnapshot,
+    TlsDefaultCertificateBindingSnapshot, TlsListenerStatusSnapshot, TlsOcspRefreshSpec,
+    TlsOcspStatusSnapshot, TlsReloadBoundarySnapshot, TlsRuntimeSnapshot, TlsSniBindingSnapshot,
+    TlsVhostBindingSnapshot, TrafficStatsSnapshot, UpstreamPeerStatsSnapshot,
+    UpstreamStatsSnapshot, UpstreamTlsStatusSnapshot, VhostStatsSnapshot,
+    tls_ocsp_refresh_specs_for_config, tls_reloadable_fields, tls_restart_required_fields,
+    tls_runtime_snapshot_for_config,
 };
 pub use tls::{
     build_ocsp_request_for_certificate, build_ocsp_request_for_certificate_with_options,

--- a/crates/rginx-http/src/pki/certificate.rs
+++ b/crates/rginx-http/src/pki/certificate.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::io::BufReader;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -8,6 +7,7 @@ use rasn_pkix::{
     AuthorityKeyIdentifier, BasicConstraints, Certificate, DirectoryString, ExtKeyUsageSyntax,
     Extension, GeneralName, KeyUsage, Name, SubjectAltName, SubjectKeyIdentifier, Time,
 };
+use rustls::pki_types::{CertificateDer, pem::PemObject};
 use sha2::{Digest, Sha256};
 
 use crate::client_ip::TlsClientIdentity;
@@ -272,15 +272,21 @@ fn decode_certificate(bytes: &[u8]) -> Option<Certificate> {
 }
 
 fn load_certificate_chain_der(path: &Path) -> std::io::Result<Vec<Vec<u8>>> {
-    let file = std::fs::File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let certs = rustls_pemfile::certs(&mut reader)
+    let certs = CertificateDer::pem_file_iter(path)
+        .map_err(pem_error_to_io_error)?
         .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        .map_err(pem_error_to_io_error)?;
     if !certs.is_empty() {
         return Ok(certs.into_iter().map(|cert| cert.as_ref().to_vec()).collect());
     }
     Ok(vec![std::fs::read(path)?])
+}
+
+fn pem_error_to_io_error(error: rustls::pki_types::pem::Error) -> std::io::Error {
+    match error {
+        rustls::pki_types::pem::Error::Io(error) => error,
+        other => std::io::Error::new(std::io::ErrorKind::InvalidData, other),
+    }
 }
 
 fn name_to_string(name: &Name) -> String {

--- a/crates/rginx-http/src/proxy/clients/http3.rs
+++ b/crates/rginx-http/src/proxy/clients/http3.rs
@@ -1,0 +1,237 @@
+use bytes::{Buf, Bytes, BytesMut};
+use h3::client;
+use http::{HeaderMap, Request, Response};
+use std::net::{SocketAddr, ToSocketAddrs};
+
+use crate::handler::{HttpBody, boxed_body};
+
+use super::*;
+
+#[derive(Clone)]
+pub(crate) struct Http3Client {
+    client_config: quinn::ClientConfig,
+    connect_timeout: Duration,
+}
+
+impl Http3Client {
+    pub(super) fn new(client_config: quinn::ClientConfig, connect_timeout: Duration) -> Self {
+        Self { client_config, connect_timeout }
+    }
+
+    pub(super) async fn request(
+        &self,
+        upstream: &Upstream,
+        peer: &UpstreamPeer,
+        request: Request<HttpBody>,
+    ) -> Result<Response<HttpBody>, Error> {
+        let remote_addr = resolve_peer_socket_addr(peer)?;
+        let endpoint_bind_addr = match remote_addr {
+            SocketAddr::V4(_) => "0.0.0.0:0".parse().unwrap(),
+            SocketAddr::V6(_) => "[::]:0".parse().unwrap(),
+        };
+        let mut endpoint = quinn::Endpoint::client(endpoint_bind_addr).map_err(Error::Io)?;
+        endpoint.set_default_client_config(self.client_config.clone());
+
+        let server_name = server_name_for_peer(upstream, peer)?;
+        let connecting = endpoint.connect(remote_addr, &server_name).map_err(|error| {
+            Error::Server(format!(
+                "failed to start upstream http3 connect to `{}`: {error}",
+                peer.url
+            ))
+        })?;
+        let connection = tokio::time::timeout(self.connect_timeout, connecting)
+            .await
+            .map_err(|_| {
+                Error::Server(format!(
+                    "upstream http3 connect to `{}` timed out after {} ms",
+                    peer.url,
+                    self.connect_timeout.as_millis()
+                ))
+            })?
+            .map_err(|error| {
+                Error::Server(format!("upstream http3 connect to `{}` failed: {error}", peer.url))
+            })?;
+
+        let (mut driver, mut send_request) =
+            client::new(h3_quinn::Connection::new(connection)).await.map_err(|error| {
+                Error::Server(format!(
+                    "failed to initialize upstream http3 session for `{}`: {error}",
+                    peer.url
+                ))
+            })?;
+        let driver_task = tokio::spawn(async move {
+            let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
+        });
+
+        let (parts, mut body) = request.into_parts();
+        let mut request_builder =
+            Request::builder().method(parts.method).uri(parts.uri).version(Version::HTTP_3);
+        for (name, value) in &parts.headers {
+            request_builder = request_builder.header(name, value);
+        }
+        let request = request_builder.body(()).map_err(|error| {
+            Error::Server(format!("failed to build upstream http3 request: {error}"))
+        })?;
+
+        let mut request_stream = send_request.send_request(request).await.map_err(|error| {
+            Error::Server(format!(
+                "failed to send upstream http3 request headers to `{}`: {error}",
+                peer.url
+            ))
+        })?;
+
+        let mut finalized = false;
+        while let Some(frame) = body.frame().await {
+            let frame = frame.map_err(|error| {
+                Error::Server(format!(
+                    "failed to read downstream request body for upstream http3 `{}`: {error}",
+                    peer.url
+                ))
+            })?;
+            match frame.into_data() {
+                Ok(data) => {
+                    if !data.is_empty() {
+                        request_stream.send_data(data).await.map_err(|error| {
+                            Error::Server(format!(
+                                "failed to send upstream http3 request body to `{}`: {error}",
+                                peer.url
+                            ))
+                        })?;
+                    }
+                }
+                Err(frame) => {
+                    if let Ok(trailers) = frame.into_trailers() {
+                        request_stream.send_trailers(trailers).await.map_err(|error| {
+                            Error::Server(format!(
+                                "failed to send upstream http3 request trailers to `{}`: {error}",
+                                peer.url
+                            ))
+                        })?;
+                        finalized = true;
+                    }
+                }
+            }
+        }
+        if !finalized {
+            request_stream.finish().await.map_err(|error| {
+                Error::Server(format!(
+                    "failed to finish upstream http3 request to `{}`: {error}",
+                    peer.url
+                ))
+            })?;
+        }
+
+        let response = request_stream.recv_response().await.map_err(|error| {
+            Error::Server(format!(
+                "failed to receive upstream http3 response headers from `{}`: {error}",
+                peer.url
+            ))
+        })?;
+        let mut buffered_body = BytesMut::new();
+        while let Some(mut chunk) = request_stream.recv_data().await.map_err(|error| {
+            Error::Server(format!(
+                "failed to receive upstream http3 response body from `{}`: {error}",
+                peer.url
+            ))
+        })? {
+            buffered_body.extend_from_slice(chunk.copy_to_bytes(chunk.remaining()).as_ref());
+        }
+        let buffered_trailers = request_stream.recv_trailers().await.map_err(|error| {
+            Error::Server(format!(
+                "failed to receive upstream http3 response trailers from `{}`: {error}",
+                peer.url
+            ))
+        })?;
+        driver_task.abort();
+        drop(endpoint);
+
+        let (parts, _) = response.into_parts();
+        let mut response_builder = Response::builder().status(parts.status);
+        for (name, value) in &parts.headers {
+            response_builder = response_builder.header(name, value);
+        }
+        response_builder
+            .body(boxed_body(BufferedResponseBody::new(buffered_body.freeze(), buffered_trailers)))
+            .map_err(|error| {
+                Error::Server(format!("failed to build upstream http3 response: {error}"))
+            })
+    }
+}
+
+struct BufferedResponseBody {
+    body: Option<Bytes>,
+    trailers: Option<HeaderMap>,
+}
+
+impl BufferedResponseBody {
+    fn new(body: Bytes, trailers: Option<HeaderMap>) -> Self {
+        Self { body: (!body.is_empty()).then_some(body), trailers }
+    }
+}
+
+impl hyper::body::Body for BufferedResponseBody {
+    type Data = Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+
+        if let Some(body) = this.body.take() {
+            return std::task::Poll::Ready(Some(Ok(hyper::body::Frame::data(body))));
+        }
+
+        if let Some(trailers) = this.trailers.take() {
+            return std::task::Poll::Ready(Some(Ok(hyper::body::Frame::trailers(trailers))));
+        }
+
+        std::task::Poll::Ready(None)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.body.is_none() && self.trailers.is_none()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        let mut hint = hyper::body::SizeHint::default();
+        if let Some(body) = &self.body {
+            hint.set_exact(body.len() as u64);
+        }
+        hint
+    }
+}
+
+fn resolve_peer_socket_addr(peer: &UpstreamPeer) -> Result<SocketAddr, Error> {
+    peer.authority
+        .to_socket_addrs()
+        .map_err(|error| {
+            Error::Server(format!(
+                "failed to resolve upstream http3 peer authority `{}`: {error}",
+                peer.authority
+            ))
+        })?
+        .next()
+        .ok_or_else(|| {
+            Error::Server(format!(
+                "upstream http3 peer authority `{}` did not resolve to any address",
+                peer.authority
+            ))
+        })
+}
+
+fn server_name_for_peer(upstream: &Upstream, peer: &UpstreamPeer) -> Result<String, Error> {
+    if let Some(server_name_override) = upstream.server_name_override.as_ref() {
+        return Ok(server_name_override.clone());
+    }
+
+    peer.url.parse::<http::Uri>().ok().and_then(|uri| uri.host().map(str::to_string)).ok_or_else(
+        || {
+            Error::Server(format!(
+                "failed to derive TLS server name for upstream http3 peer `{}`",
+                peer.url
+            ))
+        },
+    )
+}

--- a/crates/rginx-http/src/proxy/clients/mod.rs
+++ b/crates/rginx-http/src/proxy/clients/mod.rs
@@ -7,6 +7,7 @@ use super::health::{
 use super::*;
 use rginx_core::{ClientIdentity, TlsVersion};
 
+mod http3;
 #[cfg(test)]
 mod tests;
 mod tls;
@@ -14,7 +15,7 @@ mod tls;
 #[cfg(test)]
 pub(super) use tls::load_custom_ca_store;
 
-pub type ProxyClient = Client<HttpsConnector<HttpConnector>, HttpBody>;
+pub type HyperProxyClient = Client<HttpsConnector<HttpConnector>, HttpBody>;
 pub(crate) type HealthChangeNotifier = Arc<dyn Fn(&str) + Send + Sync + 'static>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -66,6 +67,12 @@ pub struct ProxyClients {
     health: PeerHealthRegistry,
 }
 
+#[derive(Clone)]
+pub(crate) enum ProxyClient {
+    Http(Box<HyperProxyClient>),
+    Http3(http3::Http3Client),
+}
+
 impl ProxyClients {
     pub fn from_config(config: &ConfigSnapshot) -> Result<Self, Error> {
         Self::from_config_with_health_notifier(config, None)
@@ -96,7 +103,7 @@ impl ProxyClients {
         Ok(Self { clients: Arc::new(clients), health })
     }
 
-    pub fn for_upstream(&self, upstream: &Upstream) -> Result<ProxyClient, Error> {
+    pub(crate) fn for_upstream(&self, upstream: &Upstream) -> Result<ProxyClient, Error> {
         let profile = UpstreamClientProfile::from_upstream(upstream);
         self.clients.get(&profile).cloned().ok_or_else(|| {
             Error::Server(format!(
@@ -158,7 +165,40 @@ impl ProxyClients {
     }
 }
 
+impl ProxyClient {
+    pub async fn request(
+        &self,
+        upstream: &Upstream,
+        peer: &UpstreamPeer,
+        request: Request<HttpBody>,
+    ) -> Result<Response<HttpBody>, Error> {
+        match self {
+            Self::Http(client) => client
+                .request(request)
+                .await
+                .map(|response| response.map(crate::handler::boxed_body))
+                .map_err(|error| Error::Server(format!("upstream request failed: {error}"))),
+            Self::Http3(client) => client.request(upstream, peer, request).await,
+        }
+    }
+}
+
 fn build_client_for_profile(profile: &UpstreamClientProfile) -> Result<ProxyClient, Error> {
+    if profile.protocol == UpstreamProtocol::Http3 {
+        let client_config = tls::build_http3_client_config(
+            &profile.tls,
+            profile.tls_versions.as_deref(),
+            profile.server_verify_depth,
+            profile.server_crl_path.as_deref(),
+            profile.client_identity.as_ref(),
+            profile.server_name,
+        )?;
+        return Ok(ProxyClient::Http3(http3::Http3Client::new(
+            client_config,
+            profile.connect_timeout,
+        )));
+    }
+
     let mut connector = HttpConnector::new();
     connector.enforce_http(false);
     connector.set_connect_timeout(Some(profile.connect_timeout));
@@ -188,6 +228,7 @@ fn build_client_for_profile(profile: &UpstreamClientProfile) -> Result<ProxyClie
         UpstreamProtocol::Auto => builder.enable_all_versions().wrap_connector(connector),
         UpstreamProtocol::Http1 => builder.enable_http1().wrap_connector(connector),
         UpstreamProtocol::Http2 => builder.enable_http2().wrap_connector(connector),
+        UpstreamProtocol::Http3 => unreachable!("handled before hyper connector construction"),
     };
 
     let mut client_builder = Client::builder(TokioExecutor::new());
@@ -205,5 +246,5 @@ fn build_client_for_profile(profile: &UpstreamClientProfile) -> Result<ProxyClie
         client_builder.http2_only(true);
     }
 
-    Ok(client_builder.build(connector))
+    Ok(ProxyClient::Http(Box::new(client_builder.build(connector))))
 }

--- a/crates/rginx-http/src/proxy/clients/tests.rs
+++ b/crates/rginx-http/src/proxy/clients/tests.rs
@@ -80,6 +80,7 @@ fn peer_health_snapshot_delegates_to_registry() {
             server,
             tls_termination_enabled: false,
             proxy_protocol_enabled: false,
+            http3: None,
         }],
         default_vhost: VirtualHost {
             id: "server".to_string(),

--- a/crates/rginx-http/src/proxy/clients/tls.rs
+++ b/crates/rginx-http/src/proxy/clients/tls.rs
@@ -1,13 +1,16 @@
-use std::fs::File;
-use std::io::BufReader;
 use std::path::Path;
+use std::sync::Arc;
 
 use super::*;
 use crate::tls::certificates::load_certificate_revocation_lists;
+use quinn::crypto::rustls::QuicClientConfig;
 use rginx_core::{ClientIdentity, TlsVersion};
 use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::pki_types::{
+    CertificateDer, PrivateKeyDer, ServerName, UnixTime,
+    pem::{Error as PemError, PemObject},
+};
 use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme};
 use rustls_native_certs::load_native_certs;
 
@@ -47,6 +50,37 @@ pub(super) fn build_tls_config(
     }?;
     config.enable_sni = server_name;
     Ok(config)
+}
+
+pub(super) fn build_http3_client_config(
+    tls: &UpstreamTls,
+    versions: Option<&[TlsVersion]>,
+    server_verify_depth: Option<u32>,
+    server_crl_path: Option<&Path>,
+    client_identity: Option<&ClientIdentity>,
+    server_name: bool,
+) -> Result<quinn::ClientConfig, Error> {
+    if let Some(versions) = versions
+        && !versions.contains(&TlsVersion::Tls13)
+    {
+        return Err(Error::Config("upstream http3 requires TLS1.3 to remain enabled".to_string()));
+    }
+
+    let mut tls_config = build_tls_config(
+        tls,
+        Some(&[TlsVersion::Tls13]),
+        server_verify_depth,
+        server_crl_path,
+        client_identity,
+        server_name,
+    )?;
+    tls_config.alpn_protocols = vec![b"h3".to_vec()];
+
+    let quic_config = QuicClientConfig::try_from(tls_config).map_err(|error| {
+        Error::Server(format!("failed to build quic client config for upstream http3: {error}"))
+    })?;
+
+    Ok(quinn::ClientConfig::new(Arc::new(quic_config)))
 }
 
 fn build_server_cert_verifier(
@@ -124,15 +158,10 @@ fn load_native_root_store() -> Result<RootCertStore, Error> {
 }
 
 fn load_certificate_chain(path: &Path) -> Result<Vec<CertificateDer<'static>>, Error> {
-    let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let certs =
-        rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>().map_err(|error| {
-            Error::Server(format!(
-                "failed to parse certificates from `{}`: {error}",
-                path.display()
-            ))
-        })?;
+    let certs = CertificateDer::pem_file_iter(path)
+        .map_err(|error| map_pem_error(path, "certificates", error))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|error| map_pem_error(path, "certificates", error))?;
 
     if certs.is_empty() {
         let der = std::fs::read(path)?;
@@ -143,18 +172,23 @@ fn load_certificate_chain(path: &Path) -> Result<Vec<CertificateDer<'static>>, E
 }
 
 fn load_private_key(path: &Path) -> Result<rustls::pki_types::PrivateKeyDer<'static>, Error> {
-    let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::private_key(&mut reader)
-        .map_err(|error| {
-            Error::Server(format!("failed to parse private key `{}`: {error}", path.display()))
-        })?
-        .ok_or_else(|| {
-            Error::Server(format!(
-                "private key file `{}` did not contain a supported PEM private key",
-                path.display()
-            ))
-        })
+    match PrivateKeyDer::from_pem_file(path) {
+        Ok(key) => Ok(key),
+        Err(PemError::NoItemsFound) => Err(Error::Server(format!(
+            "private key file `{}` did not contain a supported PEM private key",
+            path.display()
+        ))),
+        Err(error) => Err(map_pem_error(path, "private key", error)),
+    }
+}
+
+fn map_pem_error(path: &Path, item: &str, error: PemError) -> Error {
+    match error {
+        PemError::Io(error) => Error::Io(error),
+        other => {
+            Error::Server(format!("failed to parse {item} from `{}`: {other}", path.display()))
+        }
+    }
 }
 
 fn rustls_versions(versions: &[TlsVersion]) -> Vec<&'static rustls::SupportedProtocolVersion> {

--- a/crates/rginx-http/src/proxy/common.rs
+++ b/crates/rginx-http/src/proxy/common.rs
@@ -195,6 +195,7 @@ pub(super) fn connection_header_contains_token(headers: &HeaderMap, token: &str)
 
 pub(super) fn upstream_request_version(protocol: UpstreamProtocol) -> Version {
     match protocol {
+        UpstreamProtocol::Http3 => Version::HTTP_3,
         UpstreamProtocol::Http2 => Version::HTTP_2,
         UpstreamProtocol::Auto | UpstreamProtocol::Http1 => Version::HTTP_11,
     }

--- a/crates/rginx-http/src/proxy/forward/mod.rs
+++ b/crates/rginx-http/src/proxy/forward/mod.rs
@@ -35,7 +35,7 @@ pub struct DownstreamRequestContext<'a> {
 pub async fn forward_request(
     state: SharedState,
     clients: ProxyClients,
-    mut request: Request<Incoming>,
+    mut request: Request<HttpBody>,
     listener_id: &str,
     target: &ProxyTarget,
     client_address: ClientAddress,
@@ -85,6 +85,13 @@ pub async fn forward_request(
     } else {
         None
     };
+    if downstream_upgrade.is_some() && target.upstream.protocol == UpstreamProtocol::Http3 {
+        state.record_upstream_bad_gateway_response(&target.upstream_name);
+        return bad_gateway(
+            &request_headers,
+            format!("upstream `{}` does not support upgrade over http3\n", target.upstream_name),
+        );
+    }
 
     let mut prepared_request = match PreparedProxyRequest::from_request(
         request,
@@ -199,7 +206,7 @@ pub async fn forward_request(
             upstream_request_timeout,
             &target.upstream_name,
             "request",
-            client.request(upstream_request),
+            client.request(target.upstream.as_ref(), peer, upstream_request),
         )
         .await
         {

--- a/crates/rginx-http/src/proxy/forward/response.rs
+++ b/crates/rginx-http/src/proxy/forward/response.rs
@@ -12,7 +12,7 @@ pub(super) struct GrpcResponseDeadline {
 }
 
 pub(super) fn build_downstream_response(
-    response: Response<Incoming>,
+    response: Response<HttpBody>,
     upstream_name: &str,
     peer_url: &str,
     idle_timeout: Duration,

--- a/crates/rginx-http/src/proxy/health.rs
+++ b/crates/rginx-http/src/proxy/health.rs
@@ -65,7 +65,9 @@ pub async fn probe_upstream_peer(
         }
     };
 
-    match tokio::time::timeout(check.timeout, client.request(request)).await {
+    match tokio::time::timeout(check.timeout, client.request(upstream.as_ref(), &peer, request))
+        .await
+    {
         Ok(Ok(response)) if check.grpc_service.is_some() => {
             match tokio::time::timeout(check.timeout, evaluate_grpc_health_probe_response(response))
                 .await

--- a/crates/rginx-http/src/proxy/health/registry.rs
+++ b/crates/rginx-http/src/proxy/health/registry.rs
@@ -730,6 +730,7 @@ mod tests {
                 server,
                 tls_termination_enabled: false,
                 proxy_protocol_enabled: false,
+                http3: None,
             }],
             default_vhost: rginx_core::VirtualHost {
                 id: "server".to_string(),

--- a/crates/rginx-http/src/proxy/mod.rs
+++ b/crates/rginx-http/src/proxy/mod.rs
@@ -11,7 +11,7 @@ pub(super) use http::header::{
 };
 pub(super) use http::{Method, Request, Response, StatusCode, Uri, Version};
 pub(super) use http_body_util::BodyExt;
-pub(super) use hyper::body::{Body as _, Frame, Incoming, SizeHint};
+pub(super) use hyper::body::{Body as _, Frame, SizeHint};
 pub(super) use hyper::upgrade::OnUpgrade;
 pub(super) use hyper_rustls::{FixedServerNameResolver, HttpsConnector, HttpsConnectorBuilder};
 pub(super) use hyper_util::client::legacy::Client;
@@ -52,7 +52,7 @@ const GRPC_TIMEOUT_HEADER: &str = "grpc-timeout";
 const MAX_GRPC_TIMEOUT_DIGITS: usize = 8;
 
 pub(crate) use clients::HealthChangeNotifier;
-pub use clients::{ProxyClient, ProxyClients};
+pub use clients::ProxyClients;
 pub use forward::{DownstreamRequestContext, DownstreamRequestOptions, forward_request};
 pub use health::probe_upstream_peer;
 pub use health::{PeerHealthSnapshot, UpstreamHealthSnapshot};

--- a/crates/rginx-http/src/proxy/request_body.rs
+++ b/crates/rginx-http/src/proxy/request_body.rs
@@ -102,7 +102,7 @@ impl hyper::body::Body for ReplayableRequestBody {
 
 impl PreparedProxyRequest {
     pub(super) async fn from_request(
-        request: Request<Incoming>,
+        request: Request<HttpBody>,
         upstream_name: &str,
         request_body_read_timeout: Option<Duration>,
         write_timeout: Duration,
@@ -184,7 +184,7 @@ async fn prepare_request_body(
     upstream_name: &str,
     method: &Method,
     headers: &HeaderMap,
-    body: Incoming,
+    body: HttpBody,
     body_timeout: Duration,
     max_replayable_request_body_bytes: usize,
     max_request_body_bytes: Option<usize>,
@@ -291,7 +291,7 @@ where
 }
 
 fn downstream_request_body(
-    body: Incoming,
+    body: HttpBody,
     body_timeout: Duration,
     label: String,
     grpc_web_mode: Option<&GrpcWebMode>,

--- a/crates/rginx-http/src/proxy/tests/client_profiles.rs
+++ b/crates/rginx-http/src/proxy/tests/client_profiles.rs
@@ -5,6 +5,7 @@ fn upstream_request_version_follows_upstream_protocol() {
     assert_eq!(upstream_request_version(UpstreamProtocol::Auto), Version::HTTP_11);
     assert_eq!(upstream_request_version(UpstreamProtocol::Http1), Version::HTTP_11);
     assert_eq!(upstream_request_version(UpstreamProtocol::Http2), Version::HTTP_2);
+    assert_eq!(upstream_request_version(UpstreamProtocol::Http3), Version::HTTP_3);
 }
 
 #[test]
@@ -178,15 +179,28 @@ fn proxy_clients_cache_distinguishes_upstream_protocol() {
         UpstreamTls::NativeRoots,
         upstream_settings(UpstreamProtocol::Http2),
     );
+    let http3 = Upstream::new(
+        "http3".to_string(),
+        vec![UpstreamPeer {
+            url: "https://127.0.0.1:9444".to_string(),
+            scheme: "https".to_string(),
+            authority: "127.0.0.1:9444".to_string(),
+            weight: 1,
+            backup: false,
+        }],
+        UpstreamTls::NativeRoots,
+        upstream_settings(UpstreamProtocol::Http3),
+    );
 
     let snapshot = snapshot_with_upstreams([
         ("auto".to_string(), Arc::new(auto)),
         ("http1".to_string(), Arc::new(http1)),
         ("http2".to_string(), Arc::new(http2)),
+        ("http3".to_string(), Arc::new(http3)),
     ]);
 
     let clients = ProxyClients::from_config(&snapshot).expect("clients should build");
-    assert_eq!(clients.cached_client_count(), 3);
+    assert_eq!(clients.cached_client_count(), 4);
 }
 
 #[test]

--- a/crates/rginx-http/src/proxy/tests/client_profiles.rs
+++ b/crates/rginx-http/src/proxy/tests/client_profiles.rs
@@ -175,19 +175,13 @@ fn proxy_clients_cache_distinguishes_upstream_protocol() {
     );
     let http2 = Upstream::new(
         "http2".to_string(),
-        vec![peer],
+        vec![peer.clone()],
         UpstreamTls::NativeRoots,
         upstream_settings(UpstreamProtocol::Http2),
     );
     let http3 = Upstream::new(
         "http3".to_string(),
-        vec![UpstreamPeer {
-            url: "https://127.0.0.1:9444".to_string(),
-            scheme: "https".to_string(),
-            authority: "127.0.0.1:9444".to_string(),
-            weight: 1,
-            backup: false,
-        }],
+        vec![peer.clone()],
         UpstreamTls::NativeRoots,
         upstream_settings(UpstreamProtocol::Http3),
     );

--- a/crates/rginx-http/src/proxy/tests/mod.rs
+++ b/crates/rginx-http/src/proxy/tests/mod.rs
@@ -126,6 +126,7 @@ fn default_listener(server: rginx_core::Server) -> rginx_core::Listener {
         server,
         tls_termination_enabled: false,
         proxy_protocol_enabled: false,
+        http3: None,
     }
 }
 

--- a/crates/rginx-http/src/server/graceful.rs
+++ b/crates/rginx-http/src/server/graceful.rs
@@ -28,7 +28,13 @@ pub(super) async fn serve_h1_connection_io<T>(
         let connection_addrs = service_connection_addrs.clone();
         async move {
             Ok::<_, Infallible>(
-                crate::handler::handle(request, state, connection_addrs, &listener_id).await,
+                crate::handler::handle(
+                    request.map(crate::handler::boxed_body),
+                    state,
+                    connection_addrs,
+                    &listener_id,
+                )
+                .await,
             )
         }
     });
@@ -92,7 +98,13 @@ pub(super) async fn serve_h2_connection_io<T>(
         let connection_addrs = service_connection_addrs.clone();
         async move {
             Ok::<_, Infallible>(
-                crate::handler::handle(request, state, connection_addrs, &listener_id).await,
+                crate::handler::handle(
+                    request.map(crate::handler::boxed_body),
+                    state,
+                    connection_addrs,
+                    &listener_id,
+                )
+                .await,
             )
         }
     });

--- a/crates/rginx-http/src/server/http3.rs
+++ b/crates/rginx-http/src/server/http3.rs
@@ -1,0 +1,430 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use bytes::{Buf, Bytes};
+use h3::quic::{RecvStream, SendStream};
+use h3::server::{Connection as H3Connection, RequestResolver, RequestStream};
+use http::{Response, Version};
+use http_body_util::BodyExt;
+use hyper::body::{Body, Frame, SizeHint};
+use pin_project_lite::pin_project;
+use quinn::Incoming;
+use tokio::sync::watch;
+use tokio::task::{JoinError, JoinSet};
+
+use rginx_core::{Error, Result};
+
+use crate::client_ip::ConnectionPeerAddrs;
+use crate::handler::{BoxError, HttpResponse};
+use crate::tls::build_http3_server_config;
+
+pin_project! {
+    struct Http3RequestBody<S> {
+        #[pin]
+        stream: RequestStream<S, Bytes>,
+        data_finished: bool,
+        trailers_finished: bool,
+    }
+}
+
+impl<S> Http3RequestBody<S> {
+    fn new(stream: RequestStream<S, Bytes>) -> Self {
+        Self { stream, data_finished: false, trailers_finished: false }
+    }
+}
+
+impl<S> Body for Http3RequestBody<S>
+where
+    S: RecvStream,
+{
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<std::result::Result<Frame<Self::Data>, Self::Error>>> {
+        let mut this = self.project();
+
+        if !*this.data_finished {
+            match this.stream.as_mut().poll_recv_data(cx) {
+                Poll::Ready(Ok(Some(mut chunk))) => {
+                    let bytes = chunk.copy_to_bytes(chunk.remaining());
+                    return Poll::Ready(Some(Ok(Frame::data(bytes))));
+                }
+                Poll::Ready(Ok(None)) => {
+                    *this.data_finished = true;
+                }
+                Poll::Ready(Err(error)) => {
+                    *this.data_finished = true;
+                    *this.trailers_finished = true;
+                    return Poll::Ready(Some(Err(stream_error(error))));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        if !*this.trailers_finished {
+            match this.stream.as_mut().poll_recv_trailers(cx) {
+                Poll::Ready(Ok(Some(trailers))) => {
+                    *this.trailers_finished = true;
+                    return Poll::Ready(Some(Ok(Frame::trailers(trailers))));
+                }
+                Poll::Ready(Ok(None)) => {
+                    *this.trailers_finished = true;
+                }
+                Poll::Ready(Err(error)) => {
+                    *this.trailers_finished = true;
+                    return Poll::Ready(Some(Err(stream_error(error))));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        Poll::Ready(None)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.data_finished && self.trailers_finished
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::default()
+    }
+}
+
+pub async fn serve_http3(
+    endpoint: quinn::Endpoint,
+    listener_id: String,
+    state: crate::state::SharedState,
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<()> {
+    let mut connections = JoinSet::new();
+    let mut draining = *shutdown.borrow();
+    if draining {
+        endpoint.set_server_config(None);
+    }
+
+    loop {
+        tokio::select! {
+            changed = shutdown.changed(), if !draining => {
+                match changed {
+                    Ok(()) if *shutdown.borrow() => {
+                        tracing::info!("http3 accept loop entering drain mode");
+                        draining = true;
+                        endpoint.set_server_config(None);
+                        if connections.is_empty() {
+                            break;
+                        }
+                    }
+                    Ok(()) => continue,
+                    Err(_) => {
+                        tracing::info!("http3 accept loop entering drain mode because shutdown channel closed");
+                        draining = true;
+                        endpoint.set_server_config(None);
+                        if connections.is_empty() {
+                            break;
+                        }
+                    }
+                }
+            }
+            accepted = endpoint.accept(), if !draining => {
+                while let Some(result) = connections.try_join_next() {
+                    log_connection_task_result(result);
+                }
+
+                let Some(incoming) = accepted else {
+                    break;
+                };
+
+                let remote_addr = incoming.remote_address();
+                let current_listener = state.current_listener(&listener_id).await.expect(
+                    "listener id should remain available while http3 accept loop is running",
+                );
+                let Some(connection_guard) =
+                    state.try_acquire_connection(&listener_id, current_listener.server.max_connections)
+                else {
+                    state.record_connection_rejected(&listener_id);
+                    tracing::warn!(
+                        remote_addr = %remote_addr,
+                        listener = %listener_id,
+                        max_connections = current_listener.server.max_connections,
+                        active_connections = state.active_connection_count(),
+                        "rejecting downstream http3 connection because server max_connections was reached"
+                    );
+                    incoming.refuse();
+                    continue;
+                };
+                state.record_connection_accepted(&listener_id);
+
+                let state = state.clone();
+                let shutdown = shutdown.clone();
+                let listener_id = listener_id.clone();
+                connections.spawn(async move {
+                    serve_http3_connection(
+                        incoming,
+                        listener_id,
+                        state,
+                        remote_addr,
+                        shutdown,
+                        connection_guard,
+                    )
+                    .await
+                });
+            }
+            joined = connections.join_next(), if !connections.is_empty() => {
+                if let Some(result) = joined {
+                    log_connection_task_result(result);
+                }
+                if draining && connections.is_empty() {
+                    break;
+                }
+            }
+            else => {
+                if draining || connections.is_empty() {
+                    break;
+                }
+            }
+        }
+    }
+
+    while let Some(result) = connections.join_next().await {
+        log_connection_task_result(result);
+    }
+
+    endpoint.close(quinn::VarInt::from_u32(0), b"shutdown");
+    endpoint.wait_idle().await;
+
+    tracing::info!("http3 server stopped");
+    Ok(())
+}
+
+pub fn bind_http3_endpoint(
+    listener: &rginx_core::Listener,
+    default_vhost: &rginx_core::VirtualHost,
+    vhosts: &[rginx_core::VirtualHost],
+) -> Result<Option<quinn::Endpoint>> {
+    let listen_addr = match listener.http3.as_ref() {
+        Some(http3) => http3.listen_addr,
+        None => return Ok(None),
+    };
+    let socket = std::net::UdpSocket::bind(listen_addr).map_err(Error::Io)?;
+    bind_http3_endpoint_with_socket(listener, default_vhost, vhosts, socket).map(Some)
+}
+
+pub fn bind_http3_endpoint_with_socket(
+    listener: &rginx_core::Listener,
+    default_vhost: &rginx_core::VirtualHost,
+    vhosts: &[rginx_core::VirtualHost],
+    socket: std::net::UdpSocket,
+) -> Result<quinn::Endpoint> {
+    let server_config = build_http3_server_config(
+        listener.server.tls.as_ref(),
+        listener.server.default_certificate.as_deref(),
+        listener.tls_enabled(),
+        default_vhost,
+        vhosts,
+    )?
+    .ok_or_else(|| {
+        Error::Config("http3 listener requires downstream TLS termination".to_string())
+    })?;
+
+    let quic_config = quinn::ServerConfig::with_crypto(Arc::new(
+        quinn::crypto::rustls::QuicServerConfig::try_from(server_config).map_err(|error| {
+            Error::Server(format!("failed to build quic server config for http3 listener: {error}"))
+        })?,
+    ));
+    let runtime = quinn::default_runtime()
+        .ok_or_else(|| Error::Server("no async runtime found for http3 endpoint".to_string()))?;
+    quinn::Endpoint::new(quinn::EndpointConfig::default(), Some(quic_config), socket, runtime)
+        .map_err(Error::Io)
+}
+
+async fn serve_http3_connection(
+    incoming: Incoming,
+    listener_id: String,
+    state: crate::state::SharedState,
+    remote_addr: SocketAddr,
+    mut shutdown: watch::Receiver<bool>,
+    _connection_guard: crate::state::ActiveConnectionGuard,
+) -> Result<()> {
+    let connection = incoming
+        .await
+        .map_err(|error| Error::Server(format!("http3 connection handshake failed: {error}")))?;
+    let mut request_tasks = JoinSet::new();
+    let h3_connection = h3_quinn::Connection::new(connection);
+    let mut h3 = H3Connection::new(h3_connection).await.map_err(|error| {
+        Error::Server(format!("failed to initialize http3 connection: {error}"))
+    })?;
+
+    let connection_addrs = Arc::new(ConnectionPeerAddrs {
+        socket_peer_addr: remote_addr,
+        proxy_protocol_source_addr: None,
+        tls_client_identity: None,
+        tls_version: Some("TLS1.3".to_string()),
+        tls_alpn: Some("h3".to_string()),
+    });
+
+    let mut draining = *shutdown.borrow();
+    if draining {
+        let _ = h3.shutdown(0).await;
+    }
+
+    loop {
+        tokio::select! {
+            changed = shutdown.changed(), if !draining => {
+                match changed {
+                    Ok(()) if *shutdown.borrow() => {
+                        draining = true;
+                        let _ = h3.shutdown(0).await;
+                    }
+                    Ok(()) => {}
+                    Err(_) => {
+                        draining = true;
+                        let _ = h3.shutdown(0).await;
+                    }
+                }
+            }
+            accepted = h3.accept(), if !draining => {
+                match accepted {
+                    Ok(Some(resolver)) => {
+                        let state = state.clone();
+                        let listener_id = listener_id.clone();
+                        let connection_addrs = connection_addrs.clone();
+                        request_tasks.spawn(async move {
+                            serve_http3_request(resolver, listener_id, state, connection_addrs).await
+                        });
+                    }
+                    Ok(None) => break,
+                    Err(error) => {
+                        return Err(Error::Server(format!("http3 request accept failed: {error}")));
+                    }
+                }
+            }
+            joined = request_tasks.join_next(), if !request_tasks.is_empty() => {
+                if let Some(result) = joined {
+                    log_request_task_result(result);
+                }
+                if draining && request_tasks.is_empty() {
+                    break;
+                }
+            }
+            else => {
+                if request_tasks.is_empty() {
+                    break;
+                }
+            }
+        }
+    }
+
+    while let Some(result) = request_tasks.join_next().await {
+        log_request_task_result(result);
+    }
+
+    Ok(())
+}
+
+async fn serve_http3_request(
+    resolver: RequestResolver<h3_quinn::Connection, Bytes>,
+    listener_id: String,
+    state: crate::state::SharedState,
+    connection_addrs: Arc<ConnectionPeerAddrs>,
+) -> Result<()> {
+    let (request, stream) = resolver
+        .resolve_request()
+        .await
+        .map_err(|error| Error::Server(format!("failed to resolve http3 request: {error}")))?;
+    let (send_stream, recv_stream) = stream.split();
+    let mut request =
+        request.map(|()| crate::handler::boxed_body(Http3RequestBody::new(recv_stream)));
+    *request.version_mut() = Version::HTTP_3;
+
+    let response = crate::handler::handle(request, state, connection_addrs, &listener_id).await;
+    send_http3_response(send_stream, response).await
+}
+
+async fn send_http3_response<S>(
+    mut stream: RequestStream<S, Bytes>,
+    response: HttpResponse,
+) -> Result<()>
+where
+    S: SendStream<Bytes>,
+{
+    let (parts, mut body) = response.into_parts();
+    let mut response_builder = Response::builder().status(parts.status);
+    for (name, value) in &parts.headers {
+        response_builder = response_builder.header(name, value);
+    }
+    let response = response_builder.body(()).map_err(|error| {
+        Error::Server(format!("failed to build http3 response headers: {error}"))
+    })?;
+    stream.send_response(response).await.map_err(|error| {
+        Error::Server(format!("failed to send http3 response headers: {error}"))
+    })?;
+
+    while let Some(frame) = body.frame().await {
+        let frame = frame.map_err(|error| {
+            Error::Server(format!("failed to read response body frame for http3: {error}"))
+        })?;
+        match frame.into_data() {
+            Ok(data) => {
+                if !data.is_empty() {
+                    tracing::debug!(len = data.len(), "http3 sending response data frame");
+                    stream.send_data(data).await.map_err(|error| {
+                        Error::Server(format!("failed to send http3 response body: {error}"))
+                    })?;
+                }
+            }
+            Err(frame) => {
+                if let Ok(trailers) = frame.into_trailers() {
+                    tracing::debug!(count = trailers.len(), "http3 sending response trailers");
+                    stream.send_trailers(trailers).await.map_err(|error| {
+                        Error::Server(format!("failed to send http3 response trailers: {error}"))
+                    })?;
+                }
+            }
+        }
+    }
+
+    stream
+        .finish()
+        .await
+        .map_err(|error| Error::Server(format!("failed to finish http3 response stream: {error}")))
+}
+
+fn log_connection_task_result(result: std::result::Result<Result<()>, JoinError>) {
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            tracing::warn!(%error, "http3 connection task failed");
+        }
+        Err(error) if error.is_panic() => {
+            tracing::warn!(%error, "http3 connection task panicked");
+        }
+        Err(error) if !error.is_cancelled() => {
+            tracing::warn!(%error, "http3 connection task failed to join");
+        }
+        Err(_) => {}
+    }
+}
+
+fn log_request_task_result(result: std::result::Result<Result<()>, JoinError>) {
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            tracing::warn!(%error, "http3 request task failed");
+        }
+        Err(error) if error.is_panic() => {
+            tracing::warn!(%error, "http3 request task panicked");
+        }
+        Err(error) if !error.is_cancelled() => {
+            tracing::warn!(%error, "http3 request task failed to join");
+        }
+        Err(_) => {}
+    }
+}
+
+fn stream_error(error: impl std::fmt::Display) -> BoxError {
+    std::io::Error::other(format!("{error}")).into()
+}

--- a/crates/rginx-http/src/server/http3.rs
+++ b/crates/rginx-http/src/server/http3.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use bytes::{Buf, Bytes};
 use h3::quic::{RecvStream, SendStream};
@@ -308,6 +309,9 @@ async fn serve_http3_connection(
                     log_request_task_result(result);
                 }
                 if draining && request_tasks.is_empty() {
+                    // Give Quinn a brief window to flush the final response frames before
+                    // dropping the drained connection.
+                    tokio::time::sleep(Duration::from_millis(50)).await;
                     break;
                 }
             }

--- a/crates/rginx-http/src/server/http3.rs
+++ b/crates/rginx-http/src/server/http3.rs
@@ -210,6 +210,7 @@ pub fn bind_http3_endpoint(
         None => return Ok(None),
     };
     let socket = std::net::UdpSocket::bind(listen_addr).map_err(Error::Io)?;
+    socket.set_nonblocking(true).map_err(Error::Io)?;
     bind_http3_endpoint_with_socket(listener, default_vhost, vhosts, socket).map(Some)
 }
 

--- a/crates/rginx-http/src/server/mod.rs
+++ b/crates/rginx-http/src/server/mod.rs
@@ -1,9 +1,11 @@
 mod accept;
 mod connection;
 mod graceful;
+mod http3;
 mod proxy_protocol;
 
 #[cfg(test)]
 mod tests;
 
 pub use accept::serve;
+pub use http3::{bind_http3_endpoint, bind_http3_endpoint_with_socket, serve_http3};

--- a/crates/rginx-http/src/server/tests.rs
+++ b/crates/rginx-http/src/server/tests.rs
@@ -1,5 +1,5 @@
 use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair};
-use rustls_pemfile::certs;
+use rustls::pki_types::{CertificateDer, pem::PemObject};
 
 use super::connection::parse_tls_client_identity;
 use super::proxy_protocol::parse_proxy_protocol_v1;
@@ -41,8 +41,7 @@ fn parse_tls_client_identity_extracts_subject_and_dns_san() {
     let key_pair = KeyPair::generate().expect("keypair should generate");
     let cert = params.self_signed(&key_pair).expect("cert should generate");
     let pem = cert.pem();
-    let mut reader = std::io::Cursor::new(pem.as_bytes());
-    let cert = certs(&mut reader)
+    let cert = CertificateDer::pem_slice_iter(pem.as_bytes())
         .collect::<Result<Vec<_>, _>>()
         .expect("certificate PEM should parse")
         .remove(0);
@@ -74,8 +73,7 @@ fn parse_tls_client_identity_preserves_leaf_fields_and_chain_order() {
         leaf_params.signed_by(&leaf_key, &ca_issuer).expect("leaf cert should be signed by CA");
 
     let pem = format!("{}{}", leaf_cert.pem(), _ca_cert.pem());
-    let mut reader = std::io::Cursor::new(pem.as_bytes());
-    let certs = certs(&mut reader)
+    let certs = CertificateDer::pem_slice_iter(pem.as_bytes())
         .collect::<Result<Vec<_>, _>>()
         .expect("certificate PEM chain should parse");
 

--- a/crates/rginx-http/src/state/lifecycle.rs
+++ b/crates/rginx-http/src/state/lifecycle.rs
@@ -35,12 +35,34 @@ impl SharedState {
                     listener_id: listener.id.clone(),
                     listener_name: listener.name.clone(),
                     listen_addr: listener.server.listen_addr,
+                    binding_count: listener.binding_count(),
+                    http3_enabled: listener.http3_enabled(),
                     tls_enabled: listener.tls_enabled(),
                     proxy_protocol_enabled: listener.proxy_protocol_enabled,
                     default_certificate: listener.server.default_certificate.clone(),
                     keep_alive: listener.server.keep_alive,
                     max_connections: listener.server.max_connections,
                     access_log_format_configured: listener.server.access_log_format.is_some(),
+                    bindings: listener
+                        .transport_bindings()
+                        .into_iter()
+                        .map(|binding| crate::state::RuntimeListenerBindingSnapshot {
+                            binding_name: binding.name.to_string(),
+                            transport: binding.kind.as_str().to_string(),
+                            listen_addr: binding.listen_addr,
+                            protocols: binding
+                                .protocols
+                                .into_iter()
+                                .map(|protocol| protocol.as_str().to_string())
+                                .collect(),
+                            advertise_alt_svc: binding
+                                .alt_svc_max_age
+                                .map(|_| binding.advertise_alt_svc),
+                            alt_svc_max_age_secs: binding
+                                .alt_svc_max_age
+                                .map(|max_age| max_age.as_secs()),
+                        })
+                        .collect(),
                 })
                 .collect(),
             worker_threads: config.runtime.worker_threads,

--- a/crates/rginx-http/src/state/snapshots.rs
+++ b/crates/rginx-http/src/state/snapshots.rs
@@ -57,9 +57,13 @@ pub struct TlsListenerStatusSnapshot {
     pub listener_name: String,
     pub listen_addr: std::net::SocketAddr,
     pub tls_enabled: bool,
+    pub http3_enabled: bool,
+    pub http3_listen_addr: Option<std::net::SocketAddr>,
     pub default_certificate: Option<String>,
     pub versions: Option<Vec<String>>,
     pub alpn_protocols: Vec<String>,
+    pub http3_versions: Vec<String>,
+    pub http3_alpn_protocols: Vec<String>,
     pub session_resumption_enabled: Option<bool>,
     pub session_tickets_enabled: Option<bool>,
     pub session_cache_size: Option<usize>,
@@ -288,12 +292,27 @@ pub struct RuntimeListenerSnapshot {
     pub listener_id: String,
     pub listener_name: String,
     pub listen_addr: std::net::SocketAddr,
+    pub binding_count: usize,
+    pub http3_enabled: bool,
     pub tls_enabled: bool,
     pub proxy_protocol_enabled: bool,
     pub default_certificate: Option<String>,
     pub keep_alive: bool,
     pub max_connections: Option<usize>,
     pub access_log_format_configured: bool,
+    pub bindings: Vec<RuntimeListenerBindingSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeListenerBindingSnapshot {
+    pub binding_name: String,
+    pub transport: String,
+    pub listen_addr: std::net::SocketAddr,
+    pub protocols: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub advertise_alt_svc: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alt_svc_max_age_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/rginx-http/src/state/tests.rs
+++ b/crates/rginx-http/src/state/tests.rs
@@ -15,7 +15,7 @@ use rginx_core::{
 };
 
 use super::{
-    ConfigSnapshot, ReloadOutcomeSnapshot, SharedState, TlsHandshakeFailureReason,
+    ConfigSnapshot, ReloadOutcomeSnapshot, SharedState, SnapshotModule, TlsHandshakeFailureReason,
     inspect_certificate, validate_config_transition,
 };
 
@@ -46,6 +46,7 @@ fn snapshot(listen: &str) -> ConfigSnapshot {
             server,
             tls_termination_enabled: false,
             proxy_protocol_enabled: false,
+            http3: None,
         }],
         default_vhost: VirtualHost {
             id: "server".to_string(),
@@ -119,6 +120,23 @@ fn snapshot_with_routes(listen: &str) -> ConfigSnapshot {
     snapshot
 }
 
+fn snapshot_with_routes_and_upstream(listen: &str) -> ConfigSnapshot {
+    let mut snapshot = snapshot_with_upstream(listen);
+    snapshot.default_vhost.routes = vec![Route {
+        id: "server/routes[0]|exact:/".to_string(),
+        matcher: RouteMatcher::Exact("/".to_string()),
+        grpc_match: None,
+        action: RouteAction::Return(ReturnAction {
+            status: StatusCode::OK,
+            location: String::new(),
+            body: Some("ok\n".to_string()),
+        }),
+        access_control: RouteAccessControl::default(),
+        rate_limit: None,
+    }];
+    snapshot
+}
+
 #[test]
 fn validate_config_transition_allows_unchanged_listener() {
     let current = snapshot("127.0.0.1:8080");
@@ -177,14 +195,23 @@ async fn status_snapshot_reports_runtime_summary() {
     assert_eq!(status.listeners[0].listener_id, "default");
     assert_eq!(status.listeners[0].listener_name, "default");
     assert_eq!(status.listeners[0].listen_addr, "127.0.0.1:8080".parse().unwrap());
+    assert_eq!(status.listeners[0].binding_count, 1);
+    assert!(!status.listeners[0].http3_enabled);
     assert!(!status.listeners[0].tls_enabled);
     assert!(!status.listeners[0].proxy_protocol_enabled);
     assert!(!status.listeners[0].access_log_format_configured);
+    assert_eq!(status.listeners[0].bindings.len(), 1);
+    assert_eq!(status.listeners[0].bindings[0].transport, "tcp");
+    assert_eq!(status.listeners[0].bindings[0].protocols, vec!["http1".to_string()]);
     assert_eq!(status.total_vhosts, 1);
     assert_eq!(status.total_routes, 0);
     assert_eq!(status.total_upstreams, 0);
     assert!(!status.tls_enabled);
     assert_eq!(status.tls.listeners.len(), 1);
+    assert!(!status.tls.listeners[0].http3_enabled);
+    assert_eq!(status.tls.listeners[0].http3_listen_addr, None);
+    assert!(status.tls.listeners[0].http3_versions.is_empty());
+    assert!(status.tls.listeners[0].http3_alpn_protocols.is_empty());
     assert_eq!(status.tls.listeners[0].session_resumption_enabled, None);
     assert_eq!(status.tls.listeners[0].session_tickets_enabled, None);
     assert_eq!(status.tls.listeners[0].session_cache_size, None);
@@ -195,6 +222,38 @@ async fn status_snapshot_reports_runtime_summary() {
     assert_eq!(status.mtls.authenticated_requests, 0);
     assert_eq!(status.active_connections, 0);
     assert_eq!(status.reload.attempts_total, 0);
+}
+
+#[tokio::test]
+async fn status_snapshot_reports_http3_listener_bindings() {
+    let mut config = snapshot("127.0.0.1:8443");
+    config.listeners[0].tls_termination_enabled = true;
+    config.listeners[0].http3 = Some(rginx_core::ListenerHttp3 {
+        listen_addr: "127.0.0.1:8443".parse().unwrap(),
+        advertise_alt_svc: true,
+        alt_svc_max_age: Duration::from_secs(7200),
+    });
+    let shared = SharedState::from_config(config).expect("shared state should build");
+
+    let status = shared.status_snapshot().await;
+    assert_eq!(status.listeners.len(), 1);
+    assert_eq!(status.listeners[0].binding_count, 2);
+    assert!(status.listeners[0].http3_enabled);
+    assert_eq!(status.listeners[0].bindings.len(), 2);
+    assert_eq!(status.listeners[0].bindings[0].transport, "tcp");
+    assert_eq!(
+        status.listeners[0].bindings[0].protocols,
+        vec!["http1".to_string(), "http2".to_string()]
+    );
+    assert_eq!(status.listeners[0].bindings[1].transport, "udp");
+    assert_eq!(status.listeners[0].bindings[1].protocols, vec!["http3".to_string()]);
+    assert_eq!(status.listeners[0].bindings[1].advertise_alt_svc, Some(true));
+    assert_eq!(status.listeners[0].bindings[1].alt_svc_max_age_secs, Some(7200));
+    assert_eq!(status.tls.listeners.len(), 1);
+    assert!(status.tls.listeners[0].http3_enabled);
+    assert_eq!(status.tls.listeners[0].http3_listen_addr, Some("127.0.0.1:8443".parse().unwrap()));
+    assert_eq!(status.tls.listeners[0].http3_versions, vec!["TLS1.3".to_string()]);
+    assert_eq!(status.tls.listeners[0].http3_alpn_protocols, vec!["h3".to_string()]);
 }
 
 #[test]
@@ -259,6 +318,113 @@ async fn mtls_status_snapshot_excludes_non_mtls_listener_handshake_failures() {
     assert_eq!(counters.downstream_tls_handshake_failures, 1);
     assert_eq!(status.mtls.configured_listeners, 0);
     assert_eq!(status.mtls.handshake_failures_total, 0);
+}
+
+#[tokio::test]
+async fn current_listener_returns_retired_listener_and_exposes_runtime_metadata() {
+    let config_path = PathBuf::from("/etc/rginx/rginx.ron");
+    let shared = SharedState::from_config_path(config_path.clone(), snapshot("127.0.0.1:8080"))
+        .expect("shared state should build");
+
+    let mut retired = snapshot("127.0.0.1:9090")
+        .listeners
+        .into_iter()
+        .next()
+        .expect("snapshot should contain a listener");
+    retired.id = "retired".to_string();
+    retired.name = "retired".to_string();
+    shared.retire_listener_runtime(&retired);
+
+    let expected_path = config_path;
+    assert_eq!(shared.config_path().map(|path| path.as_path()), Some(expected_path.as_path()));
+    assert_eq!(shared.current_revision().await, 0);
+
+    let listener =
+        shared.current_listener("retired").await.expect("retired listener should be returned");
+    assert_eq!(listener.id, "retired");
+    assert_eq!(listener.name, "retired");
+    assert_eq!(listener.server.listen_addr, "127.0.0.1:9090".parse().unwrap());
+}
+
+#[tokio::test]
+async fn wait_for_snapshot_change_returns_after_state_update() {
+    let shared = SharedState::from_config(snapshot_with_upstream("127.0.0.1:8080"))
+        .expect("shared state should build");
+
+    let since_version = shared.current_snapshot_version();
+    let waiter = {
+        let shared = shared.clone();
+        tokio::spawn(async move {
+            shared.wait_for_snapshot_change(since_version, Some(Duration::from_secs(1))).await
+        })
+    };
+
+    tokio::task::yield_now().await;
+    shared.record_upstream_request("backend");
+
+    let changed_version = waiter.await.expect("wait task should complete");
+    assert!(changed_version > since_version);
+    assert_eq!(changed_version, shared.current_snapshot_version());
+}
+
+#[tokio::test]
+async fn wait_for_snapshot_change_returns_current_version_after_timeout() {
+    let shared =
+        SharedState::from_config(snapshot("127.0.0.1:8080")).expect("shared state should build");
+
+    shared.record_reload_success(1, Vec::new());
+    let since_version = shared.current_snapshot_version();
+
+    let changed_version =
+        shared.wait_for_snapshot_change(since_version, Some(Duration::from_millis(20))).await;
+
+    assert_eq!(changed_version, since_version);
+}
+
+#[test]
+fn snapshot_delta_since_filters_modules_and_reports_changed_targets() {
+    let shared = SharedState::from_config(snapshot_with_routes_and_upstream("127.0.0.1:8080"))
+        .expect("shared state should build");
+
+    let since_version = shared.current_snapshot_version();
+    shared.record_ocsp_refresh_success("listener:default");
+    shared.record_downstream_request("default", "server", Some("server/routes[0]|exact:/"));
+    shared.record_upstream_request("backend");
+
+    let delta = shared.snapshot_delta_since(
+        since_version,
+        Some(&[SnapshotModule::Status, SnapshotModule::Traffic, SnapshotModule::Upstreams]),
+        Some(30),
+    );
+
+    assert_eq!(
+        delta.included_modules,
+        vec![SnapshotModule::Status, SnapshotModule::Traffic, SnapshotModule::Upstreams]
+    );
+    assert_eq!(delta.since_version, since_version);
+    assert_eq!(delta.current_snapshot_version, shared.current_snapshot_version());
+    assert_eq!(delta.recent_window_secs, Some(30));
+    assert!(delta.status_version.expect("status version should be present") > since_version);
+    assert!(delta.traffic_version.expect("traffic version should be present") > since_version);
+    assert!(delta.upstreams_version.expect("upstream version should be present") > since_version);
+    assert_eq!(delta.counters_version, None);
+    assert_eq!(delta.peer_health_version, None);
+    assert_eq!(delta.status_changed, Some(true));
+    assert_eq!(delta.counters_changed, None);
+    assert_eq!(delta.traffic_changed, Some(true));
+    assert_eq!(delta.traffic_recent_changed, Some(true));
+    assert_eq!(delta.peer_health_changed, None);
+    assert_eq!(delta.upstreams_changed, Some(true));
+    assert_eq!(delta.upstreams_recent_changed, Some(true));
+    assert_eq!(delta.changed_listener_ids, Some(vec!["default".to_string()]));
+    assert_eq!(delta.changed_vhost_ids, Some(vec!["server".to_string()]));
+    assert_eq!(delta.changed_route_ids, Some(vec!["server/routes[0]|exact:/".to_string()]));
+    assert_eq!(delta.changed_recent_listener_ids, Some(vec!["default".to_string()]));
+    assert_eq!(delta.changed_recent_vhost_ids, Some(vec!["server".to_string()]));
+    assert_eq!(delta.changed_recent_route_ids, Some(vec!["server/routes[0]|exact:/".to_string()]));
+    assert_eq!(delta.changed_peer_health_upstream_names, None);
+    assert_eq!(delta.changed_upstream_names, Some(vec!["backend".to_string()]));
+    assert_eq!(delta.changed_recent_upstream_names, Some(vec!["backend".to_string()]));
 }
 
 #[test]

--- a/crates/rginx-http/src/state/tls_runtime/bindings.rs
+++ b/crates/rginx-http/src/state/tls_runtime/bindings.rs
@@ -219,6 +219,7 @@ mod tests {
             },
             tls_termination_enabled,
             proxy_protocol_enabled: false,
+            http3: None,
         }
     }
 

--- a/crates/rginx-http/src/state/tls_runtime/listeners.rs
+++ b/crates/rginx-http/src/state/tls_runtime/listeners.rs
@@ -9,11 +9,14 @@ pub(super) fn tls_listener_status_snapshots(
         .map(|listener| {
             let sni_names = tls_listener_sni_names(config, listener.tls_enabled());
             let tls = listener.server.tls.as_ref();
+            let http3 = listener.http3.as_ref();
             TlsListenerStatusSnapshot {
                 listener_id: listener.id.clone(),
                 listener_name: listener.name.clone(),
                 listen_addr: listener.server.listen_addr,
                 tls_enabled: listener.tls_enabled(),
+                http3_enabled: http3.is_some(),
+                http3_listen_addr: http3.map(|http3| http3.listen_addr),
                 default_certificate: listener.server.default_certificate.clone(),
                 versions: tls.and_then(|tls| {
                     tls.versions.as_ref().map(|versions| {
@@ -26,6 +29,10 @@ pub(super) fn tls_listener_status_snapshots(
                 alpn_protocols: tls
                     .and_then(|tls| tls.alpn_protocols.clone())
                     .unwrap_or_else(|| vec!["h2".to_string(), "http/1.1".to_string()]),
+                http3_versions: http3
+                    .map(|_| vec![tls_version_label(rginx_core::TlsVersion::Tls13).to_string()])
+                    .unwrap_or_default(),
+                http3_alpn_protocols: http3.map(|_| vec!["h3".to_string()]).unwrap_or_default(),
                 session_resumption_enabled: tls.map(|tls| tls.session_resumption != Some(false)),
                 session_tickets_enabled: tls.map(|tls| {
                     tls.session_resumption != Some(false) && tls.session_tickets != Some(false)

--- a/crates/rginx-http/src/tls/acceptor.rs
+++ b/crates/rginx-http/src/tls/acceptor.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use rginx_core::{Error, Result, ServerClientAuthMode, ServerTls, VirtualHost};
+use rginx_core::{Error, Result, ServerClientAuthMode, ServerTls, TlsVersion, VirtualHost};
 use rustls::ServerConfig;
 use rustls::server::WebPkiClientVerifier;
 use tokio_rustls::TlsAcceptor;
@@ -23,6 +23,54 @@ pub fn build_tls_acceptor(
     default_vhost: &VirtualHost,
     vhosts: &[VirtualHost],
 ) -> Result<Option<TlsAcceptor>> {
+    build_tls_server_config(
+        default_tls,
+        default_certificate,
+        tls_termination_enabled,
+        default_vhost,
+        vhosts,
+        default_tls
+            .and_then(|tls| tls.alpn_protocols.clone())
+            .unwrap_or_else(|| vec!["h2".to_string(), "http/1.1".to_string()]),
+        false,
+    )
+    .map(|config| config.map(TlsAcceptor::from))
+}
+
+pub fn build_http3_server_config(
+    default_tls: Option<&ServerTls>,
+    default_certificate: Option<&str>,
+    tls_termination_enabled: bool,
+    default_vhost: &VirtualHost,
+    vhosts: &[VirtualHost],
+) -> Result<Option<Arc<ServerConfig>>> {
+    if default_tls.and_then(|tls| tls.client_auth.as_ref()).is_some() {
+        return Err(Error::Config(
+            "http3 currently does not support downstream client_auth on the same listener"
+                .to_string(),
+        ));
+    }
+
+    build_tls_server_config(
+        default_tls,
+        default_certificate,
+        tls_termination_enabled,
+        default_vhost,
+        vhosts,
+        vec!["h3".to_string()],
+        true,
+    )
+}
+
+fn build_tls_server_config(
+    default_tls: Option<&ServerTls>,
+    default_certificate: Option<&str>,
+    tls_termination_enabled: bool,
+    default_vhost: &VirtualHost,
+    vhosts: &[VirtualHost],
+    alpn_protocols: Vec<String>,
+    http3_only: bool,
+) -> Result<Option<Arc<ServerConfig>>> {
     if !tls_termination_enabled {
         return Ok(None);
     }
@@ -74,7 +122,7 @@ pub fn build_tls_acceptor(
     }
 
     let resolver = Arc::new(SniCertificateResolver::new(default_certs, all_certs));
-    let builder = build_server_config_builder(default_tls)?;
+    let builder = build_server_config_builder(default_tls, http3_only)?;
     let mut config = if let Some(client_auth) = default_tls.and_then(|tls| tls.client_auth.as_ref())
     {
         let roots = load_ca_cert_store(&client_auth.ca_cert_path)?;
@@ -106,23 +154,35 @@ pub fn build_tls_acceptor(
     } else {
         builder.with_no_client_auth().with_cert_resolver(resolver)
     };
-    config.alpn_protocols = default_tls
-        .and_then(|tls| tls.alpn_protocols.clone())
-        .unwrap_or_else(|| vec!["h2".to_string(), "http/1.1".to_string()])
-        .into_iter()
-        .map(String::into_bytes)
-        .collect();
+    config.alpn_protocols = alpn_protocols.into_iter().map(String::into_bytes).collect();
     apply_session_policy(&mut config, default_tls)?;
 
-    Ok(Some(TlsAcceptor::from(Arc::new(config))))
+    Ok(Some(Arc::new(config)))
 }
 
 fn build_server_config_builder(
     tls: Option<&ServerTls>,
+    http3_only: bool,
 ) -> Result<rustls::ConfigBuilder<ServerConfig, rustls::WantsVerifier>> {
     let provider =
         tls.map(build_crypto_provider).transpose()?.unwrap_or_else(default_crypto_provider);
     let builder = ServerConfig::builder_with_provider(Arc::new(provider));
+    if http3_only {
+        if let Some(versions) = tls.and_then(|tls| tls.versions.as_deref())
+            && !versions.contains(&TlsVersion::Tls13)
+        {
+            return Err(Error::Config(
+                "http3 requires TLS1.3 to remain enabled on the same listener".to_string(),
+            ));
+        }
+
+        return builder.with_protocol_versions(&[&rustls::version::TLS13]).map_err(|error| {
+            Error::Server(format!(
+                "failed to configure server TLS protocol versions for http3: {error}"
+            ))
+        });
+    }
+
     match tls.and_then(|tls| tls.versions.as_deref()) {
         Some(versions) => {
             builder.with_protocol_versions(&rustls_versions(versions)).map_err(|error| {

--- a/crates/rginx-http/src/tls/certificates.rs
+++ b/crates/rginx-http/src/tls/certificates.rs
@@ -1,11 +1,12 @@
-use std::fs::File;
-use std::io::BufReader;
 use std::path::Path;
 use std::sync::Arc;
 
 use rginx_core::{Error, Result, ServerCertificateBundle, ServerTls, VirtualHostTls};
 use rustls::RootCertStore;
-use rustls::pki_types::{CertificateDer, CertificateRevocationListDer};
+use rustls::pki_types::{
+    CertificateDer, CertificateRevocationListDer, PrivateKeyDer,
+    pem::{Error as PemError, PemObject},
+};
 
 use crate::pki::validate_der_certificate_revocation_list;
 
@@ -105,11 +106,10 @@ pub(crate) fn load_certified_key_bundle(
 pub(crate) fn load_certificate_chain_from_path(
     path: &Path,
 ) -> Result<Vec<rustls::pki_types::CertificateDer<'static>>> {
-    let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let certs = rustls_pemfile::certs(&mut reader)
+    let certs = CertificateDer::pem_file_iter(path)
+        .map_err(|error| map_pem_error(path, "certificates", error))?
         .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(Error::Io)?;
+        .map_err(|error| map_pem_error(path, "certificates", error))?;
 
     if certs.is_empty() {
         return Err(Error::Server(format!(
@@ -122,11 +122,10 @@ pub(crate) fn load_certificate_chain_from_path(
 }
 
 pub(crate) fn load_ca_cert_store(path: &Path) -> Result<RootCertStore> {
-    let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let certs = rustls_pemfile::certs(&mut reader)
+    let certs = CertificateDer::pem_file_iter(path)
+        .map_err(|error| map_pem_error(path, "CA certificates", error))?
         .collect::<std::result::Result<Vec<CertificateDer<'static>>, _>>()
-        .map_err(Error::Io)?;
+        .map_err(|error| map_pem_error(path, "CA certificates", error))?;
 
     let mut roots = RootCertStore::empty();
     if certs.is_empty() {
@@ -151,11 +150,10 @@ pub(crate) fn load_ca_cert_store(path: &Path) -> Result<RootCertStore> {
 pub(crate) fn load_certificate_revocation_lists(
     path: &Path,
 ) -> Result<Vec<CertificateRevocationListDer<'static>>> {
-    let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let crls = rustls_pemfile::crls(&mut reader)
+    let crls = CertificateRevocationListDer::pem_file_iter(path)
+        .map_err(|error| map_pem_error(path, "certificate revocation lists", error))?
         .collect::<std::result::Result<Vec<CertificateRevocationListDer<'static>>, _>>()
-        .map_err(Error::Io)?;
+        .map_err(|error| map_pem_error(path, "certificate revocation lists", error))?;
 
     if !crls.is_empty() {
         return Ok(crls);
@@ -173,14 +171,23 @@ fn validate_der_crl(path: &Path, der: &[u8]) -> Result<()> {
 pub(crate) fn load_private_key_from_path(
     path: &Path,
 ) -> Result<rustls::pki_types::PrivateKeyDer<'static>> {
-    let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::private_key(&mut reader).map_err(Error::Io)?.ok_or_else(|| {
-        Error::Server(format!(
+    match PrivateKeyDer::from_pem_file(path) {
+        Ok(key) => Ok(key),
+        Err(PemError::NoItemsFound) => Err(Error::Server(format!(
             "server TLS private key file `{}` did not contain a supported PEM private key",
             path.display()
-        ))
-    })
+        ))),
+        Err(error) => Err(map_pem_error(path, "private key", error)),
+    }
+}
+
+fn map_pem_error(path: &Path, item: &str, error: PemError) -> Error {
+    match error {
+        PemError::Io(error) => Error::Io(error),
+        other => {
+            Error::Server(format!("failed to parse {item} from `{}`: {other}", path.display()))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/rginx-http/src/tls/mod.rs
+++ b/crates/rginx-http/src/tls/mod.rs
@@ -11,6 +11,7 @@ mod sni;
 #[cfg(test)]
 mod tests;
 
+pub use acceptor::build_http3_server_config;
 pub use acceptor::build_tls_acceptor;
 #[cfg(test)]
 pub(crate) use sni::best_matching_wildcard_certificates;

--- a/crates/rginx-http/src/transition.rs
+++ b/crates/rginx-http/src/transition.rs
@@ -1,16 +1,26 @@
 use rginx_core::{ConfigSnapshot, Error, Result};
 
-const RELOADABLE_FIELDS: [&str; 6] = [
+const RELOADABLE_FIELDS: [&str; 10] = [
     "server.tls",
+    "server.http3.advertise_alt_svc",
+    "server.http3.alt_svc_max_age_secs",
     "listeners[].tls",
+    "listeners[].http3.advertise_alt_svc",
+    "listeners[].http3.alt_svc_max_age_secs",
     "servers[].tls",
     "upstreams[].tls",
     "upstreams[].server_name",
     "upstreams[].server_name_override",
 ];
 
-const RESTART_REQUIRED_FIELDS: [&str; 4] =
-    ["listen", "listeners[].listen", "runtime.worker_threads", "runtime.accept_workers"];
+const RESTART_REQUIRED_FIELDS: [&str; 6] = [
+    "listen",
+    "server.http3.listen",
+    "listeners[].listen",
+    "listeners[].http3.listen",
+    "runtime.worker_threads",
+    "runtime.accept_workers",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigTransitionKind {
@@ -76,15 +86,30 @@ pub fn plan_config_transition(
         .collect::<std::collections::HashMap<_, _>>();
 
     for current_listener in &current.listeners {
-        if let Some(next_listener) = next_by_id.get(current_listener.id.as_str())
-            && current_listener.server.listen_addr != next_listener.server.listen_addr
-        {
-            changes.push(format!(
-                "{}.listen {} -> {}",
-                current_listener.id,
-                current_listener.server.listen_addr,
-                next_listener.server.listen_addr
-            ));
+        if let Some(next_listener) = next_by_id.get(current_listener.id.as_str()) {
+            if current_listener.server.listen_addr != next_listener.server.listen_addr {
+                changes.push(format!(
+                    "{}.listen {} -> {}",
+                    current_listener.id,
+                    current_listener.server.listen_addr,
+                    next_listener.server.listen_addr
+                ));
+            }
+
+            let current_http3 = current_listener.http3.as_ref().map(|http3| http3.listen_addr);
+            let next_http3 = next_listener_http3(Some(next_listener));
+            if current_http3 != next_http3 {
+                changes.push(format!(
+                    "{}.http3.listen {} -> {}",
+                    current_listener.id,
+                    current_http3
+                        .map(|listen_addr| listen_addr.to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                    next_http3
+                        .map(|listen_addr| listen_addr.to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                ));
+            }
         }
     }
 
@@ -110,6 +135,10 @@ pub fn plan_config_transition(
     };
 
     ConfigTransitionPlan { kind, boundary, changed_restart_required_fields: changes }
+}
+
+fn next_listener_http3(listener: Option<&rginx_core::Listener>) -> Option<std::net::SocketAddr> {
+    listener.and_then(|listener| listener.http3.as_ref()).map(|http3| http3.listen_addr)
 }
 
 pub fn validate_config_transition(current: &ConfigSnapshot, next: &ConfigSnapshot) -> Result<()> {
@@ -159,6 +188,7 @@ mod tests {
                 server,
                 tls_termination_enabled: false,
                 proxy_protocol_enabled: false,
+                http3: None,
             }],
             default_vhost: VirtualHost {
                 id: "server".to_string(),
@@ -178,7 +208,11 @@ mod tests {
             boundary.reloadable_fields,
             vec![
                 "server.tls".to_string(),
+                "server.http3.advertise_alt_svc".to_string(),
+                "server.http3.alt_svc_max_age_secs".to_string(),
                 "listeners[].tls".to_string(),
+                "listeners[].http3.advertise_alt_svc".to_string(),
+                "listeners[].http3.alt_svc_max_age_secs".to_string(),
                 "servers[].tls".to_string(),
                 "upstreams[].tls".to_string(),
                 "upstreams[].server_name".to_string(),
@@ -189,7 +223,9 @@ mod tests {
             boundary.restart_required_fields,
             vec![
                 "listen".to_string(),
+                "server.http3.listen".to_string(),
                 "listeners[].listen".to_string(),
+                "listeners[].http3.listen".to_string(),
                 "runtime.worker_threads".to_string(),
                 "runtime.accept_workers".to_string(),
             ]
@@ -252,6 +288,7 @@ mod tests {
                 },
                 tls_termination_enabled: false,
                 proxy_protocol_enabled: false,
+                http3: None,
             },
         ];
 
@@ -260,5 +297,30 @@ mod tests {
         assert!(plan.changed_restart_required_fields.is_empty());
         validate_config_transition(&current, &next)
             .expect("listener add/remove should stay within the hot-reload boundary");
+    }
+
+    #[test]
+    fn planner_reports_restart_required_http3_listener_binding_changes() {
+        let mut current = snapshot("127.0.0.1:8443");
+        current.listeners[0].tls_termination_enabled = true;
+        current.listeners[0].http3 = Some(rginx_core::ListenerHttp3 {
+            listen_addr: "127.0.0.1:8443".parse().unwrap(),
+            advertise_alt_svc: true,
+            alt_svc_max_age: Duration::from_secs(3600),
+        });
+
+        let mut next = snapshot("127.0.0.1:8443");
+        next.listeners[0].tls_termination_enabled = true;
+        next.listeners[0].http3 = Some(rginx_core::ListenerHttp3 {
+            listen_addr: "127.0.0.1:9443".parse().unwrap(),
+            advertise_alt_svc: true,
+            alt_svc_max_age: Duration::from_secs(3600),
+        });
+
+        let plan = plan_config_transition(&current, &next);
+        assert_eq!(plan.kind, ConfigTransitionKind::RestartRequired);
+        assert!(plan.changed_restart_required_fields.iter().any(|change| {
+            change.contains("default.http3.listen 127.0.0.1:8443 -> 127.0.0.1:9443")
+        }));
     }
 }

--- a/crates/rginx-runtime/Cargo.toml
+++ b/crates/rginx-runtime/Cargo.toml
@@ -18,6 +18,7 @@ hyper.workspace = true
 hyper-rustls.workspace = true
 hyper-util.workspace = true
 libc = "0.2"
+quinn.workspace = true
 rginx-config = { path = "../rginx-config" }
 rginx-core = { path = "../rginx-core" }
 rginx-http = { path = "../rginx-http" }

--- a/crates/rginx-runtime/src/admin.rs
+++ b/crates/rginx-runtime/src/admin.rs
@@ -17,7 +17,7 @@ use tokio::task::{JoinError, JoinSet};
 
 const INSTALLED_CONFIG_PATH: &str = "/etc/rginx/rginx.ron";
 const INSTALLED_ADMIN_SOCKET_PATH: &str = "/run/rginx/admin.sock";
-const ADMIN_SNAPSHOT_SCHEMA_VERSION: u32 = 11;
+const ADMIN_SNAPSHOT_SCHEMA_VERSION: u32 = 12;
 const DEFAULT_RECENT_WINDOW_SECS: u64 = 60;
 const EXTENDED_RECENT_WINDOW_SECS: u64 = 300;
 

--- a/crates/rginx-runtime/src/bootstrap/listeners.rs
+++ b/crates/rginx-runtime/src/bootstrap/listeners.rs
@@ -426,7 +426,9 @@ fn bind_std_listener(listen_addr: std::net::SocketAddr) -> Result<StdTcpListener
 }
 
 fn bind_std_udp_socket(listen_addr: std::net::SocketAddr) -> Result<StdUdpSocket> {
-    StdUdpSocket::bind(listen_addr).map_err(Error::Io)
+    let socket = StdUdpSocket::bind(listen_addr)?;
+    socket.set_nonblocking(true)?;
+    Ok(socket)
 }
 
 #[cfg(test)]

--- a/crates/rginx-runtime/src/bootstrap/listeners.rs
+++ b/crates/rginx-runtime/src/bootstrap/listeners.rs
@@ -1,21 +1,23 @@
 use std::collections::{HashMap, HashSet};
-use std::net::TcpListener as StdTcpListener;
+use std::net::{TcpListener as StdTcpListener, UdpSocket as StdUdpSocket};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use rginx_core::{ConfigSnapshot, Error, Listener, Result};
+use rginx_core::{ConfigSnapshot, Error, Listener, Result, VirtualHost};
 use tokio::net::TcpListener;
 use tokio::sync::{Notify, watch};
 use tokio::task::JoinHandle;
 
-use crate::restart::ListenerHandle;
+use crate::restart::{InheritedListeners, ListenerHandle};
 
 pub(super) type ListenerGroupMap = HashMap<String, ListenerWorkerGroup>;
 
 pub(super) struct PreparedListenerWorkerGroup {
     listener: Listener,
     std_listener: Arc<StdTcpListener>,
+    std_udp_socket: Option<Arc<StdUdpSocket>>,
     worker_listeners: Vec<TcpListener>,
+    http3_endpoint: Option<quinn::Endpoint>,
 }
 
 pub(super) struct WorkerDrainGuard {
@@ -34,13 +36,18 @@ impl Drop for WorkerDrainGuard {
 pub(super) struct ListenerWorkerGroup {
     pub(super) listener: Listener,
     std_listener: Arc<StdTcpListener>,
+    std_udp_socket: Option<Arc<StdUdpSocket>>,
     shutdown_tx: watch::Sender<bool>,
     tasks: Vec<JoinHandle<Result<()>>>,
 }
 
 impl ListenerWorkerGroup {
     pub(super) fn restart_handle(&self) -> ListenerHandle {
-        ListenerHandle { listener: self.listener.clone(), std_listener: self.std_listener.clone() }
+        ListenerHandle {
+            listener: self.listener.clone(),
+            std_listener: self.std_listener.clone(),
+            std_udp_socket: self.std_udp_socket.clone(),
+        }
     }
 
     pub(super) fn initiate_shutdown(&self) {
@@ -59,23 +66,32 @@ impl ListenerWorkerGroup {
 }
 
 pub(super) async fn build_initial_listener_groups(
-    listeners: &[Listener],
-    accept_workers: usize,
-    mut inherited: HashMap<std::net::SocketAddr, StdTcpListener>,
+    config: &ConfigSnapshot,
+    mut inherited: InheritedListeners,
     http_state: rginx_http::SharedState,
     drain_completion_notify: Arc<Notify>,
 ) -> Result<ListenerGroupMap> {
     let mut groups = HashMap::new();
 
-    for listener in listeners {
-        let std_listener = match inherited.remove(&listener.server.listen_addr) {
+    for listener in &config.listeners {
+        let std_listener = match inherited.tcp.remove(&listener.server.listen_addr) {
             Some(listener_socket) => listener_socket,
             None => bind_std_listener(listener.server.listen_addr)?,
+        };
+        let std_udp_socket = match &listener.http3 {
+            Some(http3) => match inherited.udp.remove(&http3.listen_addr) {
+                Some(socket) => Some(Arc::new(socket)),
+                None => Some(Arc::new(bind_std_udp_socket(http3.listen_addr)?)),
+            },
+            None => None,
         };
         let prepared = prepare_listener_worker_group(
             listener.clone(),
             Arc::new(std_listener),
-            accept_workers,
+            std_udp_socket,
+            config.runtime.accept_workers,
+            &config.default_vhost,
+            &config.vhosts,
         )?;
         let group = activate_prepared_listener_worker_group(
             prepared,
@@ -89,6 +105,7 @@ pub(super) async fn build_initial_listener_groups(
 }
 
 pub(super) fn prepare_added_listener_bindings(
+    next_config: &ConfigSnapshot,
     next_listeners: &[Listener],
     accept_workers: usize,
     active_listener_groups: &ListenerGroupMap,
@@ -101,11 +118,23 @@ pub(super) fn prepare_added_listener_bindings(
         .collect::<HashSet<_>>();
     let active_addrs = active_listener_groups
         .values()
-        .map(|group| group.listener.server.listen_addr)
+        .flat_map(|group| {
+            group
+                .listener
+                .transport_bindings()
+                .into_iter()
+                .map(|binding| (binding.kind, binding.listen_addr))
+        })
         .collect::<HashSet<_>>();
     let draining_addrs = draining_listener_groups
         .iter()
-        .map(|group| group.listener.server.listen_addr)
+        .flat_map(|group| {
+            group
+                .listener
+                .transport_bindings()
+                .into_iter()
+                .map(|binding| (binding.kind, binding.listen_addr))
+        })
         .collect::<HashSet<_>>();
 
     let mut prepared = Vec::new();
@@ -119,18 +148,29 @@ pub(super) fn prepare_added_listener_bindings(
                 listener.name
             )));
         }
-        if active_addrs.contains(&listener.server.listen_addr)
-            || draining_addrs.contains(&listener.server.listen_addr)
-        {
-            return Err(Error::Server(format!(
-                "listener `{}` reuses listen address `{}` with a different listener identity during reload",
-                listener.name, listener.server.listen_addr
-            )));
+        for binding in listener.transport_bindings() {
+            let key = (binding.kind, binding.listen_addr);
+            if active_addrs.contains(&key) || draining_addrs.contains(&key) {
+                return Err(Error::Server(format!(
+                    "listener `{}` reuses {} listen address `{}` with a different listener identity during reload",
+                    listener.name,
+                    binding.kind.as_str(),
+                    binding.listen_addr
+                )));
+            }
         }
         prepared.push(prepare_listener_worker_group(
             listener.clone(),
             Arc::new(bind_std_listener(listener.server.listen_addr)?),
+            listener
+                .http3
+                .as_ref()
+                .map(|http3| bind_std_udp_socket(http3.listen_addr))
+                .transpose()?
+                .map(Arc::new),
             accept_workers,
+            &next_config.default_vhost,
+            &next_config.vhosts,
         )?);
     }
 
@@ -267,14 +307,32 @@ pub(super) async fn join_aborted_listener_worker_groups(
 fn prepare_listener_worker_group(
     listener: Listener,
     std_listener: Arc<StdTcpListener>,
+    std_udp_socket: Option<Arc<StdUdpSocket>>,
     accept_workers: usize,
+    default_vhost: &VirtualHost,
+    vhosts: &[VirtualHost],
 ) -> Result<PreparedListenerWorkerGroup> {
     let mut worker_listeners = Vec::new();
     for _worker_index in 0..accept_workers {
         worker_listeners.push(TcpListener::from_std(std_listener.try_clone()?)?);
     }
+    let http3_endpoint = match &std_udp_socket {
+        Some(socket) => Some(rginx_http::server::bind_http3_endpoint_with_socket(
+            &listener,
+            default_vhost,
+            vhosts,
+            socket.try_clone()?,
+        )?),
+        None => rginx_http::server::bind_http3_endpoint(&listener, default_vhost, vhosts)?,
+    };
 
-    Ok(PreparedListenerWorkerGroup { listener, std_listener, worker_listeners })
+    Ok(PreparedListenerWorkerGroup {
+        listener,
+        std_listener,
+        std_udp_socket,
+        worker_listeners,
+        http3_endpoint,
+    })
 }
 
 fn activate_prepared_listener_worker_group(
@@ -284,7 +342,9 @@ fn activate_prepared_listener_worker_group(
 ) -> ListenerWorkerGroup {
     let (shutdown_tx, _shutdown_rx) = watch::channel(false);
     let mut tasks = Vec::new();
-    let remaining_workers = Arc::new(AtomicUsize::new(prepared.worker_listeners.len()));
+    let remaining_workers = Arc::new(AtomicUsize::new(
+        prepared.worker_listeners.len() + usize::from(prepared.http3_endpoint.is_some()),
+    ));
 
     for (worker_index, listener_socket) in prepared.worker_listeners.into_iter().enumerate() {
         tracing::info!(
@@ -304,9 +364,32 @@ fn activate_prepared_listener_worker_group(
         }));
     }
 
+    if let Some(endpoint) = prepared.http3_endpoint {
+        tracing::info!(
+            listener = %prepared.listener.name,
+            listen = %prepared
+                .listener
+                .http3
+                .as_ref()
+                .map(|http3| http3.listen_addr)
+                .unwrap_or(prepared.listener.server.listen_addr),
+            "starting http3 accept worker"
+        );
+        let listener_id = prepared.listener.id.clone();
+        let http_state = http_state.clone();
+        let shutdown = shutdown_tx.subscribe();
+        let remaining_workers = remaining_workers.clone();
+        let drain_completion_notify = drain_completion_notify.clone();
+        tasks.push(tokio::spawn(async move {
+            let _drain_guard = WorkerDrainGuard { remaining_workers, drain_completion_notify };
+            rginx_http::server::serve_http3(endpoint, listener_id, http_state, shutdown).await
+        }));
+    }
+
     ListenerWorkerGroup {
         listener: prepared.listener,
         std_listener: prepared.std_listener,
+        std_udp_socket: prepared.std_udp_socket,
         shutdown_tx,
         tasks,
     }
@@ -342,6 +425,10 @@ fn bind_std_listener(listen_addr: std::net::SocketAddr) -> Result<StdTcpListener
     Ok(socket)
 }
 
+fn bind_std_udp_socket(listen_addr: std::net::SocketAddr) -> Result<StdUdpSocket> {
+    StdUdpSocket::bind(listen_addr).map_err(Error::Io)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -371,6 +458,26 @@ mod tests {
             },
             tls_termination_enabled: false,
             proxy_protocol_enabled: false,
+            http3: None,
+        }
+    }
+
+    fn config_with_listeners(listeners: Vec<Listener>) -> ConfigSnapshot {
+        ConfigSnapshot {
+            runtime: rginx_core::RuntimeSettings {
+                shutdown_timeout: std::time::Duration::from_secs(1),
+                worker_threads: None,
+                accept_workers: 1,
+            },
+            listeners,
+            default_vhost: rginx_core::VirtualHost {
+                id: "server".to_string(),
+                server_names: Vec::new(),
+                routes: Vec::new(),
+                tls: None,
+            },
+            vhosts: Vec::new(),
+            upstreams: HashMap::new(),
         }
     }
 
@@ -382,6 +489,7 @@ mod tests {
         ListenerWorkerGroup {
             listener,
             std_listener: Arc::new(std_listener),
+            std_udp_socket: None,
             shutdown_tx,
             tasks: Vec::new(),
         }
@@ -398,7 +506,10 @@ mod tests {
             active_listener.id.clone(),
             listener_group_with_socket(active_listener, std_listener),
         )]);
+        let next_config =
+            config_with_listeners(vec![listener("listener-b", "listener-b", listen_addr)]);
         let error = match prepare_added_listener_bindings(
+            &next_config,
             &[listener("listener-b", "listener-b", listen_addr)],
             1,
             &active_groups,
@@ -408,7 +519,7 @@ mod tests {
             Err(error) => error,
         };
 
-        assert!(error.to_string().contains("reuses listen address"));
+        assert!(error.to_string().contains("reuses tcp listen address"));
     }
 
     #[test]
@@ -421,7 +532,10 @@ mod tests {
             listener("listener-a", "listener-a", listen_addr),
             std_listener,
         )];
+        let next_config =
+            config_with_listeners(vec![listener("listener-b", "listener-b", listen_addr)]);
         let error = match prepare_added_listener_bindings(
+            &next_config,
             &[listener("listener-b", "listener-b", listen_addr)],
             1,
             &HashMap::new(),
@@ -431,6 +545,6 @@ mod tests {
             Err(error) => error,
         };
 
-        assert!(error.to_string().contains("reuses listen address"));
+        assert!(error.to_string().contains("reuses tcp listen address"));
     }
 }

--- a/crates/rginx-runtime/src/bootstrap/mod.rs
+++ b/crates/rginx-runtime/src/bootstrap/mod.rs
@@ -25,8 +25,7 @@ pub async fn run(config_path: PathBuf, config: ConfigSnapshot) -> Result<()> {
     let inherited_listeners = crate::restart::take_inherited_listeners_from_env()?;
     let drain_completion_notify = Arc::new(Notify::new());
     let mut active_listener_groups = build_initial_listener_groups(
-        &current_config.listeners,
-        current_config.runtime.accept_workers,
+        current_config.as_ref(),
         inherited_listeners,
         state.http.clone(),
         drain_completion_notify.clone(),

--- a/crates/rginx-runtime/src/bootstrap/reload.rs
+++ b/crates/rginx-runtime/src/bootstrap/reload.rs
@@ -18,6 +18,7 @@ pub(super) async fn handle_reload_signal(
 ) {
     match runtime_reload::prepare_reload(state).await {
         Ok(pending) => match prepare_added_listener_bindings(
+            &pending.next_config,
             &pending.next_config.listeners,
             pending.next_config.runtime.accept_workers,
             active_listener_groups,

--- a/crates/rginx-runtime/src/bootstrap/shutdown.rs
+++ b/crates/rginx-runtime/src/bootstrap/shutdown.rs
@@ -83,3 +83,153 @@ pub(super) async fn graceful_shutdown(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::future::pending;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use hyper::http::StatusCode;
+    use rginx_core::{
+        ConfigSnapshot, Listener, ReturnAction, Route, RouteAccessControl, RouteAction,
+        RouteMatcher, RuntimeSettings, Server, VirtualHost,
+    };
+    use tokio::sync::watch;
+
+    use super::*;
+
+    fn snapshot() -> ConfigSnapshot {
+        ConfigSnapshot {
+            runtime: RuntimeSettings {
+                shutdown_timeout: Duration::from_secs(1),
+                worker_threads: None,
+                accept_workers: 1,
+            },
+            listeners: vec![Listener {
+                id: "default".to_string(),
+                name: "default".to_string(),
+                server: Server {
+                    listen_addr: "127.0.0.1:0".parse().expect("socket addr should parse"),
+                    default_certificate: None,
+                    trusted_proxies: Vec::new(),
+                    keep_alive: true,
+                    max_headers: None,
+                    max_request_body_bytes: None,
+                    max_connections: None,
+                    header_read_timeout: None,
+                    request_body_read_timeout: None,
+                    response_write_timeout: None,
+                    access_log_format: None,
+                    tls: None,
+                },
+                tls_termination_enabled: false,
+                proxy_protocol_enabled: false,
+                http3: None,
+            }],
+            default_vhost: VirtualHost {
+                id: "server".to_string(),
+                server_names: Vec::new(),
+                routes: vec![Route {
+                    id: "server/routes[0]|exact:/".to_string(),
+                    matcher: RouteMatcher::Exact("/".to_string()),
+                    grpc_match: None,
+                    action: RouteAction::Return(ReturnAction {
+                        status: StatusCode::OK,
+                        location: String::new(),
+                        body: Some("ok\n".to_string()),
+                    }),
+                    access_control: RouteAccessControl::default(),
+                    rate_limit: None,
+                }],
+                tls: None,
+            },
+            vhosts: Vec::new(),
+            upstreams: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_waits_for_background_tasks_and_signals_shutdown() {
+        let state = RuntimeState::new(PathBuf::from("/tmp/rginx-shutdown-test.ron"), snapshot())
+            .expect("runtime state should build");
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let background_task_drained = Arc::new(AtomicBool::new(false));
+        let drained = background_task_drained.clone();
+        state.http.spawn_background_task(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            drained.store(true, Ordering::Relaxed);
+        });
+
+        let mut active_listener_groups = ListenerGroupMap::new();
+        let mut draining_listener_groups = Vec::new();
+        let mut admin_task = tokio::spawn(async { Ok::<(), std::io::Error>(()) });
+        let mut health_task = tokio::spawn(async {});
+        let mut ocsp_task = tokio::spawn(async {});
+
+        graceful_shutdown(
+            &state,
+            Duration::from_millis(200),
+            &shutdown_tx,
+            &mut active_listener_groups,
+            &mut draining_listener_groups,
+            &mut admin_task,
+            &mut health_task,
+            &mut ocsp_task,
+        )
+        .await
+        .expect("graceful shutdown should succeed");
+
+        assert!(*shutdown_rx.borrow());
+        assert!(background_task_drained.load(Ordering::Relaxed));
+        assert!(admin_task.is_finished());
+        assert!(health_task.is_finished());
+        assert!(ocsp_task.is_finished());
+        assert!(active_listener_groups.is_empty());
+        assert!(draining_listener_groups.is_empty());
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_aborts_pending_tasks_after_timeout() {
+        let state = RuntimeState::new(PathBuf::from("/tmp/rginx-shutdown-timeout.ron"), snapshot())
+            .expect("runtime state should build");
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let background_task_started = Arc::new(AtomicBool::new(false));
+        let started = background_task_started.clone();
+        state.http.spawn_background_task(async move {
+            started.store(true, Ordering::Relaxed);
+            pending::<()>().await;
+        });
+
+        let mut active_listener_groups = ListenerGroupMap::new();
+        let mut draining_listener_groups = Vec::new();
+        let mut admin_task = tokio::spawn(async { pending::<std::io::Result<()>>().await });
+        let mut health_task = tokio::spawn(async { pending::<()>().await });
+        let mut ocsp_task = tokio::spawn(async { pending::<()>().await });
+
+        tokio::task::yield_now().await;
+        graceful_shutdown(
+            &state,
+            Duration::from_millis(20),
+            &shutdown_tx,
+            &mut active_listener_groups,
+            &mut draining_listener_groups,
+            &mut admin_task,
+            &mut health_task,
+            &mut ocsp_task,
+        )
+        .await
+        .expect("timeout branch should still resolve successfully");
+
+        assert!(*shutdown_rx.borrow());
+        assert!(background_task_started.load(Ordering::Relaxed));
+        assert!(admin_task.is_finished());
+        assert!(health_task.is_finished());
+        assert!(ocsp_task.is_finished());
+        assert!(active_listener_groups.is_empty());
+        assert!(draining_listener_groups.is_empty());
+    }
+}

--- a/crates/rginx-runtime/src/health.rs
+++ b/crates/rginx-runtime/src/health.rs
@@ -226,6 +226,7 @@ mod tests {
                 server,
                 tls_termination_enabled: false,
                 proxy_protocol_enabled: false,
+                http3: None,
             }],
             default_vhost: VirtualHost {
                 id: "server".to_string(),

--- a/crates/rginx-runtime/src/ocsp.rs
+++ b/crates/rginx-runtime/src/ocsp.rs
@@ -426,12 +426,15 @@ mod tests {
         Client::builder(TokioExecutor::new()).build(connector)
     }
 
-    fn spawn_http_responder(status: &str, body: Vec<u8>) -> SocketAddr {
+    fn spawn_http_responder(
+        status: &str,
+        body: Vec<u8>,
+    ) -> (SocketAddr, std::thread::JoinHandle<()>) {
         let listener = TcpListener::bind(("127.0.0.1", 0)).expect("test responder should bind");
         let listen_addr = listener.local_addr().expect("responder addr should exist");
         let status = status.to_string();
 
-        thread::spawn(move || {
+        let handle = thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("request should connect");
             let mut buffer = [0_u8; 1024];
             let _ = stream.read(&mut buffer);
@@ -444,13 +447,14 @@ mod tests {
             stream.flush().expect("response should flush");
         });
 
-        listen_addr
+        (listen_addr, handle)
     }
 
     #[tokio::test]
     async fn fetch_ocsp_response_from_url_rejects_non_success_status() {
         let client = test_ocsp_client();
-        let responder = spawn_http_responder("500 Internal Server Error", b"fail".to_vec());
+        let (responder, responder_handle) =
+            spawn_http_responder("500 Internal Server Error", b"fail".to_vec());
 
         let error = fetch_ocsp_response_from_url(
             &client,
@@ -461,12 +465,13 @@ mod tests {
         .expect_err("HTTP 500 should be rejected");
 
         assert!(error.contains("responder returned HTTP 500"));
+        responder_handle.join().expect("responder thread should join");
     }
 
     #[tokio::test]
     async fn fetch_ocsp_response_from_url_rejects_empty_body() {
         let client = test_ocsp_client();
-        let responder = spawn_http_responder("200 OK", Vec::new());
+        let (responder, responder_handle) = spawn_http_responder("200 OK", Vec::new());
 
         let error = fetch_ocsp_response_from_url(
             &client,
@@ -477,13 +482,16 @@ mod tests {
         .expect_err("empty OCSP body should be rejected");
 
         assert!(error.contains("empty OCSP response body"));
+        responder_handle.join().expect("responder thread should join");
     }
 
     #[tokio::test]
     async fn fetch_ocsp_response_tries_multiple_responders_until_one_succeeds() {
         let client = test_ocsp_client();
-        let first = spawn_http_responder("500 Internal Server Error", b"nope".to_vec());
-        let second = spawn_http_responder("200 OK", b"valid-ocsp-response".to_vec());
+        let (first, first_handle) =
+            spawn_http_responder("500 Internal Server Error", b"nope".to_vec());
+        let (second, second_handle) =
+            spawn_http_responder("200 OK", b"valid-ocsp-response".to_vec());
 
         let response = fetch_ocsp_response(
             &client,
@@ -494,6 +502,8 @@ mod tests {
         .expect("second responder should succeed");
 
         assert_eq!(response, b"valid-ocsp-response".to_vec());
+        first_handle.join().expect("first responder thread should join");
+        second_handle.join().expect("second responder thread should join");
     }
 
     #[tokio::test]

--- a/crates/rginx-runtime/src/ocsp.rs
+++ b/crates/rginx-runtime/src/ocsp.rs
@@ -392,3 +392,156 @@ fn load_native_root_store() -> Result<RootCertStore, String> {
     }
     Ok(roots)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::io::{Read, Write};
+    use std::net::{SocketAddr, TcpListener};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::thread;
+
+    use super::*;
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+        let path =
+            env::temp_dir().join(format!("{prefix}-{}", NEXT_ID.fetch_add(1, Ordering::Relaxed)));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    fn test_ocsp_client() -> OcspClient {
+        let tls_config = ClientConfig::builder()
+            .with_root_certificates(RootCertStore::empty())
+            .with_no_client_auth();
+        let connector = HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .build();
+        Client::builder(TokioExecutor::new()).build(connector)
+    }
+
+    fn spawn_http_responder(status: &str, body: Vec<u8>) -> SocketAddr {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("test responder should bind");
+        let listen_addr = listener.local_addr().expect("responder addr should exist");
+        let status = status.to_string();
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("request should connect");
+            let mut buffer = [0_u8; 1024];
+            let _ = stream.read(&mut buffer);
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/ocsp-response\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).expect("response head should be written");
+            stream.write_all(&body).expect("response body should be written");
+            stream.flush().expect("response should flush");
+        });
+
+        listen_addr
+    }
+
+    #[tokio::test]
+    async fn fetch_ocsp_response_from_url_rejects_non_success_status() {
+        let client = test_ocsp_client();
+        let responder = spawn_http_responder("500 Internal Server Error", b"fail".to_vec());
+
+        let error = fetch_ocsp_response_from_url(
+            &client,
+            &format!("http://{responder}/ocsp"),
+            vec![1, 2, 3],
+        )
+        .await
+        .expect_err("HTTP 500 should be rejected");
+
+        assert!(error.contains("responder returned HTTP 500"));
+    }
+
+    #[tokio::test]
+    async fn fetch_ocsp_response_from_url_rejects_empty_body() {
+        let client = test_ocsp_client();
+        let responder = spawn_http_responder("200 OK", Vec::new());
+
+        let error = fetch_ocsp_response_from_url(
+            &client,
+            &format!("http://{responder}/ocsp"),
+            vec![4, 5, 6],
+        )
+        .await
+        .expect_err("empty OCSP body should be rejected");
+
+        assert!(error.contains("empty OCSP response body"));
+    }
+
+    #[tokio::test]
+    async fn fetch_ocsp_response_tries_multiple_responders_until_one_succeeds() {
+        let client = test_ocsp_client();
+        let first = spawn_http_responder("500 Internal Server Error", b"nope".to_vec());
+        let second = spawn_http_responder("200 OK", b"valid-ocsp-response".to_vec());
+
+        let response = fetch_ocsp_response(
+            &client,
+            &[format!("http://{first}/ocsp"), format!("http://{second}/ocsp")],
+            vec![7, 8, 9],
+        )
+        .await
+        .expect("second responder should succeed");
+
+        assert_eq!(response, b"valid-ocsp-response".to_vec());
+    }
+
+    #[tokio::test]
+    async fn write_ocsp_cache_file_creates_parent_directory_and_skips_unchanged_writes() {
+        let temp_dir = temp_dir("rginx-runtime-ocsp-cache");
+        let cache_path = temp_dir.join("nested").join("server.ocsp");
+
+        let first_write = write_ocsp_cache_file(&cache_path, b"fresh-ocsp-response")
+            .await
+            .expect("initial write should succeed");
+        let second_write = write_ocsp_cache_file(&cache_path, b"fresh-ocsp-response")
+            .await
+            .expect("unchanged write should succeed");
+
+        assert!(first_write);
+        assert!(!second_write);
+        assert_eq!(
+            tokio::fs::read(&cache_path).await.expect("cache file should be readable"),
+            b"fresh-ocsp-response"
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[tokio::test]
+    async fn handle_ocsp_refresh_failure_clears_oversized_cache_file() {
+        let temp_dir = temp_dir("rginx-runtime-ocsp-clear");
+        let cache_path = temp_dir.join("server.ocsp");
+        tokio::fs::write(&cache_path, vec![0_u8; rginx_http::MAX_OCSP_RESPONSE_BYTES + 1])
+            .await
+            .expect("oversized cache should be written");
+
+        let (message, cache_cleared) = handle_ocsp_refresh_failure(
+            Path::new("/tmp/unused-cert.pem"),
+            &cache_path,
+            rginx_core::OcspResponderPolicy::IssuerOrDelegated,
+            "refresh failed".to_string(),
+        )
+        .await;
+
+        assert!(cache_cleared);
+        assert!(message.contains("refresh failed"));
+        assert!(message.contains("cleared stale OCSP cache"));
+        assert_eq!(
+            tokio::fs::read(&cache_path).await.expect("cleared cache should be readable"),
+            Vec::<u8>::new()
+        );
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+}

--- a/crates/rginx-runtime/src/restart.rs
+++ b/crates/rginx-runtime/src/restart.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::io::{self, Write};
-use std::net::{SocketAddr, TcpListener as StdTcpListener};
+use std::net::{SocketAddr, TcpListener as StdTcpListener, UdpSocket as StdUdpSocket};
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::UnixStream as StdUnixStream;
 use std::path::Path;
@@ -23,26 +23,50 @@ const CHILD_READY_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct ListenerHandle {
     pub listener: Listener,
     pub std_listener: Arc<StdTcpListener>,
+    pub std_udp_socket: Option<Arc<StdUdpSocket>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum InheritedSocketKind {
+    Tcp,
+    Udp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct InheritedListenerFd {
+    kind: InheritedSocketKind,
     listen_addr: SocketAddr,
     fd: RawFd,
 }
 
+pub struct InheritedListeners {
+    pub tcp: HashMap<SocketAddr, StdTcpListener>,
+    pub udp: HashMap<SocketAddr, StdUdpSocket>,
+}
+
 pub async fn restart(config_path: &Path, listener_handles: &[ListenerHandle]) -> Result<()> {
     let executable = env::current_exe().map_err(Error::Io)?;
-    let inherited = listener_handles
-        .iter()
-        .map(|handle| {
-            set_fd_inheritable(handle.std_listener.as_raw_fd())?;
-            Ok(InheritedListenerFd {
-                listen_addr: handle.listener.server.listen_addr,
-                fd: handle.std_listener.as_raw_fd(),
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let mut inherited = Vec::new();
+    for handle in listener_handles {
+        set_fd_inheritable(handle.std_listener.as_raw_fd())?;
+        inherited.push(InheritedListenerFd {
+            kind: InheritedSocketKind::Tcp,
+            listen_addr: handle.listener.server.listen_addr,
+            fd: handle.std_listener.as_raw_fd(),
+        });
+
+        if let Some(http3) = &handle.listener.http3
+            && let Some(std_udp_socket) = &handle.std_udp_socket
+        {
+            set_fd_inheritable(std_udp_socket.as_raw_fd())?;
+            inherited.push(InheritedListenerFd {
+                kind: InheritedSocketKind::Udp,
+                listen_addr: http3.listen_addr,
+                fd: std_udp_socket.as_raw_fd(),
+            });
+        }
+    }
 
     let (ready_parent, ready_child) = StdUnixStream::pair().map_err(Error::Io)?;
     set_fd_inheritable(ready_child.as_raw_fd())?;
@@ -92,9 +116,9 @@ pub async fn restart(config_path: &Path, listener_handles: &[ListenerHandle]) ->
     }
 }
 
-pub fn take_inherited_listeners_from_env() -> Result<HashMap<SocketAddr, StdTcpListener>> {
+pub fn take_inherited_listeners_from_env() -> Result<InheritedListeners> {
     let Some(raw) = env::var_os(INHERITED_LISTENERS_ENV) else {
-        return Ok(HashMap::new());
+        return Ok(InheritedListeners { tcp: HashMap::new(), udp: HashMap::new() });
     };
     let raw = raw
         .into_string()
@@ -102,17 +126,26 @@ pub fn take_inherited_listeners_from_env() -> Result<HashMap<SocketAddr, StdTcpL
     let inherited = serde_json::from_str::<Vec<InheritedListenerFd>>(&raw)
         .map_err(|error| Error::Server(format!("failed to decode inherited listeners: {error}")))?;
 
-    let mut by_addr = HashMap::new();
+    let mut tcp = HashMap::new();
+    let mut udp = HashMap::new();
     for entry in inherited {
-        let listener = unsafe { StdTcpListener::from_raw_fd(entry.fd) };
-        listener.set_nonblocking(true)?;
-        by_addr.insert(entry.listen_addr, listener);
+        match entry.kind {
+            InheritedSocketKind::Tcp => {
+                let listener = unsafe { StdTcpListener::from_raw_fd(entry.fd) };
+                listener.set_nonblocking(true)?;
+                tcp.insert(entry.listen_addr, listener);
+            }
+            InheritedSocketKind::Udp => {
+                let socket = unsafe { StdUdpSocket::from_raw_fd(entry.fd) };
+                udp.insert(entry.listen_addr, socket);
+            }
+        }
     }
 
     unsafe {
         env::remove_var(INHERITED_LISTENERS_ENV);
     }
-    Ok(by_addr)
+    Ok(InheritedListeners { tcp, udp })
 }
 
 pub fn notify_ready_if_requested() -> Result<()> {
@@ -152,11 +185,14 @@ fn set_fd_inheritable(fd: RawFd) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use std::env;
-    use std::net::{SocketAddr, TcpListener as StdTcpListener};
+    use std::net::{SocketAddr, TcpListener as StdTcpListener, UdpSocket as StdUdpSocket};
     use std::os::fd::AsRawFd;
     use std::sync::Mutex;
 
-    use super::{INHERITED_LISTENERS_ENV, InheritedListenerFd, take_inherited_listeners_from_env};
+    use super::{
+        INHERITED_LISTENERS_ENV, InheritedListenerFd, InheritedSocketKind,
+        take_inherited_listeners_from_env,
+    };
 
     static INHERITED_LISTENERS_ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -169,7 +205,8 @@ mod tests {
 
         let inherited =
             take_inherited_listeners_from_env().expect("inherited listeners should load");
-        assert!(inherited.is_empty());
+        assert!(inherited.tcp.is_empty());
+        assert!(inherited.udp.is_empty());
     }
 
     #[test]
@@ -180,16 +217,30 @@ mod tests {
         let listen_addr: SocketAddr = listener.local_addr().expect("listener addr should exist");
         let fd = listener.as_raw_fd();
         std::mem::forget(listener);
+        let udp_socket = StdUdpSocket::bind(("127.0.0.1", 0)).expect("udp socket should bind");
+        let udp_listen_addr: SocketAddr =
+            udp_socket.local_addr().expect("udp socket addr should exist");
+        let udp_fd = udp_socket.as_raw_fd();
+        std::mem::forget(udp_socket);
 
-        let encoded = serde_json::to_string(&vec![InheritedListenerFd { listen_addr, fd }])
-            .expect("listener map should encode");
+        let encoded = serde_json::to_string(&vec![
+            InheritedListenerFd { kind: InheritedSocketKind::Tcp, listen_addr, fd },
+            InheritedListenerFd {
+                kind: InheritedSocketKind::Udp,
+                listen_addr: udp_listen_addr,
+                fd: udp_fd,
+            },
+        ])
+        .expect("listener map should encode");
         unsafe {
             env::set_var(INHERITED_LISTENERS_ENV, encoded);
         }
 
         let inherited =
             take_inherited_listeners_from_env().expect("inherited listeners should load");
-        assert_eq!(inherited.len(), 1);
-        assert!(inherited.contains_key(&listen_addr));
+        assert_eq!(inherited.tcp.len(), 1);
+        assert_eq!(inherited.udp.len(), 1);
+        assert!(inherited.tcp.contains_key(&listen_addr));
+        assert!(inherited.udp.contains_key(&udp_listen_addr));
     }
 }

--- a/crates/rginx-runtime/src/restart.rs
+++ b/crates/rginx-runtime/src/restart.rs
@@ -137,6 +137,7 @@ pub fn take_inherited_listeners_from_env() -> Result<InheritedListeners> {
             }
             InheritedSocketKind::Udp => {
                 let socket = unsafe { StdUdpSocket::from_raw_fd(entry.fd) };
+                socket.set_nonblocking(true)?;
                 udp.insert(entry.listen_addr, socket);
             }
         }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,21 @@
+# rginx is Linux-only and the release pipeline only produces Linux artifacts.
+[graph]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+]
+
+[licenses]
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8

--- a/scripts/nginx_compare/configs.py
+++ b/scripts/nginx_compare/configs.py
@@ -87,7 +87,7 @@ def rginx_proxy_config(port: int, upstream_port: int) -> str:
     )
 
 
-def rginx_tls_return_config(port: int, cert_path: pathlib.Path, key_path: pathlib.Path) -> str:
+def _rginx_return_config_with_server_extra(port: int, server_extra: str) -> str:
     return textwrap.dedent(
         f"""\
         Config(
@@ -99,10 +99,7 @@ def rginx_tls_return_config(port: int, cert_path: pathlib.Path, key_path: pathli
             server: ServerConfig(
                 listen: "127.0.0.1:{port}",
                 keep_alive: Some(true),
-                tls: Some(ServerTlsConfig(
-                    cert_path: "{cert_path}",
-                    key_path: "{key_path}",
-                )),
+{server_extra}
             ),
             upstreams: [],
             locations: [
@@ -127,54 +124,41 @@ def rginx_tls_return_config(port: int, cert_path: pathlib.Path, key_path: pathli
         )
         """
     )
+
+
+def rginx_tls_return_config(port: int, cert_path: pathlib.Path, key_path: pathlib.Path) -> str:
+    server_extra = textwrap.indent(
+        textwrap.dedent(
+            f"""\
+            tls: Some(ServerTlsConfig(
+                cert_path: "{cert_path}",
+                key_path: "{key_path}",
+            )),
+            """
+        ).rstrip(),
+        " " * 16,
+    )
+    return _rginx_return_config_with_server_extra(port, server_extra)
 
 
 def rginx_http3_return_config(port: int, cert_path: pathlib.Path, key_path: pathlib.Path) -> str:
-    return textwrap.dedent(
-        f"""\
-        Config(
-            runtime: RuntimeConfig(
-                shutdown_timeout_secs: 5,
-                worker_threads: Some({BENCHMARK_WORKERS}),
-                accept_workers: Some({BENCHMARK_WORKERS}),
-            ),
-            server: ServerConfig(
-                listen: "127.0.0.1:{port}",
-                keep_alive: Some(true),
-                server_names: ["localhost"],
-                tls: Some(ServerTlsConfig(
-                    cert_path: "{cert_path}",
-                    key_path: "{key_path}",
-                )),
-                http3: Some(Http3Config(
-                    advertise_alt_svc: Some(true),
-                    alt_svc_max_age_secs: Some(7200),
-                )),
-            ),
-            upstreams: [],
-            locations: [
-                LocationConfig(
-                    matcher: Exact("/-/ready"),
-                    handler: Return(
-                        status: 200,
-                        location: "",
-                        body: Some("ready\\n"),
-                    ),
-                ),
-                LocationConfig(
-                    matcher: Exact("/"),
-                    handler: Return(
-                        status: 200,
-                        location: "",
-                        body: Some("ok\\n"),
-                    ),
-                ),
-            ],
-            servers: [],
-        )
-        """
+    server_extra = textwrap.indent(
+        textwrap.dedent(
+            f"""\
+            server_names: ["localhost"],
+            tls: Some(ServerTlsConfig(
+                cert_path: "{cert_path}",
+                key_path: "{key_path}",
+            )),
+            http3: Some(Http3Config(
+                advertise_alt_svc: Some(true),
+                alt_svc_max_age_secs: Some(7200),
+            )),
+            """
+        ).rstrip(),
+        " " * 16,
     )
-    
+    return _rginx_return_config_with_server_extra(port, server_extra)
 
 def rginx_grpc_proxy_config(
     port: int,

--- a/scripts/nginx_compare/configs.py
+++ b/scripts/nginx_compare/configs.py
@@ -129,6 +129,53 @@ def rginx_tls_return_config(port: int, cert_path: pathlib.Path, key_path: pathli
     )
 
 
+def rginx_http3_return_config(port: int, cert_path: pathlib.Path, key_path: pathlib.Path) -> str:
+    return textwrap.dedent(
+        f"""\
+        Config(
+            runtime: RuntimeConfig(
+                shutdown_timeout_secs: 5,
+                worker_threads: Some({BENCHMARK_WORKERS}),
+                accept_workers: Some({BENCHMARK_WORKERS}),
+            ),
+            server: ServerConfig(
+                listen: "127.0.0.1:{port}",
+                keep_alive: Some(true),
+                server_names: ["localhost"],
+                tls: Some(ServerTlsConfig(
+                    cert_path: "{cert_path}",
+                    key_path: "{key_path}",
+                )),
+                http3: Some(Http3Config(
+                    advertise_alt_svc: Some(true),
+                    alt_svc_max_age_secs: Some(7200),
+                )),
+            ),
+            upstreams: [],
+            locations: [
+                LocationConfig(
+                    matcher: Exact("/-/ready"),
+                    handler: Return(
+                        status: 200,
+                        location: "",
+                        body: Some("ready\\n"),
+                    ),
+                ),
+                LocationConfig(
+                    matcher: Exact("/"),
+                    handler: Return(
+                        status: 200,
+                        location: "",
+                        body: Some("ok\\n"),
+                    ),
+                ),
+            ],
+            servers: [],
+        )
+        """
+    )
+    
+
 def rginx_grpc_proxy_config(
     port: int,
     cert_path: pathlib.Path,

--- a/scripts/nginx_compare/render.py
+++ b/scripts/nginx_compare/render.py
@@ -48,7 +48,7 @@ def render_markdown(
         "# rginx vs nginx performance snapshot",
         "",
         "- Environment: Docker / Debian trixie",
-        f"- Benchmark tools: Python HTTP/1.1 keepalive runner for {requests} requests / concurrency {concurrency}, `curl` threadpool for TLS / HTTP2 / gRPC / grpc-web",
+        f"- Benchmark tools: Python HTTP/1.1 keepalive runner for {requests} requests / concurrency {concurrency}, `curl` threadpool for TLS / HTTP2 / HTTP3 / gRPC / grpc-web",
         f"- Reported values: median of {rounds} rounds",
         f"- rginx: `{rginx_version_text}`",
         f"- nginx: `{nginx_version_text}` (ref `{nginx_ref}`, source commit `{nginx_commit}`)",
@@ -116,7 +116,8 @@ def render_markdown(
             "",
             "- The goal is repeatable relative comparison inside the same trixie container, not a universal headline benchmark.",
             "- Reported throughput, latency, and reload numbers are medians across repeated rounds rather than a single sample.",
-            "- HTTP/1.1 direct/proxy scenarios use a built-in Python keepalive client; TLS, HTTP/2, gRPC, and grpc-web scenarios use concurrent `curl` processes.",
+            "- HTTP/1.1 direct/proxy scenarios use a built-in Python keepalive client; TLS, HTTP/2, HTTP/3, gRPC, and grpc-web scenarios use concurrent `curl` processes.",
+            "- HTTP/3 is currently benchmarked only for `rginx`; the nginx comparison build in this harness does not include QUIC/HTTP/3 support.",
             "- `grpc-web` is currently benchmarked only for `rginx`; `NGINX OSS` is recorded as unsupported because it has no native grpc-web translation path.",
             "- Add larger samples, repeated runs, TLS upstream verification variants, RSS/CPU sampling, and reload drain behavior before turning these numbers into external claims.",
         ]

--- a/scripts/nginx_compare/scenarios.py
+++ b/scripts/nginx_compare/scenarios.py
@@ -19,6 +19,7 @@ from configs import (
     nginx_return_config,
     nginx_tls_return_config,
     rginx_grpc_proxy_config,
+    rginx_http3_return_config,
     rginx_proxy_config,
     rginx_reload_config,
     rginx_return_config,
@@ -93,6 +94,7 @@ def run_comparison(
                 "return": {"rginx": reserve_port(), "nginx": reserve_port()},
                 "proxy": {"rginx": reserve_port(), "nginx": reserve_port()},
                 "https_return": {"rginx": reserve_port(), "nginx": reserve_port()},
+                "http3_return": {"rginx": reserve_port()},
                 "grpc": {"rginx": reserve_port(), "nginx": reserve_port()},
                 "reload": {"rginx": reserve_port(), "nginx": reserve_port()},
             }
@@ -100,6 +102,7 @@ def run_comparison(
             rginx_return_path = build_root / "rginx-return.ron"
             rginx_proxy_path = build_root / "rginx-proxy.ron"
             rginx_tls_return_path = build_root / "rginx-tls-return.ron"
+            rginx_http3_return_path = build_root / "rginx-http3-return.ron"
             rginx_grpc_path = build_root / "rginx-grpc.ron"
             rginx_reload_path = build_root / "rginx-reload.ron"
             nginx_return_dir = build_root / "nginx-return"
@@ -130,6 +133,14 @@ def run_comparison(
                 rginx_tls_return_path,
                 rginx_tls_return_config(
                     int(port_plan["https_return"]["rginx"]),
+                    frontend_cert,
+                    frontend_key,
+                ),
+            )
+            write_text(
+                rginx_http3_return_path,
+                rginx_http3_return_config(
+                    int(port_plan["http3_return"]["rginx"]),
                     frontend_cert,
                     frontend_key,
                 ),
@@ -274,6 +285,7 @@ def run_comparison(
 
             https_flags = ["--http1.1", "--insecure"]
             http2_flags = ["--http2", "--insecure"]
+            http3_flags = ["--http3-only", "--insecure"]
             grpc_flags = ["--http2", "--insecure", "--request", "POST", "--data-binary", "@-"]
             grpc_headers = ["content-type: application/grpc", "te: trailers"]
             grpc_body = grpc_frame(b"ping")
@@ -374,6 +386,25 @@ def run_comparison(
             results.append(
                 collect_rounds(lambda: run_single_server_curl_benchmark(
                     server_name="rginx",
+                    scenario_name="http3_return_200",
+                    launch_command=[str(rginx_bin), "--config", str(rginx_http3_return_path)],
+                    launch_cwd=workspace,
+                    launch_env=rginx_env,
+                    ready_tls_enabled=True,
+                    port=port_plan["http3_return"]["rginx"],
+                    work_dir=out_dir,
+                    url=f"https://127.0.0.1:{port_plan['http3_return']['rginx']}/",
+                    flags=http3_flags,
+                    headers=[],
+                    body=None,
+                    timeout_secs=10.0,
+                    requests=requests,
+                    concurrency=concurrency,
+                ))
+            )
+            results.append(
+                collect_rounds(lambda: run_single_server_curl_benchmark(
+                    server_name="rginx",
                     scenario_name="grpc_unary",
                     launch_command=[str(rginx_bin), "--config", str(rginx_grpc_path)],
                     launch_cwd=workspace,
@@ -462,6 +493,11 @@ def run_comparison(
 
             unsupported.extend(
                 [
+                    UnsupportedScenario(
+                        server="nginx",
+                        scenario="http3_return_200",
+                        reason="nginx compare harness does not build QUIC/HTTP/3 support",
+                    ),
                     UnsupportedScenario(
                         server="nginx",
                         scenario="grpc_web_binary",

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -150,9 +150,9 @@ WORKSPACE_VERSION="$(workspace_version)"
 
 run_step cargo fmt --all --check
 run_step ./scripts/test-fast.sh
+run_step ./scripts/run-clippy-gate.sh
 run_step ./scripts/test-slow.sh
 run_step ./scripts/run-tls-gate.sh
-run_step cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
 log "running: cargo run -p rginx -- --version"
 VERSION_OUTPUT="$(cargo run -p rginx -- --version | tail -n 1)"

--- a/scripts/run-benchmark-matrix.py
+++ b/scripts/run-benchmark-matrix.py
@@ -77,12 +77,14 @@ def benchmark(
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Run the benchmark matrix for HTTP, TLS, HTTP/2, gRPC, and grpc-web."
+        description="Run the benchmark matrix for HTTP, TLS, HTTP/2, HTTP/3, gRPC, and grpc-web."
     )
     parser.add_argument("--http1-url")
     parser.add_argument("--https-url")
     parser.add_argument("--http2-url")
+    parser.add_argument("--http3-url")
     parser.add_argument("--grpc-url")
+    parser.add_argument("--grpc-http3-url")
     parser.add_argument("--grpc-web-url")
     parser.add_argument("--grpc-web-text-url")
     parser.add_argument(
@@ -114,12 +116,26 @@ def main() -> int:
         scenarios.append(
             Scenario("http2_tls", args.http2_url, ["--http2", "--insecure"], [])
         )
+    if args.http3_url:
+        scenarios.append(
+            Scenario("http3_tls", args.http3_url, ["--http3-only", "--insecure"], [])
+        )
     if args.grpc_url:
         scenarios.append(
             Scenario(
                 "grpc_h2",
                 args.grpc_url,
                 ["--http2", "--insecure", "--request", "POST", "--data-binary", "@-"],
+                ["content-type: application/grpc", "te: trailers"],
+                grpc_body,
+            )
+        )
+    if args.grpc_http3_url:
+        scenarios.append(
+            Scenario(
+                "grpc_h3",
+                args.grpc_http3_url,
+                ["--http3-only", "--insecure", "--request", "POST", "--data-binary", "@-"],
                 ["content-type: application/grpc", "te: trailers"],
                 grpc_body,
             )
@@ -148,8 +164,8 @@ def main() -> int:
     if not scenarios:
         parser.error(
             "at least one benchmark URL must be provided; "
-            "supported flags are --http1-url, --https-url, --http2-url, "
-            "--grpc-url, --grpc-web-url, and --grpc-web-text-url"
+            "supported flags are --http1-url, --https-url, --http2-url, --http3-url, "
+            "--grpc-url, --grpc-http3-url, --grpc-web-url, and --grpc-web-text-url"
         )
 
     rows = []

--- a/scripts/run-clippy-gate.sh
+++ b/scripts/run-clippy-gate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-$0}"
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

--- a/scripts/run-soak.sh
+++ b/scripts/run-soak.sh
@@ -58,8 +58,11 @@ fi
 matrix=(
     "phase1|HTTP/1.1 request ID and plain proxy path"
     "http2|TLS termination and inbound HTTP/2"
+    "http3|downstream HTTP/3 ingress, Alt-Svc, and middleware parity"
     "upstream_http2|HTTPS upstream ALPN HTTP/2"
+    "upstream_http3|explicit HTTP/3 upstream proxy path"
     "grpc_proxy|gRPC and grpc-web proxy path"
+    "grpc_http3|gRPC, grpc-web, and health checks over HTTP/3"
     "upgrade|Upgrade and WebSocket tunnel path"
     "reload|reload and restart handoff stability"
     "dns_refresh|hostname upstream DNS refresh"

--- a/scripts/run-tls-gate.sh
+++ b/scripts/run-tls-gate.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-$0}"
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${ROOT_DIR}"
+
 cargo test -p rginx --locked \
   --test tls_policy \
   --test downstream_mtls \
   --test upstream_mtls \
   --test upstream_http2 \
+  --test http3 \
+  --test upstream_http3 \
+  --test grpc_http3 \
   --test upstream_server_name \
   --test grpc_proxy \
   --test access_log \

--- a/scripts/test-fast.sh
+++ b/scripts/test-fast.sh
@@ -12,9 +12,21 @@ log() {
 cd "${ROOT_DIR}"
 
 log "running fast unit and crate-local tests"
-cargo test -p rginx-core --lib --locked --quiet -- --test-threads=1
-cargo test -p rginx-config --lib --locked --quiet -- --test-threads=1
-cargo test -p rginx-http --lib --locked --quiet -- --test-threads=1
-cargo test -p rginx-runtime --lib --locked --quiet -- --test-threads=1
-cargo test -p rginx-observability --lib --locked --quiet -- --test-threads=1
+
+matrix=(
+    "rginx-core|crate-local core model and config invariants"
+    "rginx-config|config compile and validate paths, including HTTP/3 listener metadata"
+    "rginx-http|transport, proxy, TLS, and HTTP/3 runtime unit coverage"
+    "rginx-runtime|reload/restart orchestration and listener bootstrap coverage"
+    "rginx-observability|logging and tracing setup"
+)
+
+for entry in "${matrix[@]}"; do
+    crate_name="${entry%%|*}"
+    label="${entry#*|}"
+    log "running ${crate_name}: ${label}"
+    cargo test -p "${crate_name}" --lib --locked --quiet -- --test-threads=1
+done
+
+log "running rginx binary unit tests"
 cargo test -p rginx --bin rginx --locked --quiet -- --test-threads=1

--- a/scripts/test-slow.sh
+++ b/scripts/test-slow.sh
@@ -30,7 +30,11 @@ for test_name in "${required_http3_targets[@]}"; do
 done
 
 mapfile -t tests < <(
-    find "${ROOT_DIR}/crates/rginx-app/tests" -maxdepth 1 -type f -name '*.rs' -printf '%f\n' |
+    find "${ROOT_DIR}/crates/rginx-app/tests" -maxdepth 1 -type f -name '*.rs' |
+        while IFS= read -r path; do
+            file_name="${path##*/}"
+            printf '%s\n' "${file_name%.rs}"
+        done |
         sed 's/\.rs$//' |
         sort
 )

--- a/scripts/test-slow.sh
+++ b/scripts/test-slow.sh
@@ -12,4 +12,30 @@ log() {
 cd "${ROOT_DIR}"
 
 log "running slow integration tests"
-cargo test -p rginx --tests --locked --quiet -- --test-threads=1
+
+required_http3_targets=(
+    "http3"
+    "upstream_http3"
+    "grpc_http3"
+    "reload"
+    "admin"
+    "check"
+)
+
+for test_name in "${required_http3_targets[@]}"; do
+    if [[ ! -f "${ROOT_DIR}/crates/rginx-app/tests/${test_name}.rs" ]]; then
+        printf '[test-slow] missing required HTTP/3 gate target: %s\n' "${test_name}" >&2
+        exit 1
+    fi
+done
+
+mapfile -t tests < <(
+    find "${ROOT_DIR}/crates/rginx-app/tests" -maxdepth 1 -type f -name '*.rs' -printf '%f\n' |
+        sed 's/\.rs$//' |
+        sort
+)
+
+for test_name in "${tests[@]}"; do
+    log "running ${test_name}"
+    cargo test -p rginx --test "${test_name}" --locked --quiet -- --test-threads=1
+done


### PR DESCRIPTION
## Summary
- complete the staged HTTP/3 delivery plan through Phase 8 across config, runtime, downstream, upstream, gRPC, health checks, reload/restart, and release tooling
- add dedicated downstream/upstream/gRPC over HTTP/3 integration coverage plus HTTP/3 drain and restart regression tests
- wire HTTP/3 into the default validation gates, clippy gate, soak scripts, benchmark matrix, and bump the workspace version to `0.1.3-rc.10`

## Validation
- `./scripts/test-fast.sh`
- `./scripts/run-clippy-gate.sh`
- `./scripts/test-slow.sh`
- `./scripts/run-tls-gate.sh`
- `./scripts/run-soak.sh --iterations 1`
- `./scripts/prepare-release.sh --tag v0.1.3-rc.10 --allow-dirty --skip-fetch`
