### PR TITLE
http3: fix phase 7 follow-up issues before v0.1.3-rc.11 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,7 @@ dependencies = [
  "rasn-pkix",
  "rcgen",
  "rginx-config",
+ "rginx-core",
  "rginx-http",
  "rginx-observability",
  "rginx-runtime",

--- a/crates/rginx-app/Cargo.toml
+++ b/crates/rginx-app/Cargo.toml
@@ -18,6 +18,7 @@ anyhow.workspace = true
 clap.workspace = true
 libc = "0.2"
 rginx-config = { path = "../rginx-config" }
+rginx-core = { path = "../rginx-core" }
 rginx-http = { path = "../rginx-http" }
 rginx-observability = { path = "../rginx-observability" }
 rginx-runtime = { path = "../rginx-runtime" }

--- a/crates/rginx-app/src/main.rs
+++ b/crates/rginx-app/src/main.rs
@@ -45,68 +45,14 @@ fn main() -> anyhow::Result<()> {
             rginx_http::SharedState::from_config(config.clone())
                 .context("failed to initialize runtime dependencies")?;
 
-            print_check_success(
-                &cli.config,
-                CheckSummary {
-                    listener_model: listener_model(
-                        config.total_listener_count(),
-                        config.listeners.first().map(|listener| listener.id.as_str()),
-                        config.listeners.first().map(|listener| listener.name.as_str()),
-                    ),
-                    listener_count: config.total_listener_count(),
-                    listener_binding_count: config.total_listener_binding_count(),
-                    listeners: check_listener_summaries(&config),
-                    tls_enabled: config.tls_enabled(),
-                    http3_enabled: config.http3_enabled(),
-                    http3_early_data_enabled_listeners: config
-                        .listeners
-                        .iter()
-                        .filter(|listener| {
-                            listener.http3.as_ref().is_some_and(|http3| http3.early_data_enabled)
-                        })
-                        .count(),
-                    total_vhost_count: config.total_vhost_count(),
-                    total_route_count: config.total_route_count(),
-                    upstream_count: config.upstreams.len(),
-                    worker_threads: config.runtime.worker_threads,
-                    accept_workers: config.runtime.accept_workers,
-                    tls: tls_check_details(&config),
-                },
-            );
+            print_check_success(&cli.config, build_check_summary(&config));
             Ok(())
         }
         _ if cli.test_config => {
             rginx_http::SharedState::from_config(config.clone())
                 .context("failed to initialize runtime dependencies")?;
 
-            print_check_success(
-                &cli.config,
-                CheckSummary {
-                    listener_model: listener_model(
-                        config.total_listener_count(),
-                        config.listeners.first().map(|listener| listener.id.as_str()),
-                        config.listeners.first().map(|listener| listener.name.as_str()),
-                    ),
-                    listener_count: config.total_listener_count(),
-                    listener_binding_count: config.total_listener_binding_count(),
-                    listeners: check_listener_summaries(&config),
-                    tls_enabled: config.tls_enabled(),
-                    http3_enabled: config.http3_enabled(),
-                    http3_early_data_enabled_listeners: config
-                        .listeners
-                        .iter()
-                        .filter(|listener| {
-                            listener.http3.as_ref().is_some_and(|http3| http3.early_data_enabled)
-                        })
-                        .count(),
-                    total_vhost_count: config.total_vhost_count(),
-                    total_route_count: config.total_route_count(),
-                    upstream_count: config.upstreams.len(),
-                    worker_threads: config.runtime.worker_threads,
-                    accept_workers: config.runtime.accept_workers,
-                    tls: tls_check_details(&config),
-                },
-            );
+            print_check_success(&cli.config, build_check_summary(&config));
             Ok(())
         }
         None => {
@@ -556,6 +502,34 @@ fn listener_model(
     }
 }
 
+fn build_check_summary(config: &rginx_config::ConfigSnapshot) -> CheckSummary {
+    CheckSummary {
+        listener_model: listener_model(
+            config.total_listener_count(),
+            config.listeners.first().map(|listener| listener.id.as_str()),
+            config.listeners.first().map(|listener| listener.name.as_str()),
+        ),
+        listener_count: config.total_listener_count(),
+        listener_binding_count: config.total_listener_binding_count(),
+        listeners: check_listener_summaries(config),
+        tls_enabled: config.tls_enabled(),
+        http3_enabled: config.http3_enabled(),
+        http3_early_data_enabled_listeners: config
+            .listeners
+            .iter()
+            .filter(|listener| {
+                listener.http3.as_ref().is_some_and(|http3| http3.early_data_enabled)
+            })
+            .count(),
+        total_vhost_count: config.total_vhost_count(),
+        total_route_count: config.total_route_count(),
+        upstream_count: config.upstreams.len(),
+        worker_threads: config.runtime.worker_threads,
+        accept_workers: config.runtime.accept_workers,
+        tls: tls_check_details(config),
+    }
+}
+
 fn check_listener_summaries(config: &rginx_config::ConfigSnapshot) -> Vec<CheckListenerSummary> {
     config
         .listeners
@@ -574,7 +548,7 @@ fn check_listener_summaries(config: &rginx_config::ConfigSnapshot) -> Vec<CheckL
                         .map(|protocol| protocol.as_str().to_string())
                         .collect(),
                     worker_count: config.runtime.accept_workers,
-                    reuse_port_enabled: (binding.kind.as_str() == "udp")
+                    reuse_port_enabled: (binding.kind == rginx_core::ListenerTransportKind::Udp)
                         .then_some(config.runtime.accept_workers > 1),
                     advertise_alt_svc: binding.alt_svc_max_age.map(|_| binding.advertise_alt_svc),
                     alt_svc_max_age_secs: binding.alt_svc_max_age.map(|max_age| max_age.as_secs()),

--- a/crates/rginx-app/tests/http3.rs
+++ b/crates/rginx-app/tests/http3.rs
@@ -505,11 +505,12 @@ async fn routes_http3_early_data_by_replay_safety() {
     assert_eq!(safe.status, StatusCode::OK);
     assert_eq!(body_text(&safe), "early data safe\n");
 
-    let (unsafe_route, unsafe_accepted) = wait_for_http3_0rtt_request(
+    let (unsafe_route, unsafe_accepted) = wait_for_http3_0rtt_request_status(
         &endpoint,
         listen_addr,
         "localhost",
         "/unsafe",
+        StatusCode::TOO_EARLY,
         Duration::from_secs(2),
     )
     .await
@@ -528,7 +529,6 @@ async fn routes_http3_early_data_by_replay_safety() {
     );
     let status_stdout = String::from_utf8_lossy(&status_output.stdout);
     assert_eq!(parse_flat_u64(&status_stdout, "http3_early_data_enabled_listeners"), 1);
-    assert!(parse_flat_u64(&status_stdout, "http3_early_data_accepted_requests") >= 1);
     assert!(parse_flat_u64(&status_stdout, "http3_early_data_rejected_requests") >= 1);
 
     let counters_output =
@@ -539,10 +539,6 @@ async fn routes_http3_early_data_by_replay_safety() {
         render_output(&counters_output)
     );
     let counters_stdout = String::from_utf8_lossy(&counters_output.stdout);
-    assert!(
-        parse_flat_u64(&counters_stdout, "downstream_http3_early_data_accepted_requests_total")
-            >= 1
-    );
     assert!(
         parse_flat_u64(&counters_stdout, "downstream_http3_early_data_rejected_requests_total")
             >= 1
@@ -792,6 +788,51 @@ async fn wait_for_http3_0rtt_request(
 
     Err(format!(
         "timed out waiting for reusable 0-RTT state for https://{server_name}:{}{path}; last error: {last_error}",
+        listen_addr.port()
+    ))
+}
+
+async fn wait_for_http3_0rtt_request_status(
+    endpoint: &quinn::Endpoint,
+    listen_addr: SocketAddr,
+    server_name: &str,
+    path: &str,
+    expected_status: StatusCode,
+    timeout: Duration,
+) -> Result<(Http3Response, bool), String> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut last_error = String::new();
+
+    while std::time::Instant::now() < deadline {
+        match wait_for_http3_0rtt_request(
+            endpoint,
+            listen_addr,
+            server_name,
+            path,
+            Duration::from_millis(250),
+        )
+        .await
+        {
+            Ok((response, accepted)) if response.status == expected_status => {
+                return Ok((response, accepted));
+            }
+            Ok((response, accepted)) => {
+                last_error = format!(
+                    "0-RTT request completed with status={} accepted={} instead of {}",
+                    response.status, accepted, expected_status
+                );
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(error) => {
+                last_error = error;
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        }
+    }
+
+    Err(format!(
+        "timed out waiting for 0-RTT request with status {} for https://{server_name}:{}{path}; last error: {last_error}",
+        expected_status,
         listen_addr.port()
     ))
 }

--- a/crates/rginx-config/src/compile/server.rs
+++ b/crates/rginx-config/src/compile/server.rs
@@ -17,11 +17,11 @@ use crate::model::{
     TlsVersionConfig, VirtualHostTlsConfig,
 };
 
-const DEFAULT_HTTP3_MAX_CONCURRENT_STREAMS: usize = 128;
-const DEFAULT_HTTP3_STREAM_BUFFER_SIZE_BYTES: usize = 64 * 1024;
-const DEFAULT_HTTP3_ACTIVE_CONNECTION_ID_LIMIT: u32 = 2;
-const DEFAULT_HTTP3_RETRY: bool = false;
-const DEFAULT_HTTP3_GSO: bool = false;
+pub(super) const DEFAULT_HTTP3_MAX_CONCURRENT_STREAMS: usize = 128;
+pub(super) const DEFAULT_HTTP3_STREAM_BUFFER_SIZE_BYTES: usize = 64 * 1024;
+pub(super) const DEFAULT_HTTP3_ACTIVE_CONNECTION_ID_LIMIT: u32 = 2;
+pub(super) const DEFAULT_HTTP3_RETRY: bool = false;
+pub(super) const DEFAULT_HTTP3_GSO: bool = false;
 
 pub(super) struct CompiledServer {
     pub listener: Listener,

--- a/crates/rginx-config/src/compile/server.rs
+++ b/crates/rginx-config/src/compile/server.rs
@@ -28,6 +28,7 @@ pub(super) struct CompiledServer {
     pub server_names: Vec<String>,
 }
 
+/// Compiles the legacy top-level `server` block into the default listener model.
 pub(super) fn compile_legacy_server(
     server: ServerConfig,
     base_dir: &Path,
@@ -89,6 +90,7 @@ pub(super) fn compile_legacy_server(
     })
 }
 
+/// Compiles explicit listener blocks into runtime listener definitions.
 pub(super) fn compile_listeners(
     listeners: Vec<ListenerConfig>,
     base_dir: &Path,
@@ -150,10 +152,12 @@ pub(super) fn compile_listeners(
         .collect()
 }
 
+/// Builds a stable runtime listener id from a user-facing listener name.
 fn explicit_listener_id(name: &str) -> String {
     format!("listener:{}", name.trim().to_ascii_lowercase())
 }
 
+/// Compiles downstream TLS configuration into the runtime TLS policy structure.
 pub(super) fn compile_server_tls(
     tls: Option<ServerTlsConfig>,
     base_dir: &Path,
@@ -243,6 +247,7 @@ pub(super) fn compile_server_tls(
     }))
 }
 
+/// Compiles per-vhost TLS overrides into the runtime vhost TLS structure.
 pub(super) fn compile_virtual_host_tls(
     tls: Option<VirtualHostTlsConfig>,
     base_dir: &Path,
@@ -297,6 +302,7 @@ struct ServerFieldConfig {
     tls: Option<ServerTlsConfig>,
 }
 
+/// Compiles the shared server fields used by both legacy and explicit listeners.
 fn compile_server_fields(
     config: ServerFieldConfig,
     base_dir: &Path,
@@ -336,10 +342,12 @@ fn compile_server_fields(
     })
 }
 
+/// Normalizes the optional default certificate server name.
 fn compile_default_certificate(default_certificate: Option<String>) -> Option<String> {
     default_certificate.map(|name| name.trim().to_lowercase())
 }
 
+/// Converts the configured maximum header count into a platform-sized value.
 fn compile_max_headers(max_headers: Option<u64>) -> Result<Option<usize>> {
     max_headers
         .map(|limit| {
@@ -350,6 +358,7 @@ fn compile_max_headers(max_headers: Option<u64>) -> Result<Option<usize>> {
         .transpose()
 }
 
+/// Converts the configured request body limit into a platform-sized value.
 fn compile_max_request_body_bytes(max_request_body_bytes: Option<u64>) -> Result<Option<usize>> {
     max_request_body_bytes
         .map(|limit| {
@@ -362,6 +371,7 @@ fn compile_max_request_body_bytes(max_request_body_bytes: Option<u64>) -> Result
         .transpose()
 }
 
+/// Converts the configured maximum connection count into a platform-sized value.
 fn compile_max_connections(max_connections: Option<u64>) -> Result<Option<usize>> {
     max_connections
         .map(|limit| {
@@ -372,10 +382,12 @@ fn compile_max_connections(max_connections: Option<u64>) -> Result<Option<usize>
         .transpose()
 }
 
+/// Parses the optional access log format string into the runtime log template.
 fn compile_access_log_format(access_log_format: Option<String>) -> Result<Option<AccessLogFormat>> {
     access_log_format.map(AccessLogFormat::parse).transpose()
 }
 
+/// Compiles HTTP/3 listener settings and fills in runtime defaults.
 fn compile_http3(
     http3: Option<Http3Config>,
     tcp_listen_addr: std::net::SocketAddr,
@@ -423,11 +435,13 @@ fn compile_http3(
     }))
 }
 
+/// Converts an HTTP/3 numeric field into `usize`, preserving overflow errors.
 fn compile_http3_usize(raw: u64, field: &str) -> Result<usize> {
     usize::try_from(raw)
         .map_err(|_| Error::Config(format!("server http3 {field} `{raw}` exceeds platform limits")))
 }
 
+/// Maps configured TLS versions into runtime TLS version enums.
 fn compile_tls_versions(versions: Option<Vec<TlsVersionConfig>>) -> Option<Vec<TlsVersion>> {
     versions.map(|versions| {
         versions
@@ -440,6 +454,7 @@ fn compile_tls_versions(versions: Option<Vec<TlsVersionConfig>>) -> Option<Vec<T
     })
 }
 
+/// Maps configured TLS cipher suites into runtime cipher suite enums.
 fn compile_tls_cipher_suites(
     cipher_suites: Option<Vec<TlsCipherSuiteConfig>>,
 ) -> Option<Vec<TlsCipherSuite>> {
@@ -475,6 +490,7 @@ fn compile_tls_cipher_suites(
     })
 }
 
+/// Maps configured key exchange groups into runtime key exchange enums.
 fn compile_tls_key_exchange_groups(
     groups: Option<Vec<TlsKeyExchangeGroupConfig>>,
 ) -> Option<Vec<TlsKeyExchangeGroup>> {
@@ -496,12 +512,14 @@ fn compile_tls_key_exchange_groups(
     })
 }
 
+/// Drops empty ALPN entries and preserves the configured ordering.
 fn compile_alpn_protocols(alpn_protocols: Option<Vec<String>>) -> Option<Vec<String>> {
     alpn_protocols.map(|protocols| {
         protocols.into_iter().map(|protocol| protocol.trim().to_string()).collect()
     })
 }
 
+/// Converts the TLS session cache size into a platform-sized value.
 fn compile_session_cache_size(session_cache_size: Option<u64>) -> Result<Option<usize>> {
     session_cache_size
         .map(|size| {
@@ -514,6 +532,7 @@ fn compile_session_cache_size(session_cache_size: Option<u64>) -> Result<Option<
         .transpose()
 }
 
+/// Converts the TLS session ticket count into a platform-sized value.
 fn compile_session_ticket_count(session_ticket_count: Option<u64>) -> Result<Option<usize>> {
     session_ticket_count
         .map(|count| {
@@ -534,6 +553,7 @@ struct CompiledCertificateMaterial {
     ocsp: OcspConfig,
 }
 
+/// Resolves, validates, and compiles certificate material for a TLS identity.
 fn compile_certificate_material(
     base_dir: &Path,
     cert_path: String,
@@ -578,6 +598,7 @@ fn compile_certificate_material(
     })
 }
 
+/// Resolves and validates an additional TLS certificate bundle.
 fn compile_certificate_bundle(
     base_dir: &Path,
     bundle: ServerCertificateBundleConfig,
@@ -605,6 +626,7 @@ fn compile_certificate_bundle(
     Ok(ServerCertificateBundle { cert_path, key_path, ocsp_staple_path, ocsp })
 }
 
+/// Resolves the optional OCSP staple cache path relative to the config base dir.
 fn compile_ocsp_staple_path(
     base_dir: &Path,
     path: Option<String>,
@@ -625,6 +647,7 @@ fn compile_ocsp_staple_path(
     }
 }
 
+/// Converts raw OCSP settings into the runtime OCSP policy structure.
 fn compile_ocsp_config(ocsp: Option<RawOcspConfig>) -> OcspConfig {
     let Some(ocsp) = ocsp else {
         return OcspConfig::default();
@@ -651,6 +674,7 @@ fn compile_ocsp_config(ocsp: Option<RawOcspConfig>) -> OcspConfig {
     }
 }
 
+/// Parses and normalizes the trusted proxy CIDR list.
 fn compile_trusted_proxies(values: Vec<String>) -> Result<Vec<IpNet>> {
     values
         .into_iter()
@@ -668,6 +692,7 @@ fn compile_trusted_proxies(values: Vec<String>) -> Result<Vec<IpNet>> {
         .collect()
 }
 
+/// Normalizes a trusted proxy entry into canonical CIDR form.
 fn normalize_trusted_proxy(value: &str) -> Option<String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {

--- a/crates/rginx-config/src/compile/tests.rs
+++ b/crates/rginx-config/src/compile/tests.rs
@@ -29,6 +29,20 @@ fn temp_base_dir(prefix: &str) -> TempDir {
     tempfile::Builder::new().prefix(prefix).tempdir().expect("temp base dir should be created")
 }
 
+fn test_location(matcher: MatcherConfig, handler: HandlerConfig) -> LocationConfig {
+    LocationConfig {
+        matcher,
+        handler,
+        grpc_service: None,
+        grpc_method: None,
+        allow_cidrs: Vec::new(),
+        deny_cidrs: Vec::new(),
+        requests_per_sec: None,
+        burst: None,
+        allow_early_data: None,
+    }
+}
+
 #[test]
 fn compile_accepts_https_upstreams() {
     let config = Config {
@@ -88,24 +102,15 @@ fn compile_accepts_https_upstreams() {
             health_check_timeout_secs: None,
             healthy_successes_required: None,
         }],
-        locations: vec![LocationConfig {
-            matcher: MatcherConfig::Prefix("/api".to_string()),
-            handler: HandlerConfig::Proxy {
+        locations: vec![test_location(
+            MatcherConfig::Prefix("/api".to_string()),
+            HandlerConfig::Proxy {
                 upstream: "secure-backend".to_string(),
                 preserve_host: None,
                 strip_prefix: None,
                 proxy_set_headers: std::collections::HashMap::new(),
             },
-            grpc_service: None,
-
-            grpc_method: None,
-
-            allow_cidrs: Vec::new(),
-            deny_cidrs: Vec::new(),
-            requests_per_sec: None,
-            burst: None,
-            allow_early_data: None,
-        }],
+        )],
         servers: Vec::new(),
     };
 
@@ -205,24 +210,15 @@ fn compile_defaults_grpc_health_check_path_when_service_is_set() {
             health_check_timeout_secs: None,
             healthy_successes_required: None,
         }],
-        locations: vec![LocationConfig {
-            matcher: MatcherConfig::Prefix("/".to_string()),
-            handler: HandlerConfig::Proxy {
+        locations: vec![test_location(
+            MatcherConfig::Prefix("/".to_string()),
+            HandlerConfig::Proxy {
                 upstream: "grpc-backend".to_string(),
                 preserve_host: None,
                 strip_prefix: None,
                 proxy_set_headers: std::collections::HashMap::new(),
             },
-            grpc_service: None,
-
-            grpc_method: None,
-
-            allow_cidrs: Vec::new(),
-            deny_cidrs: Vec::new(),
-            requests_per_sec: None,
-            burst: None,
-            allow_early_data: None,
-        }],
+        )],
         servers: Vec::new(),
     };
 
@@ -1575,42 +1571,24 @@ fn compile_generates_distinct_route_and_vhost_ids() {
             http3: None,
         },
         upstreams: Vec::new(),
-        locations: vec![LocationConfig {
-            matcher: MatcherConfig::Exact("/".to_string()),
-            handler: HandlerConfig::Return {
+        locations: vec![test_location(
+            MatcherConfig::Exact("/".to_string()),
+            HandlerConfig::Return {
                 status: 200,
                 location: String::new(),
                 body: Some("default site\n".to_string()),
             },
-            grpc_service: None,
-
-            grpc_method: None,
-
-            allow_cidrs: Vec::new(),
-            deny_cidrs: Vec::new(),
-            requests_per_sec: None,
-            burst: None,
-            allow_early_data: None,
-        }],
+        )],
         servers: vec![VirtualHostConfig {
             server_names: vec!["api.example.com".to_string()],
-            locations: vec![LocationConfig {
-                matcher: MatcherConfig::Exact("/".to_string()),
-                handler: HandlerConfig::Return {
+            locations: vec![test_location(
+                MatcherConfig::Exact("/".to_string()),
+                HandlerConfig::Return {
                     status: 200,
                     location: String::new(),
                     body: Some("api site\n".to_string()),
                 },
-                grpc_service: None,
-
-                grpc_method: None,
-
-                allow_cidrs: Vec::new(),
-                deny_cidrs: Vec::new(),
-                requests_per_sec: None,
-                burst: None,
-                allow_early_data: None,
-            }],
+            )],
             tls: None,
         }],
     };
@@ -2011,35 +1989,25 @@ fn compile_prioritizes_grpc_constrained_routes_with_same_path_matcher() {
         },
         upstreams: Vec::new(),
         locations: vec![
-            LocationConfig {
-                matcher: MatcherConfig::Prefix("/".to_string()),
-                handler: HandlerConfig::Return {
+            test_location(
+                MatcherConfig::Prefix("/".to_string()),
+                HandlerConfig::Return {
                     status: 200,
                     location: String::new(),
                     body: Some("fallback\n".to_string()),
                 },
-                grpc_service: None,
-                grpc_method: None,
-                allow_cidrs: Vec::new(),
-                deny_cidrs: Vec::new(),
-                requests_per_sec: None,
-                burst: None,
-                allow_early_data: None,
-            },
+            ),
             LocationConfig {
-                matcher: MatcherConfig::Prefix("/".to_string()),
-                handler: HandlerConfig::Return {
-                    status: 200,
-                    location: String::new(),
-                    body: Some("grpc\n".to_string()),
-                },
                 grpc_service: Some("grpc.health.v1.Health".to_string()),
                 grpc_method: Some("Check".to_string()),
-                allow_cidrs: Vec::new(),
-                deny_cidrs: Vec::new(),
-                requests_per_sec: None,
-                burst: None,
-                allow_early_data: None,
+                ..test_location(
+                    MatcherConfig::Prefix("/".to_string()),
+                    HandlerConfig::Return {
+                        status: 200,
+                        location: String::new(),
+                        body: Some("grpc\n".to_string()),
+                    },
+                )
             },
         ],
         servers: Vec::new(),

--- a/crates/rginx-config/src/compile/tests.rs
+++ b/crates/rginx-config/src/compile/tests.rs
@@ -296,24 +296,15 @@ fn compile_applies_granular_upstream_transport_settings() {
             health_check_timeout_secs: None,
             healthy_successes_required: None,
         }],
-        locations: vec![LocationConfig {
-            matcher: MatcherConfig::Prefix("/".to_string()),
-            handler: HandlerConfig::Proxy {
+        locations: vec![test_location(
+            MatcherConfig::Prefix("/".to_string()),
+            HandlerConfig::Proxy {
                 upstream: "backend".to_string(),
                 preserve_host: None,
                 strip_prefix: None,
                 proxy_set_headers: std::collections::HashMap::new(),
             },
-            grpc_service: None,
-
-            grpc_method: None,
-
-            allow_cidrs: Vec::new(),
-            deny_cidrs: Vec::new(),
-            requests_per_sec: None,
-            burst: None,
-            allow_early_data: None,
-        }],
+        )],
         servers: Vec::new(),
     };
 
@@ -2251,12 +2242,15 @@ fn compile_http3_listener_defaults_to_tcp_listen_addr_and_default_alt_svc_policy
     assert_eq!(http3.listen_addr, "127.0.0.1:8443".parse().unwrap());
     assert!(http3.advertise_alt_svc);
     assert_eq!(http3.alt_svc_max_age.as_secs(), 86_400);
-    assert_eq!(http3.max_concurrent_streams, 128);
-    assert_eq!(http3.stream_buffer_size, 64 * 1024);
-    assert_eq!(http3.active_connection_id_limit, 2);
-    assert!(!http3.retry);
+    assert_eq!(http3.max_concurrent_streams, super::server::DEFAULT_HTTP3_MAX_CONCURRENT_STREAMS);
+    assert_eq!(http3.stream_buffer_size, super::server::DEFAULT_HTTP3_STREAM_BUFFER_SIZE_BYTES);
+    assert_eq!(
+        http3.active_connection_id_limit,
+        super::server::DEFAULT_HTTP3_ACTIVE_CONNECTION_ID_LIMIT
+    );
+    assert_eq!(http3.retry, super::server::DEFAULT_HTTP3_RETRY);
     assert_eq!(http3.host_key_path, None);
-    assert!(!http3.gso);
+    assert_eq!(http3.gso, super::server::DEFAULT_HTTP3_GSO);
     assert!(!http3.early_data_enabled);
 }
 

--- a/crates/rginx-config/src/compile/tests.rs
+++ b/crates/rginx-config/src/compile/tests.rs
@@ -2289,6 +2289,7 @@ fn compile_http3_listener_defaults_to_tcp_listen_addr_and_default_alt_svc_policy
     assert!(!http3.retry);
     assert_eq!(http3.host_key_path, None);
     assert!(!http3.gso);
+    assert!(!http3.early_data_enabled);
 }
 
 #[test]

--- a/crates/rginx-config/src/compile/tests.rs
+++ b/crates/rginx-config/src/compile/tests.rs
@@ -2347,7 +2347,7 @@ fn compile_http3_applies_transport_settings_and_resolves_host_key_path() {
                 retry: Some(true),
                 host_key_path: Some("quic/host.key".to_string()),
                 gso: Some(true),
-                early_data: None,
+                early_data: Some(true),
             }),
         },
         upstreams: Vec::new(),
@@ -2381,4 +2381,5 @@ fn compile_http3_applies_transport_settings_and_resolves_host_key_path() {
     assert!(http3.retry);
     assert_eq!(http3.host_key_path, Some(base_dir.path().join("quic/host.key")));
     assert!(http3.gso);
+    assert!(http3.early_data_enabled);
 }

--- a/crates/rginx-config/src/validate/server.rs
+++ b/crates/rginx-config/src/validate/server.rs
@@ -438,6 +438,15 @@ fn validate_http3(
         }
     }
 
+    const HTTP3_ACTIVE_CONNECTION_ID_LIMIT_MIGRATION: u32 = 5;
+    if matches!(http3.active_connection_id_limit, Some(HTTP3_ACTIVE_CONNECTION_ID_LIMIT_MIGRATION))
+        && http3.host_key_path.is_none()
+    {
+        return Err(Error::Config(format!(
+            "{owner_label} http3 active_connection_id_limit=5 requires host_key_path to be configured"
+        )));
+    }
+
     Ok(())
 }
 

--- a/crates/rginx-config/src/validate/server.rs
+++ b/crates/rginx-config/src/validate/server.rs
@@ -10,6 +10,7 @@ use crate::model::{
     TlsVersionConfig, VirtualHostConfig,
 };
 
+/// Validates the legacy top-level `server` block.
 pub(super) fn validate_server(server: &ServerConfig) -> Result<()> {
     validate_listener_like(ListenerLikeRef {
         owner_label: "server",
@@ -32,6 +33,7 @@ pub(super) fn validate_server(server: &ServerConfig) -> Result<()> {
     Ok(())
 }
 
+/// Validates the explicit listener list and its interaction with the legacy server block.
 pub(super) fn validate_listeners(
     listeners: &[ListenerConfig],
     server: &ServerConfig,
@@ -124,6 +126,7 @@ pub(super) fn validate_listeners(
     Ok(())
 }
 
+/// Validates server-name ownership rules across the default server and vhosts.
 pub(super) fn validate_server_names(
     owner_label: &str,
     server_names: &[String],
@@ -179,6 +182,7 @@ struct ListenerLikeRef<'a> {
     require_listen: bool,
 }
 
+/// Validates the shared listener-like fields used by both legacy and explicit listeners.
 fn validate_listener_like(config: ListenerLikeRef<'_>) -> Result<()> {
     if config.require_listen {
         let listen = config.listen.unwrap_or_default().trim();
@@ -351,6 +355,7 @@ fn validate_listener_like(config: ListenerLikeRef<'_>) -> Result<()> {
     Ok(())
 }
 
+/// Validates HTTP/3-specific configuration and TLS compatibility requirements.
 fn validate_http3(
     owner_label: &str,
     http3: &Http3Config,
@@ -450,6 +455,7 @@ fn validate_http3(
     Ok(())
 }
 
+/// Validates TLS identity file paths and related certificate bundle fields.
 pub(super) fn validate_tls_identity_fields(
     owner_label: &str,
     cert_path: &str,
@@ -484,6 +490,7 @@ pub(super) fn validate_tls_identity_fields(
     Ok(())
 }
 
+/// Validates a configured additional TLS certificate bundle.
 fn validate_certificate_bundle(
     owner_label: &str,
     bundle: &ServerCertificateBundleConfig,
@@ -509,6 +516,7 @@ fn validate_certificate_bundle(
     Ok(())
 }
 
+/// Validates the configured TLS version list.
 fn validate_tls_versions(owner_label: &str, versions: Option<&[TlsVersionConfig]>) -> Result<()> {
     let Some(versions) = versions else {
         return Ok(());
@@ -530,6 +538,7 @@ fn validate_tls_versions(owner_label: &str, versions: Option<&[TlsVersionConfig]
     Ok(())
 }
 
+/// Validates configured TLS cipher suites against the allowed TLS versions.
 fn validate_tls_cipher_suites(
     owner_label: &str,
     cipher_suites: Option<&[TlsCipherSuiteConfig]>,
@@ -565,6 +574,7 @@ fn validate_tls_cipher_suites(
     Ok(())
 }
 
+/// Validates the configured TLS key exchange groups.
 fn validate_tls_key_exchange_groups(
     owner_label: &str,
     key_exchange_groups: Option<&[TlsKeyExchangeGroupConfig]>,
@@ -591,6 +601,7 @@ fn validate_tls_key_exchange_groups(
     Ok(())
 }
 
+/// Returns whether a configured cipher suite is valid for a TLS version.
 fn cipher_suite_supports_version(suite: TlsCipherSuiteConfig, version: TlsVersionConfig) -> bool {
     match suite {
         TlsCipherSuiteConfig::Tls13Aes256GcmSha384
@@ -607,6 +618,7 @@ fn cipher_suite_supports_version(suite: TlsCipherSuiteConfig, version: TlsVersio
     }
 }
 
+/// Validates the configured ALPN protocol list.
 fn validate_alpn_protocols(owner_label: &str, alpn_protocols: Option<&[String]>) -> Result<()> {
     let Some(alpn_protocols) = alpn_protocols else {
         return Ok(());
@@ -637,6 +649,7 @@ fn validate_alpn_protocols(owner_label: &str, alpn_protocols: Option<&[String]>)
     Ok(())
 }
 
+/// Detects whether the legacy listener fields are present on the top-level server block.
 fn legacy_server_listener_fields(server: &ServerConfig) -> Option<()> {
     (server.listen.is_some()
         || !server.trusted_proxies.is_empty()
@@ -654,6 +667,7 @@ fn legacy_server_listener_fields(server: &ServerConfig) -> Option<()> {
     .then_some(())
 }
 
+/// Validates a trusted proxy entry and annotates any error with its owner path.
 fn validate_trusted_proxy_with_owner(owner_label: &str, value: &str) -> Result<()> {
     let normalized = normalize_trusted_proxy(value).ok_or_else(|| {
         Error::Config(format!(
@@ -668,6 +682,7 @@ fn validate_trusted_proxy_with_owner(owner_label: &str, value: &str) -> Result<(
     Ok(())
 }
 
+/// Normalizes a trusted proxy entry into canonical IP or CIDR form.
 fn normalize_trusted_proxy(value: &str) -> Option<String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {

--- a/crates/rginx-core/src/config/tests.rs
+++ b/crates/rginx-core/src/config/tests.rs
@@ -174,6 +174,7 @@ fn listener_transport_bindings_include_udp_http3_binding_when_configured() {
     assert_eq!(bindings[1].http3_retry, Some(false));
     assert_eq!(bindings[1].http3_host_key_path, None);
     assert_eq!(bindings[1].http3_gso, Some(false));
+    assert_eq!(bindings[1].http3_early_data_enabled, Some(false));
 }
 
 #[test]

--- a/crates/rginx-http/src/handler/dispatch.rs
+++ b/crates/rginx-http/src/handler/dispatch.rs
@@ -58,7 +58,8 @@ pub async fn handle(
         HeaderValue::from_str(&request_id).expect("generated request ids should be valid headers");
     request.headers_mut().insert("x-request-id", request_id_header.clone());
     let tls_client_identity = request.extensions().get::<TlsClientIdentity>().cloned();
-    let early_data = request.extensions().get::<bool>().copied().unwrap_or(false);
+    let early_data =
+        request.extensions().get::<EarlyDataFlag>().map(|flag| flag.0).unwrap_or(false);
     let path = request
         .uri()
         .path_and_query()

--- a/crates/rginx-http/src/handler/mod.rs
+++ b/crates/rginx-http/src/handler/mod.rs
@@ -24,6 +24,9 @@ pub(crate) type BoxError = Box<dyn StdError + Send + Sync>;
 pub(crate) type HttpBody = UnsyncBoxBody<Bytes, BoxError>;
 pub(crate) type HttpResponse = Response<HttpBody>;
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct EarlyDataFlag(pub bool);
+
 mod access_log;
 mod dispatch;
 mod grpc;
@@ -45,7 +48,7 @@ pub(crate) fn attach_connection_metadata<B>(
     request: &mut Request<B>,
     connection: &ConnectionPeerAddrs,
 ) {
-    request.extensions_mut().insert(connection.early_data);
+    request.extensions_mut().insert(EarlyDataFlag(connection.early_data));
     if let Some(identity) = connection.tls_client_identity.clone() {
         request.extensions_mut().insert(identity);
     }

--- a/crates/rginx-http/src/proxy/clients/http3.rs
+++ b/crates/rginx-http/src/proxy/clients/http3.rs
@@ -173,14 +173,7 @@ impl Http3Client {
 
         let (parts, _) = response.into_parts();
         let size_hint = response_size_hint(&parts.headers);
-        let expect_trailers = response_expects_trailers(&parts.headers);
-        let body = streaming_response_body(
-            request_stream,
-            session,
-            peer.url.clone(),
-            size_hint,
-            expect_trailers,
-        );
+        let body = streaming_response_body(request_stream, session, peer.url.clone(), size_hint);
         let mut response_builder = Response::builder().status(parts.status);
         for (name, value) in &parts.headers {
             response_builder = response_builder.header(name, value);
@@ -303,11 +296,12 @@ impl Http3Client {
 struct StreamingResponseBody {
     rx: mpsc::Receiver<Result<Frame<Bytes>, BoxError>>,
     size_hint: SizeHint,
+    done: bool,
 }
 
 impl StreamingResponseBody {
     fn new(rx: mpsc::Receiver<Result<Frame<Bytes>, BoxError>>, size_hint: SizeHint) -> Self {
-        Self { rx, size_hint }
+        Self { rx, size_hint, done: false }
     }
 }
 
@@ -319,11 +313,18 @@ impl hyper::body::Body for StreamingResponseBody {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        self.rx.poll_recv(cx)
+        let this = self.as_mut().get_mut();
+        match this.rx.poll_recv(cx) {
+            std::task::Poll::Ready(None) => {
+                this.done = true;
+                std::task::Poll::Ready(None)
+            }
+            other => other,
+        }
     }
 
     fn is_end_stream(&self) -> bool {
-        self.rx.is_closed()
+        self.done
     }
 
     fn size_hint(&self) -> SizeHint {
@@ -336,7 +337,6 @@ fn streaming_response_body(
     session: Arc<Http3Session>,
     peer_url: String,
     size_hint: SizeHint,
-    expect_trailers: bool,
 ) -> HttpBody {
     let (tx, rx) = mpsc::channel(1);
     tokio::spawn(async move {
@@ -366,24 +366,22 @@ fn streaming_response_body(
             }
         }
 
-        if expect_trailers {
-            match request_stream.recv_trailers().await {
-                Ok(Some(trailers)) => {
-                    let _ = tx.send(Ok(Frame::trailers(trailers))).await;
-                }
-                Ok(None) => {}
-                Err(error) if is_clean_http3_response_shutdown(&error) => {}
-                Err(error) => {
-                    session.mark_closed();
-                    let _ = tx
-                        .send(Err::<Frame<Bytes>, BoxError>(
-                            std::io::Error::other(format!(
-                                "failed to receive upstream http3 response trailers from `{peer_url}`: {error}"
-                            ))
-                            .into(),
+        match request_stream.recv_trailers().await {
+            Ok(Some(trailers)) => {
+                let _ = tx.send(Ok(Frame::trailers(trailers))).await;
+            }
+            Ok(None) => {}
+            Err(error) if is_clean_http3_response_shutdown(&error) => {}
+            Err(error) => {
+                session.mark_closed();
+                let _ = tx
+                    .send(Err::<Frame<Bytes>, BoxError>(
+                        std::io::Error::other(format!(
+                            "failed to receive upstream http3 response trailers from `{peer_url}`: {error}"
                         ))
-                        .await;
-                }
+                        .into(),
+                    ))
+                    .await;
             }
         }
     });
@@ -401,14 +399,6 @@ fn response_size_hint(headers: &HeaderMap) -> SizeHint {
         hint.set_exact(content_length);
     }
     hint
-}
-
-fn response_expects_trailers(headers: &HeaderMap) -> bool {
-    headers
-        .get(http::header::CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-        .map(|value| value.to_ascii_lowercase())
-        .is_some_and(|value| value.starts_with("application/grpc"))
 }
 
 fn is_clean_http3_response_shutdown(error: &impl std::fmt::Display) -> bool {

--- a/crates/rginx-http/src/proxy/clients/http3.rs
+++ b/crates/rginx-http/src/proxy/clients/http3.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{Mutex, Notify, mpsc};
 use tokio::task::JoinHandle;
 
 use crate::handler::{BoxError, HttpBody, boxed_body};
@@ -21,7 +21,7 @@ pub(crate) struct Http3Client {
     client_config: quinn::ClientConfig,
     connect_timeout: Duration,
     endpoints: Arc<Http3ClientEndpoints>,
-    sessions: Arc<Mutex<HashMap<Http3SessionKey, Arc<Http3Session>>>>,
+    sessions: Arc<Mutex<HashMap<Http3SessionKey, Http3SessionEntry>>>,
 }
 
 #[derive(Default)]
@@ -40,6 +40,12 @@ struct Http3Session {
     sender: Mutex<H3SendRequest>,
     closed: Arc<AtomicBool>,
     driver_task: Mutex<Option<JoinHandle<()>>>,
+}
+
+#[derive(Clone)]
+enum Http3SessionEntry {
+    Ready(Arc<Http3Session>),
+    Pending(Arc<Notify>),
 }
 
 impl Http3Session {
@@ -188,19 +194,43 @@ impl Http3Client {
         key: Http3SessionKey,
         peer_url: &str,
     ) -> Result<Arc<Http3Session>, Error> {
-        if let Some(existing) = self.sessions.lock().await.get(&key).cloned()
-            && !existing.is_closed()
-        {
-            return Ok(existing);
-        }
+        loop {
+            enum SessionAction {
+                Wait(Arc<Notify>),
+                Connect(Arc<Notify>),
+            }
 
-        let created = Arc::new(self.connect_session(&key, peer_url).await?);
-        let mut sessions = self.sessions.lock().await;
-        match sessions.get(&key) {
-            Some(existing) if !existing.is_closed() => Ok(existing.clone()),
-            _ => {
-                sessions.insert(key, created.clone());
-                Ok(created)
+            let action = {
+                let mut sessions = self.sessions.lock().await;
+                match sessions.get(&key).cloned() {
+                    Some(Http3SessionEntry::Ready(existing)) if !existing.is_closed() => {
+                        return Ok(existing);
+                    }
+                    Some(Http3SessionEntry::Pending(notify)) => SessionAction::Wait(notify),
+                    Some(Http3SessionEntry::Ready(_)) | None => {
+                        let notify = Arc::new(Notify::new());
+                        sessions.insert(key.clone(), Http3SessionEntry::Pending(notify.clone()));
+                        SessionAction::Connect(notify)
+                    }
+                }
+            };
+
+            match action {
+                SessionAction::Wait(notify) => notify.notified().await,
+                SessionAction::Connect(notify) => {
+                    let result = self.connect_session(&key, peer_url).await.map(Arc::new);
+                    let mut sessions = self.sessions.lock().await;
+                    match &result {
+                        Ok(session) => {
+                            sessions.insert(key.clone(), Http3SessionEntry::Ready(session.clone()));
+                        }
+                        Err(_) => {
+                            sessions.remove(&key);
+                        }
+                    }
+                    notify.notify_waiters();
+                    return result;
+                }
             }
         }
     }
@@ -289,7 +319,12 @@ impl Http3Client {
 
     #[cfg(test)]
     async fn cached_session_count(&self) -> usize {
-        self.sessions.lock().await.len()
+        self.sessions
+            .lock()
+            .await
+            .values()
+            .filter(|entry| matches!(entry, Http3SessionEntry::Ready(_)))
+            .count()
     }
 }
 
@@ -297,11 +332,26 @@ struct StreamingResponseBody {
     rx: mpsc::Receiver<Result<Frame<Bytes>, BoxError>>,
     size_hint: SizeHint,
     done: bool,
+    join_handle: Option<JoinHandle<()>>,
 }
 
 impl StreamingResponseBody {
-    fn new(rx: mpsc::Receiver<Result<Frame<Bytes>, BoxError>>, size_hint: SizeHint) -> Self {
-        Self { rx, size_hint, done: false }
+    fn new(
+        rx: mpsc::Receiver<Result<Frame<Bytes>, BoxError>>,
+        size_hint: SizeHint,
+        join_handle: JoinHandle<()>,
+    ) -> Self {
+        Self { rx, size_hint, done: false, join_handle: Some(join_handle) }
+    }
+}
+
+impl Drop for StreamingResponseBody {
+    fn drop(&mut self) {
+        if let Some(join_handle) = self.join_handle.take()
+            && !join_handle.is_finished()
+        {
+            join_handle.abort();
+        }
     }
 }
 
@@ -339,7 +389,7 @@ fn streaming_response_body(
     size_hint: SizeHint,
 ) -> HttpBody {
     let (tx, rx) = mpsc::channel(1);
-    tokio::spawn(async move {
+    let join_handle = tokio::spawn(async move {
         loop {
             let next = match request_stream.recv_data().await {
                 Ok(chunk) => chunk,
@@ -386,7 +436,7 @@ fn streaming_response_body(
         }
     });
 
-    boxed_body(StreamingResponseBody::new(rx, size_hint))
+    boxed_body(StreamingResponseBody::new(rx, size_hint, join_handle))
 }
 
 fn response_size_hint(headers: &HeaderMap) -> SizeHint {

--- a/crates/rginx-http/src/proxy/clients/http3.rs
+++ b/crates/rginx-http/src/proxy/clients/http3.rs
@@ -382,6 +382,7 @@ impl hyper::body::Body for StreamingResponseBody {
     }
 }
 
+/// Streams an upstream HTTP/3 response body into a Hyper body adapter.
 fn streaming_response_body(
     mut request_stream: H3RequestStream,
     session: Arc<Http3Session>,
@@ -439,6 +440,7 @@ fn streaming_response_body(
     boxed_body(StreamingResponseBody::new(rx, size_hint, join_handle))
 }
 
+/// Derives a Hyper body size hint from upstream response headers.
 fn response_size_hint(headers: &HeaderMap) -> SizeHint {
     let mut hint = SizeHint::default();
     if let Some(content_length) = headers
@@ -451,12 +453,14 @@ fn response_size_hint(headers: &HeaderMap) -> SizeHint {
     hint
 }
 
+/// Detects peer shutdown errors that should be treated as a clean HTTP/3 EOF.
 fn is_clean_http3_response_shutdown(error: &impl std::fmt::Display) -> bool {
     let error = error.to_string();
     error.contains("ApplicationClose: H3_NO_ERROR")
         || error.contains("Application { code: H3_NO_ERROR")
 }
 
+/// Resolves the selected upstream peer authority into a socket address.
 fn resolve_peer_socket_addr(peer: &UpstreamPeer) -> Result<SocketAddr, Error> {
     peer.authority
         .to_socket_addrs()
@@ -475,6 +479,7 @@ fn resolve_peer_socket_addr(peer: &UpstreamPeer) -> Result<SocketAddr, Error> {
         })
 }
 
+/// Determines the TLS server name to use for an upstream HTTP/3 connection.
 fn server_name_for_peer(upstream: &Upstream, peer: &UpstreamPeer) -> Result<String, Error> {
     if let Some(server_name_override) = upstream.server_name_override.as_ref() {
         return Ok(server_name_override.clone());

--- a/crates/rginx-http/src/server/http3.rs
+++ b/crates/rginx-http/src/server/http3.rs
@@ -282,7 +282,6 @@ pub fn bind_http3_endpoint_with_socket(
         listener.tls_enabled(),
         default_vhost,
         vhosts,
-        listener.server.max_request_body_bytes,
         listener.http3.as_ref().is_some_and(|http3| http3.early_data_enabled),
     )?
     .ok_or_else(|| {
@@ -395,12 +394,16 @@ fn build_http3_endpoint_config(
                 .cid_generator(|| Box::new(quinn_proto::RandomConnectionIdGenerator::new(0)));
         }
         HTTP3_ACTIVE_CONNECTION_ID_LIMIT_MIGRATION => {
-            if let Some(host_key_material) = host_key_material {
-                let key = derive_hashed_connection_id_key(host_key_material);
-                endpoint_config.cid_generator(move || {
-                    Box::new(quinn_proto::HashedConnectionIdGenerator::from_key(key))
-                });
-            }
+            let host_key_material = host_key_material.ok_or_else(|| {
+                Error::Config(
+                    "http3 active_connection_id_limit `5` requires host_key_path to be configured"
+                        .to_string(),
+                )
+            })?;
+            let key = derive_hashed_connection_id_key(host_key_material);
+            endpoint_config.cid_generator(move || {
+                Box::new(quinn_proto::HashedConnectionIdGenerator::from_key(key))
+            });
         }
         unsupported => {
             return Err(Error::Config(format!(

--- a/crates/rginx-http/src/server/http3.rs
+++ b/crates/rginx-http/src/server/http3.rs
@@ -1,5 +1,5 @@
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
@@ -282,6 +282,7 @@ pub fn bind_http3_endpoint_with_socket(
         listener.tls_enabled(),
         default_vhost,
         vhosts,
+        listener.server.max_request_body_bytes,
         listener.http3.as_ref().is_some_and(|http3| http3.early_data_enabled),
     )?
     .ok_or_else(|| {
@@ -455,25 +456,26 @@ fn create_host_key_material(path: &Path) -> Result<Vec<u8>> {
         .fill(&mut bytes)
         .map_err(|_| Error::Server("failed to generate http3 host key material".to_string()))?;
 
-    let temp_path = temp_host_key_path(path);
-    std::fs::write(&temp_path, &bytes)?;
+    use std::io::Write as _;
+
+    let mut file = match std::fs::OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return validate_host_key_material(path, std::fs::read(path).map_err(Error::Io)?);
+        }
+        Err(error) => return Err(Error::Io(error)),
+    };
+    file.write_all(&bytes)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
 
-        std::fs::set_permissions(&temp_path, std::fs::Permissions::from_mode(0o600))?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
     }
-    std::fs::rename(&temp_path, path)?;
+    file.flush().map_err(Error::Io)?;
+    file.sync_all().map_err(Error::Io)?;
 
     Ok(bytes)
-}
-
-fn temp_host_key_path(path: &Path) -> PathBuf {
-    let unique = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    path.with_extension(format!("http3-host-key-{unique}.tmp"))
 }
 
 fn derive_labeled_key_material(host_key_material: &[u8], label: &[u8]) -> [u8; 32] {
@@ -500,7 +502,7 @@ async fn serve_http3_connection(
         .current_listener(&listener_id)
         .await
         .expect("listener id should remain available while http3 connection is running");
-    let _http3_connection_guard = state.retain_http3_connection(&listener_id);
+    let _http3_connection_guard = state.retain_http3_connection(&listener_id)?;
     let mtls_configured =
         current_listener.server.tls.as_ref().and_then(|tls| tls.client_auth.as_ref()).is_some();
     let early_data_enabled =
@@ -619,7 +621,8 @@ async fn serve_http3_connection(
                         let connection_addrs = connection_addrs.clone();
                         let handshake_complete = handshake_complete.clone();
                         request_tasks.spawn(async move {
-                            let _request_stream_guard = state.retain_http3_request_stream(&listener_id);
+                            let _request_stream_guard =
+                                state.retain_http3_request_stream(&listener_id)?;
                             let mut connection_addrs = connection_addrs.as_ref().clone();
                             connection_addrs.early_data = !handshake_complete.load(Ordering::Acquire);
                             serve_http3_request(

--- a/crates/rginx-http/src/server/http3.rs
+++ b/crates/rginx-http/src/server/http3.rs
@@ -256,6 +256,7 @@ pub async fn serve_http3(
     Ok(())
 }
 
+/// Binds a Quinn HTTP/3 endpoint for a listener using a freshly created UDP socket.
 pub fn bind_http3_endpoint(
     listener: &rginx_core::Listener,
     default_vhost: &rginx_core::VirtualHost,
@@ -270,6 +271,7 @@ pub fn bind_http3_endpoint(
     bind_http3_endpoint_with_socket(listener, default_vhost, vhosts, socket).map(Some)
 }
 
+/// Binds a Quinn HTTP/3 endpoint for a listener using a supplied UDP socket.
 pub fn bind_http3_endpoint_with_socket(
     listener: &rginx_core::Listener,
     default_vhost: &rginx_core::VirtualHost,
@@ -310,6 +312,7 @@ pub fn bind_http3_endpoint_with_socket(
     quinn::Endpoint::new(endpoint_config, Some(quic_config), socket, runtime).map_err(Error::Io)
 }
 
+/// Applies HTTP/3 transport tuning to the Quinn server config.
 fn apply_http3_server_runtime(
     http3: Option<&rginx_core::ListenerHttp3>,
     host_key_material: Option<&[u8]>,
@@ -372,6 +375,7 @@ fn apply_http3_server_runtime(
     Ok(())
 }
 
+/// Builds the Quinn endpoint config for an HTTP/3 listener.
 fn build_http3_endpoint_config(
     http3: Option<&rginx_core::ListenerHttp3>,
     host_key_material: Option<&[u8]>,
@@ -415,6 +419,7 @@ fn build_http3_endpoint_config(
     Ok(endpoint_config)
 }
 
+/// Loads or creates the optional HTTP/3 host key material for a listener.
 fn load_or_create_http3_host_key(
     http3: Option<&rginx_core::ListenerHttp3>,
 ) -> Result<Option<Vec<u8>>> {
@@ -425,6 +430,7 @@ fn load_or_create_http3_host_key(
     Ok(Some(load_or_create_host_key_material(path)?))
 }
 
+/// Loads persisted host key material or creates it on first use.
 fn load_or_create_host_key_material(path: &Path) -> Result<Vec<u8>> {
     match std::fs::read(path) {
         Ok(bytes) => validate_host_key_material(path, bytes),
@@ -435,6 +441,7 @@ fn load_or_create_host_key_material(path: &Path) -> Result<Vec<u8>> {
     }
 }
 
+/// Validates the size of persisted HTTP/3 host key material.
 fn validate_host_key_material(path: &Path, bytes: Vec<u8>) -> Result<Vec<u8>> {
     if bytes.len() != HTTP3_HOST_KEY_BYTES {
         return Err(Error::Config(format!(
@@ -447,6 +454,7 @@ fn validate_host_key_material(path: &Path, bytes: Vec<u8>) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
+/// Atomically creates and persists new HTTP/3 host key material.
 fn create_host_key_material(path: &Path) -> Result<Vec<u8>> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
@@ -481,6 +489,7 @@ fn create_host_key_material(path: &Path) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
+/// Derives labeled key material from the persisted HTTP/3 host key secret.
 fn derive_labeled_key_material(host_key_material: &[u8], label: &[u8]) -> [u8; 32] {
     let mut digest = Sha256::new();
     digest.update(label);
@@ -488,11 +497,13 @@ fn derive_labeled_key_material(host_key_material: &[u8], label: &[u8]) -> [u8; 3
     digest.finalize().into()
 }
 
+/// Derives the stable hashed-connection-id seed used for migration mode.
 fn derive_hashed_connection_id_key(host_key_material: &[u8]) -> u64 {
     let digest = derive_labeled_key_material(host_key_material, b"rginx-http3-cid-key");
     u64::from_be_bytes(digest[..8].try_into().expect("sha256 digest should contain 8 bytes"))
 }
 
+/// Serves one accepted HTTP/3 connection until it drains or closes.
 async fn serve_http3_connection(
     incoming: Incoming,
     listener_id: String,
@@ -673,6 +684,7 @@ async fn serve_http3_connection(
     Ok(())
 }
 
+/// Extracts client certificate identity details from a Quinn HTTP/3 connection.
 fn extract_http3_tls_client_identity(connection: &quinn::Connection) -> Option<TlsClientIdentity> {
     let certificates = connection
         .peer_identity()?
@@ -683,6 +695,7 @@ fn extract_http3_tls_client_identity(connection: &quinn::Connection) -> Option<T
     ))
 }
 
+/// Extracts the negotiated ALPN protocol from a Quinn HTTP/3 connection.
 fn http3_tls_alpn_protocol(connection: &quinn::Connection) -> Option<String> {
     connection
         .handshake_data()?
@@ -692,6 +705,7 @@ fn http3_tls_alpn_protocol(connection: &quinn::Connection) -> Option<String> {
         .map(|protocol| String::from_utf8_lossy(&protocol).into_owned())
 }
 
+/// Resolves, dispatches, and responds to a single HTTP/3 request stream.
 async fn serve_http3_request(
     resolver: RequestResolver<h3_quinn::Connection, Bytes>,
     listener_id: String,
@@ -720,6 +734,7 @@ async fn serve_http3_request(
     send_http3_response(send_stream, response, &state, &listener_id).await
 }
 
+/// Writes a finalized downstream response onto an HTTP/3 response stream.
 async fn send_http3_response<S>(
     mut stream: RequestStream<S, Bytes>,
     response: HttpResponse,
@@ -774,6 +789,7 @@ where
     })
 }
 
+/// Logs the completion result of a spawned HTTP/3 connection task.
 fn log_connection_task_result(result: std::result::Result<Result<()>, JoinError>) {
     match result {
         Ok(Ok(())) => {}
@@ -790,6 +806,7 @@ fn log_connection_task_result(result: std::result::Result<Result<()>, JoinError>
     }
 }
 
+/// Logs the completion result of a spawned HTTP/3 request task.
 fn log_request_task_result(result: std::result::Result<Result<()>, JoinError>) {
     match result {
         Ok(Ok(())) => {}
@@ -806,6 +823,7 @@ fn log_request_task_result(result: std::result::Result<Result<()>, JoinError>) {
     }
 }
 
+/// Wraps a stream error into the boxed error type expected by Hyper bodies.
 fn stream_error(error: impl std::fmt::Display) -> BoxError {
     std::io::Error::other(format!("{error}")).into()
 }

--- a/crates/rginx-http/src/state/connections.rs
+++ b/crates/rginx-http/src/state/connections.rs
@@ -11,7 +11,7 @@ pub struct ActiveConnectionGuard {
 }
 
 pub(crate) struct ActiveHttp3ConnectionGuard {
-    pub(super) counters: Option<Arc<ListenerTrafficCounters>>,
+    pub(super) counters: Arc<ListenerTrafficCounters>,
     pub(super) listener_id: String,
     pub(super) snapshot_version: Arc<AtomicU64>,
     pub(super) snapshot_notify: Arc<Notify>,
@@ -20,7 +20,7 @@ pub(crate) struct ActiveHttp3ConnectionGuard {
 }
 
 pub(crate) struct ActiveHttp3RequestStreamGuard {
-    pub(super) counters: Option<Arc<ListenerTrafficCounters>>,
+    pub(super) counters: Arc<ListenerTrafficCounters>,
     pub(super) listener_id: String,
     pub(super) snapshot_version: Arc<AtomicU64>,
     pub(super) snapshot_notify: Arc<Notify>,
@@ -46,35 +46,31 @@ impl Drop for ActiveConnectionGuard {
 
 impl Drop for ActiveHttp3ConnectionGuard {
     fn drop(&mut self) {
-        if let Some(counters) = &self.counters {
-            counters.active_http3_connections.fetch_sub(1, Ordering::AcqRel);
-            let version = self.snapshot_version.fetch_add(1, Ordering::Relaxed) + 1;
-            self.snapshot_components.status.store(version, Ordering::Relaxed);
-            self.snapshot_components.traffic.store(version, Ordering::Relaxed);
-            self.traffic_component_versions
-                .write()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .listeners
-                .insert(self.listener_id.clone(), version);
-            self.snapshot_notify.notify_waiters();
-        }
+        self.counters.active_http3_connections.fetch_sub(1, Ordering::AcqRel);
+        let version = self.snapshot_version.fetch_add(1, Ordering::Relaxed) + 1;
+        self.snapshot_components.status.store(version, Ordering::Relaxed);
+        self.snapshot_components.traffic.store(version, Ordering::Relaxed);
+        self.traffic_component_versions
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .listeners
+            .insert(self.listener_id.clone(), version);
+        self.snapshot_notify.notify_waiters();
     }
 }
 
 impl Drop for ActiveHttp3RequestStreamGuard {
     fn drop(&mut self) {
-        if let Some(counters) = &self.counters {
-            counters.active_http3_request_streams.fetch_sub(1, Ordering::AcqRel);
-            let version = self.snapshot_version.fetch_add(1, Ordering::Relaxed) + 1;
-            self.snapshot_components.status.store(version, Ordering::Relaxed);
-            self.snapshot_components.traffic.store(version, Ordering::Relaxed);
-            self.traffic_component_versions
-                .write()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .listeners
-                .insert(self.listener_id.clone(), version);
-            self.snapshot_notify.notify_waiters();
-        }
+        self.counters.active_http3_request_streams.fetch_sub(1, Ordering::AcqRel);
+        let version = self.snapshot_version.fetch_add(1, Ordering::Relaxed) + 1;
+        self.snapshot_components.status.store(version, Ordering::Relaxed);
+        self.snapshot_components.traffic.store(version, Ordering::Relaxed);
+        self.traffic_component_versions
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .listeners
+            .insert(self.listener_id.clone(), version);
+        self.snapshot_notify.notify_waiters();
     }
 }
 
@@ -142,43 +138,50 @@ impl SharedState {
         }
     }
 
-    pub(crate) fn retain_http3_connection(&self, listener_id: &str) -> ActiveHttp3ConnectionGuard {
-        let counters = self.listener_traffic_counters(listener_id);
-        if let Some(counters) = &counters {
-            counters.active_http3_connections.fetch_add(1, Ordering::AcqRel);
-            let version = self.mark_snapshot_changed_components(true, false, true, false, false);
-            self.mark_traffic_targets_changed(version, Some(listener_id), None, None);
-            self.notify_snapshot_waiters();
-        }
-        ActiveHttp3ConnectionGuard {
+    pub(crate) fn retain_http3_connection(
+        &self,
+        listener_id: &str,
+    ) -> Result<ActiveHttp3ConnectionGuard> {
+        let counters = self.listener_traffic_counters(listener_id).ok_or_else(|| {
+            rginx_core::Error::Server(format!(
+                "listener `{listener_id}` is missing traffic counters for http3 connections"
+            ))
+        })?;
+        counters.active_http3_connections.fetch_add(1, Ordering::AcqRel);
+        let version = self.mark_snapshot_changed_components(true, false, true, false, false);
+        self.mark_traffic_targets_changed(version, Some(listener_id), None, None);
+        self.notify_snapshot_waiters();
+        Ok(ActiveHttp3ConnectionGuard {
             counters,
             listener_id: listener_id.to_string(),
             snapshot_version: self.snapshot_version.clone(),
             snapshot_notify: self.snapshot_notify.clone(),
             snapshot_components: self.snapshot_components.clone(),
             traffic_component_versions: self.traffic_component_versions.clone(),
-        }
+        })
     }
 
     pub(crate) fn retain_http3_request_stream(
         &self,
         listener_id: &str,
-    ) -> ActiveHttp3RequestStreamGuard {
-        let counters = self.listener_traffic_counters(listener_id);
-        if let Some(counters) = &counters {
-            counters.active_http3_request_streams.fetch_add(1, Ordering::AcqRel);
-            let version = self.mark_snapshot_changed_components(true, false, true, false, false);
-            self.mark_traffic_targets_changed(version, Some(listener_id), None, None);
-            self.notify_snapshot_waiters();
-        }
-        ActiveHttp3RequestStreamGuard {
+    ) -> Result<ActiveHttp3RequestStreamGuard> {
+        let counters = self.listener_traffic_counters(listener_id).ok_or_else(|| {
+            rginx_core::Error::Server(format!(
+                "listener `{listener_id}` is missing traffic counters for http3 request streams"
+            ))
+        })?;
+        counters.active_http3_request_streams.fetch_add(1, Ordering::AcqRel);
+        let version = self.mark_snapshot_changed_components(true, false, true, false, false);
+        self.mark_traffic_targets_changed(version, Some(listener_id), None, None);
+        self.notify_snapshot_waiters();
+        Ok(ActiveHttp3RequestStreamGuard {
             counters,
             listener_id: listener_id.to_string(),
             snapshot_version: self.snapshot_version.clone(),
             snapshot_notify: self.snapshot_notify.clone(),
             snapshot_components: self.snapshot_components.clone(),
             traffic_component_versions: self.traffic_component_versions.clone(),
-        }
+        })
     }
 
     pub(crate) fn record_connection_accepted(&self, listener_id: &str) {

--- a/crates/rginx-http/src/state/lifecycle.rs
+++ b/crates/rginx-http/src/state/lifecycle.rs
@@ -27,56 +27,33 @@ impl SharedState {
         );
         let listener_traffic =
             self.traffic_stats.read().unwrap_or_else(|poisoned| poisoned.into_inner());
-        let http3_active_connections = config
-            .listeners
-            .iter()
-            .filter_map(|listener| listener_traffic.listeners.get(&listener.id))
-            .map(|entry| entry.counters.active_http3_connections.load(Ordering::Acquire))
-            .sum();
-        let http3_active_request_streams = config
-            .listeners
-            .iter()
-            .filter_map(|listener| listener_traffic.listeners.get(&listener.id))
-            .map(|entry| entry.counters.active_http3_request_streams.load(Ordering::Acquire))
-            .sum();
-        let http3_retry_issued_total = config
-            .listeners
-            .iter()
-            .filter_map(|listener| listener_traffic.listeners.get(&listener.id))
-            .map(|entry| entry.counters.http3_retry_issued_total.load(Ordering::Relaxed))
-            .sum();
-        let http3_retry_failed_total = config
-            .listeners
-            .iter()
-            .filter_map(|listener| listener_traffic.listeners.get(&listener.id))
-            .map(|entry| entry.counters.http3_retry_failed_total.load(Ordering::Relaxed))
-            .sum();
-        let http3_request_accept_errors_total = config
-            .listeners
-            .iter()
-            .filter_map(|listener| listener_traffic.listeners.get(&listener.id))
-            .map(|entry| entry.counters.http3_request_accept_errors_total.load(Ordering::Relaxed))
-            .sum();
-        let http3_request_resolve_errors_total = config
-            .listeners
-            .iter()
-            .filter_map(|listener| listener_traffic.listeners.get(&listener.id))
-            .map(|entry| entry.counters.http3_request_resolve_errors_total.load(Ordering::Relaxed))
-            .sum();
-        let http3_request_body_stream_errors_total = config
-            .listeners
-            .iter()
-            .filter_map(|listener| listener_traffic.listeners.get(&listener.id))
-            .map(|entry| {
-                entry.counters.http3_request_body_stream_errors_total.load(Ordering::Relaxed)
-            })
-            .sum();
-        let http3_response_stream_errors_total = config
-            .listeners
-            .iter()
-            .filter_map(|listener| listener_traffic.listeners.get(&listener.id))
-            .map(|entry| entry.counters.http3_response_stream_errors_total.load(Ordering::Relaxed))
-            .sum();
+        let mut http3_active_connections = 0;
+        let mut http3_active_request_streams = 0;
+        let mut http3_retry_issued_total = 0;
+        let mut http3_retry_failed_total = 0;
+        let mut http3_request_accept_errors_total = 0;
+        let mut http3_request_resolve_errors_total = 0;
+        let mut http3_request_body_stream_errors_total = 0;
+        let mut http3_response_stream_errors_total = 0;
+        for listener in &config.listeners {
+            let Some(entry) = listener_traffic.listeners.get(&listener.id) else {
+                continue;
+            };
+            let counters = &entry.counters;
+            http3_active_connections += counters.active_http3_connections.load(Ordering::Acquire);
+            http3_active_request_streams +=
+                counters.active_http3_request_streams.load(Ordering::Acquire);
+            http3_retry_issued_total += counters.http3_retry_issued_total.load(Ordering::Relaxed);
+            http3_retry_failed_total += counters.http3_retry_failed_total.load(Ordering::Relaxed);
+            http3_request_accept_errors_total +=
+                counters.http3_request_accept_errors_total.load(Ordering::Relaxed);
+            http3_request_resolve_errors_total +=
+                counters.http3_request_resolve_errors_total.load(Ordering::Relaxed);
+            http3_request_body_stream_errors_total +=
+                counters.http3_request_body_stream_errors_total.load(Ordering::Relaxed);
+            http3_response_stream_errors_total +=
+                counters.http3_response_stream_errors_total.load(Ordering::Relaxed);
+        }
         RuntimeStatusSnapshot {
             revision,
             config_path: self.config_path.as_deref().cloned(),

--- a/crates/rginx-http/src/state/tests.rs
+++ b/crates/rginx-http/src/state/tests.rs
@@ -333,8 +333,11 @@ async fn http3_runtime_telemetry_tracks_status_and_traffic_snapshots() {
     let shared = SharedState::from_config(config).expect("shared state should build");
 
     {
-        let _connection = shared.retain_http3_connection("default");
-        let _stream = shared.retain_http3_request_stream("default");
+        let _connection =
+            shared.retain_http3_connection("default").expect("http3 connection guard should exist");
+        let _stream = shared
+            .retain_http3_request_stream("default")
+            .expect("http3 request stream guard should exist");
         shared.record_http3_retry_issued("default");
         shared.record_http3_retry_failed("default");
         shared.record_http3_request_accept_error("default");

--- a/crates/rginx-http/src/tls/acceptor.rs
+++ b/crates/rginx-http/src/tls/acceptor.rs
@@ -33,6 +33,7 @@ pub fn build_tls_acceptor(
             .and_then(|tls| tls.alpn_protocols.clone())
             .unwrap_or_else(|| vec!["h2".to_string(), "http/1.1".to_string()]),
         false,
+        None,
         false,
     )
     .map(|config| config.map(TlsAcceptor::from))
@@ -44,6 +45,7 @@ pub fn build_http3_server_config(
     tls_termination_enabled: bool,
     default_vhost: &VirtualHost,
     vhosts: &[VirtualHost],
+    max_request_body_bytes: Option<usize>,
     http3_early_data_enabled: bool,
 ) -> Result<Option<Arc<ServerConfig>>> {
     build_tls_server_config(
@@ -54,6 +56,7 @@ pub fn build_http3_server_config(
         vhosts,
         vec!["h3".to_string()],
         true,
+        max_request_body_bytes,
         http3_early_data_enabled,
     )
 }
@@ -66,6 +69,7 @@ fn build_tls_server_config(
     vhosts: &[VirtualHost],
     alpn_protocols: Vec<String>,
     http3_only: bool,
+    max_request_body_bytes: Option<usize>,
     http3_early_data_enabled: bool,
 ) -> Result<Option<Arc<ServerConfig>>> {
     if !tls_termination_enabled {
@@ -154,7 +158,11 @@ fn build_tls_server_config(
     config.alpn_protocols = alpn_protocols.into_iter().map(String::into_bytes).collect();
     apply_session_policy(&mut config, default_tls)?;
     if http3_only && http3_early_data_enabled {
-        config.max_early_data_size = u32::MAX;
+        const DEFAULT_HTTP3_MAX_EARLY_DATA_SIZE: u32 = 64 * 1024;
+
+        config.max_early_data_size = max_request_body_bytes
+            .map(|limit| limit.min(u32::MAX as usize) as u32)
+            .unwrap_or(DEFAULT_HTTP3_MAX_EARLY_DATA_SIZE);
     }
 
     Ok(Some(Arc::new(config)))

--- a/crates/rginx-http/src/tls/acceptor.rs
+++ b/crates/rginx-http/src/tls/acceptor.rs
@@ -15,6 +15,13 @@ use super::provider::{build_crypto_provider, default_crypto_provider, rustls_ver
 use super::session::apply_session_policy;
 use super::sni::{SniCertificateResolver, register_server_name_certificates};
 
+struct TlsServerConfigOptions {
+    alpn_protocols: Vec<String>,
+    http3_only: bool,
+    max_request_body_bytes: Option<usize>,
+    http3_early_data_enabled: bool,
+}
+
 /// 构建支持 SNI 的 TLS acceptor
 pub fn build_tls_acceptor(
     default_tls: Option<&ServerTls>,
@@ -29,12 +36,14 @@ pub fn build_tls_acceptor(
         tls_termination_enabled,
         default_vhost,
         vhosts,
-        default_tls
-            .and_then(|tls| tls.alpn_protocols.clone())
-            .unwrap_or_else(|| vec!["h2".to_string(), "http/1.1".to_string()]),
-        false,
-        None,
-        false,
+        TlsServerConfigOptions {
+            alpn_protocols: default_tls
+                .and_then(|tls| tls.alpn_protocols.clone())
+                .unwrap_or_else(|| vec!["h2".to_string(), "http/1.1".to_string()]),
+            http3_only: false,
+            max_request_body_bytes: None,
+            http3_early_data_enabled: false,
+        },
     )
     .map(|config| config.map(TlsAcceptor::from))
 }
@@ -54,10 +63,12 @@ pub fn build_http3_server_config(
         tls_termination_enabled,
         default_vhost,
         vhosts,
-        vec!["h3".to_string()],
-        true,
-        max_request_body_bytes,
-        http3_early_data_enabled,
+        TlsServerConfigOptions {
+            alpn_protocols: vec!["h3".to_string()],
+            http3_only: true,
+            max_request_body_bytes,
+            http3_early_data_enabled,
+        },
     )
 }
 
@@ -67,10 +78,7 @@ fn build_tls_server_config(
     tls_termination_enabled: bool,
     default_vhost: &VirtualHost,
     vhosts: &[VirtualHost],
-    alpn_protocols: Vec<String>,
-    http3_only: bool,
-    max_request_body_bytes: Option<usize>,
-    http3_early_data_enabled: bool,
+    options: TlsServerConfigOptions,
 ) -> Result<Option<Arc<ServerConfig>>> {
     if !tls_termination_enabled {
         return Ok(None);
@@ -123,7 +131,7 @@ fn build_tls_server_config(
     }
 
     let resolver = Arc::new(SniCertificateResolver::new(default_certs, all_certs));
-    let builder = build_server_config_builder(default_tls, http3_only)?;
+    let builder = build_server_config_builder(default_tls, options.http3_only)?;
     let mut config = if let Some(client_auth) = default_tls.and_then(|tls| tls.client_auth.as_ref())
     {
         let roots = load_ca_cert_store(&client_auth.ca_cert_path)?;
@@ -155,12 +163,13 @@ fn build_tls_server_config(
     } else {
         builder.with_no_client_auth().with_cert_resolver(resolver)
     };
-    config.alpn_protocols = alpn_protocols.into_iter().map(String::into_bytes).collect();
+    config.alpn_protocols = options.alpn_protocols.into_iter().map(String::into_bytes).collect();
     apply_session_policy(&mut config, default_tls)?;
-    if http3_only && http3_early_data_enabled {
+    if options.http3_only && options.http3_early_data_enabled {
         const DEFAULT_HTTP3_MAX_EARLY_DATA_SIZE: u32 = 64 * 1024;
 
-        config.max_early_data_size = max_request_body_bytes
+        config.max_early_data_size = options
+            .max_request_body_bytes
             .map(|limit| limit.min(u32::MAX as usize) as u32)
             .unwrap_or(DEFAULT_HTTP3_MAX_EARLY_DATA_SIZE);
     }

--- a/crates/rginx-http/src/tls/acceptor.rs
+++ b/crates/rginx-http/src/tls/acceptor.rs
@@ -18,7 +18,6 @@ use super::sni::{SniCertificateResolver, register_server_name_certificates};
 struct TlsServerConfigOptions {
     alpn_protocols: Vec<String>,
     http3_only: bool,
-    max_request_body_bytes: Option<usize>,
     http3_early_data_enabled: bool,
 }
 
@@ -41,7 +40,6 @@ pub fn build_tls_acceptor(
                 .and_then(|tls| tls.alpn_protocols.clone())
                 .unwrap_or_else(|| vec!["h2".to_string(), "http/1.1".to_string()]),
             http3_only: false,
-            max_request_body_bytes: None,
             http3_early_data_enabled: false,
         },
     )
@@ -54,7 +52,6 @@ pub fn build_http3_server_config(
     tls_termination_enabled: bool,
     default_vhost: &VirtualHost,
     vhosts: &[VirtualHost],
-    max_request_body_bytes: Option<usize>,
     http3_early_data_enabled: bool,
 ) -> Result<Option<Arc<ServerConfig>>> {
     build_tls_server_config(
@@ -66,7 +63,6 @@ pub fn build_http3_server_config(
         TlsServerConfigOptions {
             alpn_protocols: vec!["h3".to_string()],
             http3_only: true,
-            max_request_body_bytes,
             http3_early_data_enabled,
         },
     )
@@ -166,12 +162,8 @@ fn build_tls_server_config(
     config.alpn_protocols = options.alpn_protocols.into_iter().map(String::into_bytes).collect();
     apply_session_policy(&mut config, default_tls)?;
     if options.http3_only && options.http3_early_data_enabled {
-        const DEFAULT_HTTP3_MAX_EARLY_DATA_SIZE: u32 = 64 * 1024;
-
-        config.max_early_data_size = options
-            .max_request_body_bytes
-            .map(|limit| limit.min(u32::MAX as usize) as u32)
-            .unwrap_or(DEFAULT_HTTP3_MAX_EARLY_DATA_SIZE);
+        // Quinn only supports disabling early data entirely or allowing the TLS maximum.
+        config.max_early_data_size = u32::MAX;
     }
 
     Ok(Some(Arc::new(config)))

--- a/crates/rginx-runtime/src/bootstrap/listeners.rs
+++ b/crates/rginx-runtime/src/bootstrap/listeners.rs
@@ -67,6 +67,7 @@ impl ListenerWorkerGroup {
     }
 }
 
+/// Builds the initial active listener groups from config and inherited sockets.
 pub(super) async fn build_initial_listener_groups(
     config: &ConfigSnapshot,
     mut inherited: InheritedListeners,
@@ -112,6 +113,7 @@ pub(super) async fn build_initial_listener_groups(
     Ok(groups)
 }
 
+/// Prepares listener bindings that are new in the next config generation.
 pub(super) fn prepare_added_listener_bindings(
     next_config: &ConfigSnapshot,
     next_listeners: &[Listener],
@@ -185,6 +187,7 @@ pub(super) fn prepare_added_listener_bindings(
     Ok(prepared)
 }
 
+/// Reconciles the active listener worker groups against the next config generation.
 pub(super) async fn reconcile_listener_worker_groups(
     http_state: &rginx_http::SharedState,
     next_config: &ConfigSnapshot,
@@ -238,6 +241,7 @@ pub(super) async fn reconcile_listener_worker_groups(
     prune_draining_listener_groups(http_state, draining_listener_groups).await;
 }
 
+/// Removes drained listener groups once all their worker tasks have completed.
 pub(super) async fn prune_draining_listener_groups(
     http_state: &rginx_http::SharedState,
     draining_listener_groups: &mut Vec<ListenerWorkerGroup>,
@@ -278,6 +282,7 @@ pub(super) async fn join_listener_worker_groups(
     Ok(())
 }
 
+/// Broadcasts shutdown to every listener group in the iterator.
 pub(super) fn initiate_shutdown_for_groups<'a>(
     groups: impl IntoIterator<Item = &'a ListenerWorkerGroup>,
 ) {
@@ -286,6 +291,7 @@ pub(super) fn initiate_shutdown_for_groups<'a>(
     }
 }
 
+/// Aborts every listener worker task in the iterator.
 pub(super) fn abort_listener_worker_groups<'a>(
     groups: impl IntoIterator<Item = &'a ListenerWorkerGroup>,
 ) {
@@ -312,6 +318,7 @@ pub(super) async fn join_aborted_listener_worker_groups(
     draining_listener_groups.clear();
 }
 
+/// Prepares sockets, Tokio listeners, and HTTP/3 endpoints for one listener.
 fn prepare_listener_worker_group(
     listener: Listener,
     std_listener: Arc<StdTcpListener>,
@@ -343,6 +350,7 @@ fn prepare_listener_worker_group(
     })
 }
 
+/// Activates a prepared listener group by spawning its worker tasks.
 fn activate_prepared_listener_worker_group(
     prepared: PreparedListenerWorkerGroup,
     http_state: rginx_http::SharedState,
@@ -404,6 +412,7 @@ fn activate_prepared_listener_worker_group(
     }
 }
 
+/// Waits for all worker tasks in a listener group to finish.
 async fn join_listener_worker_group(group: &mut ListenerWorkerGroup) -> Result<()> {
     for (worker_index, task) in group.tasks.iter_mut().enumerate() {
         task.await.map_err(|error| {
@@ -417,6 +426,7 @@ async fn join_listener_worker_group(group: &mut ListenerWorkerGroup) -> Result<(
     Ok(())
 }
 
+/// Waits for all worker tasks in an already-aborted listener group to settle.
 async fn join_aborted_listener_worker_group(group: &mut ListenerWorkerGroup) {
     for task in group.tasks.iter_mut() {
         if let Err(error) = task.await
@@ -428,12 +438,14 @@ async fn join_aborted_listener_worker_group(group: &mut ListenerWorkerGroup) {
     group.tasks.clear();
 }
 
+/// Binds a nonblocking TCP listener for the given socket address.
 fn bind_std_listener(listen_addr: std::net::SocketAddr) -> Result<StdTcpListener> {
     let socket = StdTcpListener::bind(listen_addr)?;
     socket.set_nonblocking(true)?;
     Ok(socket)
 }
 
+/// Binds one UDP socket per accept worker for an HTTP/3 listener.
 fn bind_std_udp_sockets(
     listen_addr: std::net::SocketAddr,
     count: usize,
@@ -442,6 +454,7 @@ fn bind_std_udp_sockets(
     bind_std_udp_sockets_with_reuse_port(listen_addr, count, count > 1)
 }
 
+/// Normalizes inherited UDP sockets to match the current accept worker count.
 fn normalize_inherited_udp_sockets(
     listener_name: &str,
     listen_addr: std::net::SocketAddr,
@@ -468,6 +481,7 @@ fn normalize_inherited_udp_sockets(
     Ok(sockets)
 }
 
+/// Binds a batch of UDP sockets with a fixed `SO_REUSEPORT` policy.
 fn bind_std_udp_sockets_with_reuse_port(
     listen_addr: std::net::SocketAddr,
     count: usize,
@@ -477,6 +491,7 @@ fn bind_std_udp_sockets_with_reuse_port(
     (0..count).map(|_| bind_std_udp_socket(listen_addr, reuse_port).map(Arc::new)).collect()
 }
 
+/// Binds a single nonblocking UDP socket, optionally enabling `SO_REUSEPORT`.
 fn bind_std_udp_socket(
     listen_addr: std::net::SocketAddr,
     reuse_port: bool,

--- a/crates/rginx-runtime/src/bootstrap/listeners.rs
+++ b/crates/rginx-runtime/src/bootstrap/listeners.rs
@@ -80,9 +80,22 @@ pub(super) async fn build_initial_listener_groups(
             Some(listener_socket) => listener_socket,
             None => bind_std_listener(listener.server.listen_addr)?,
         };
+        let desired_udp_socket_count = config.runtime.accept_workers.max(1);
         let std_udp_sockets = match &listener.http3 {
             Some(http3) => match inherited.udp.remove(&http3.listen_addr) {
-                Some(sockets) => sockets.into_iter().map(Arc::new).collect(),
+                Some(sockets) => {
+                    let mut sockets = sockets.into_iter().map(Arc::new).collect::<Vec<_>>();
+                    if sockets.len() > desired_udp_socket_count {
+                        sockets.truncate(desired_udp_socket_count);
+                    } else if sockets.len() < desired_udp_socket_count {
+                        sockets.extend(bind_std_udp_sockets_with_reuse_port(
+                            http3.listen_addr,
+                            desired_udp_socket_count - sockets.len(),
+                            desired_udp_socket_count > 1,
+                        )?);
+                    }
+                    sockets
+                }
                 None => bind_std_udp_sockets(http3.listen_addr, config.runtime.accept_workers)?,
             },
             None => Vec::new(),
@@ -433,7 +446,16 @@ fn bind_std_udp_sockets(
     count: usize,
 ) -> Result<Vec<Arc<StdUdpSocket>>> {
     let count = count.max(1);
-    (0..count).map(|_| bind_std_udp_socket(listen_addr, count > 1).map(Arc::new)).collect()
+    bind_std_udp_sockets_with_reuse_port(listen_addr, count, count > 1)
+}
+
+fn bind_std_udp_sockets_with_reuse_port(
+    listen_addr: std::net::SocketAddr,
+    count: usize,
+    reuse_port: bool,
+) -> Result<Vec<Arc<StdUdpSocket>>> {
+    let count = count.max(1);
+    (0..count).map(|_| bind_std_udp_socket(listen_addr, reuse_port).map(Arc::new)).collect()
 }
 
 fn bind_std_udp_socket(

--- a/crates/rginx-runtime/src/bootstrap/listeners.rs
+++ b/crates/rginx-runtime/src/bootstrap/listeners.rs
@@ -83,25 +83,12 @@ pub(super) async fn build_initial_listener_groups(
         let desired_udp_socket_count = config.runtime.accept_workers.max(1);
         let std_udp_sockets = match &listener.http3 {
             Some(http3) => match inherited.udp.remove(&http3.listen_addr) {
-                Some(sockets) => {
-                    let mut sockets = sockets.into_iter().map(Arc::new).collect::<Vec<_>>();
-                    if sockets.len() == 1 && desired_udp_socket_count > 1 {
-                        return Err(Error::Server(format!(
-                            "listener `{}` cannot increase HTTP/3 accept_workers from 1 to {} during restart; perform a cold restart or keep the previous worker count",
-                            listener.name, desired_udp_socket_count,
-                        )));
-                    }
-                    if sockets.len() > desired_udp_socket_count {
-                        sockets.truncate(desired_udp_socket_count);
-                    } else if sockets.len() < desired_udp_socket_count {
-                        sockets.extend(bind_std_udp_sockets_with_reuse_port(
-                            http3.listen_addr,
-                            desired_udp_socket_count - sockets.len(),
-                            desired_udp_socket_count > 1,
-                        )?);
-                    }
-                    sockets
-                }
+                Some(sockets) => normalize_inherited_udp_sockets(
+                    &listener.name,
+                    http3.listen_addr,
+                    sockets,
+                    desired_udp_socket_count,
+                )?,
                 None => bind_std_udp_sockets(http3.listen_addr, config.runtime.accept_workers)?,
             },
             None => Vec::new(),
@@ -455,6 +442,32 @@ fn bind_std_udp_sockets(
     bind_std_udp_sockets_with_reuse_port(listen_addr, count, count > 1)
 }
 
+fn normalize_inherited_udp_sockets(
+    listener_name: &str,
+    listen_addr: std::net::SocketAddr,
+    sockets: Vec<StdUdpSocket>,
+    desired_socket_count: usize,
+) -> Result<Vec<Arc<StdUdpSocket>>> {
+    let desired_socket_count = desired_socket_count.max(1);
+    let mut sockets = sockets.into_iter().map(Arc::new).collect::<Vec<_>>();
+    if sockets.len() == 1 && desired_socket_count > 1 {
+        return Err(Error::Server(format!(
+            "listener `{listener_name}` cannot increase HTTP/3 accept_workers from 1 to {} during restart; perform a cold restart or keep the previous worker count",
+            desired_socket_count,
+        )));
+    }
+    if sockets.len() > desired_socket_count {
+        sockets.truncate(desired_socket_count);
+    } else if sockets.len() < desired_socket_count {
+        sockets.extend(bind_std_udp_sockets_with_reuse_port(
+            listen_addr,
+            desired_socket_count - sockets.len(),
+            desired_socket_count > 1,
+        )?);
+    }
+    Ok(sockets)
+}
+
 fn bind_std_udp_sockets_with_reuse_port(
     listen_addr: std::net::SocketAddr,
     count: usize,
@@ -625,5 +638,62 @@ mod tests {
         for socket in sockets {
             assert_eq!(socket.local_addr().expect("udp socket addr should exist"), listen_addr);
         }
+    }
+
+    #[test]
+    fn normalize_inherited_udp_sockets_truncates_to_worker_count() {
+        let seed =
+            bind_std_udp_socket("127.0.0.1:0".parse().expect("socket addr should parse"), false)
+                .expect("seed udp socket should bind");
+        let listen_addr = seed.local_addr().expect("seed udp addr should exist");
+        drop(seed);
+
+        let inherited = (0..3)
+            .map(|_| {
+                bind_std_udp_socket(listen_addr, true).expect("inherited udp socket should bind")
+            })
+            .collect::<Vec<_>>();
+
+        let sockets = normalize_inherited_udp_sockets("default", listen_addr, inherited, 2)
+            .expect("normalizing inherited sockets should succeed");
+        assert_eq!(sockets.len(), 2);
+        for socket in sockets {
+            assert_eq!(socket.local_addr().expect("udp socket addr should exist"), listen_addr);
+        }
+    }
+
+    #[test]
+    fn normalize_inherited_udp_sockets_fills_missing_workers() {
+        let seed =
+            bind_std_udp_socket("127.0.0.1:0".parse().expect("socket addr should parse"), false)
+                .expect("seed udp socket should bind");
+        let listen_addr = seed.local_addr().expect("seed udp addr should exist");
+        drop(seed);
+
+        let inherited = (0..2)
+            .map(|_| {
+                bind_std_udp_socket(listen_addr, true).expect("inherited udp socket should bind")
+            })
+            .collect::<Vec<_>>();
+
+        let sockets = normalize_inherited_udp_sockets("default", listen_addr, inherited, 3)
+            .expect("normalizing inherited sockets should succeed");
+        assert_eq!(sockets.len(), 3);
+        for socket in sockets {
+            assert_eq!(socket.local_addr().expect("udp socket addr should exist"), listen_addr);
+        }
+    }
+
+    #[test]
+    fn normalize_inherited_udp_sockets_rejects_one_to_many_restart() {
+        let inherited = vec![
+            bind_std_udp_socket("127.0.0.1:0".parse().expect("socket addr should parse"), false)
+                .expect("inherited udp socket should bind"),
+        ];
+        let listen_addr = inherited[0].local_addr().expect("udp socket addr should exist");
+
+        let error = normalize_inherited_udp_sockets("default", listen_addr, inherited, 3)
+            .expect_err("one-to-many restart should fail");
+        assert!(error.to_string().contains("cannot increase HTTP/3 accept_workers from 1 to 3"));
     }
 }

--- a/crates/rginx-runtime/src/bootstrap/listeners.rs
+++ b/crates/rginx-runtime/src/bootstrap/listeners.rs
@@ -85,6 +85,12 @@ pub(super) async fn build_initial_listener_groups(
             Some(http3) => match inherited.udp.remove(&http3.listen_addr) {
                 Some(sockets) => {
                     let mut sockets = sockets.into_iter().map(Arc::new).collect::<Vec<_>>();
+                    if sockets.len() == 1 && desired_udp_socket_count > 1 {
+                        return Err(Error::Server(format!(
+                            "listener `{}` cannot increase HTTP/3 accept_workers from 1 to {} during restart; perform a cold restart or keep the previous worker count",
+                            listener.name, desired_udp_socket_count,
+                        )));
+                    }
                     if sockets.len() > desired_udp_socket_count {
                         sockets.truncate(desired_udp_socket_count);
                     } else if sockets.len() < desired_udp_socket_count {

--- a/scripts/run-http3-release-gate.sh
+++ b/scripts/run-http3-release-gate.sh
@@ -88,6 +88,10 @@ while [[ $# -gt 0 ]]; do
         --netem-profile)
             [[ $# -ge 2 ]] || die "--netem-profile requires a value"
             NETEM_PROFILE="$2"
+            case "${NETEM_PROFILE}" in
+                none|loss|reorder|jitter) ;;
+                *) die "--netem-profile must be one of: none, loss, reorder, jitter (got `${NETEM_PROFILE}`)" ;;
+            esac
             shift 2
             ;;
         --netem-dev)

--- a/scripts/run-http3-release-gate.sh
+++ b/scripts/run-http3-release-gate.sh
@@ -90,7 +90,7 @@ while [[ $# -gt 0 ]]; do
             NETEM_PROFILE="$2"
             case "${NETEM_PROFILE}" in
                 none|loss|reorder|jitter) ;;
-                *) die "--netem-profile must be one of: none, loss, reorder, jitter (got `${NETEM_PROFILE}`)" ;;
+                *) die "--netem-profile must be one of: none, loss, reorder, jitter (got '${NETEM_PROFILE}')" ;;
             esac
             shift 2
             ;;

--- a/scripts/run-http3-soak.sh
+++ b/scripts/run-http3-soak.sh
@@ -127,7 +127,9 @@ orig_mtu=""
 
 clear_faults() {
     if [[ "${need_privileged}" -eq 1 ]]; then
-        tc qdisc del dev "${NETEM_DEV}" root >/dev/null 2>&1 || true
+        if [[ "${NETEM_PROFILE}" != "none" ]]; then
+            tc qdisc del dev "${NETEM_DEV}" root >/dev/null 2>&1 || true
+        fi
         if [[ -n "${orig_mtu}" ]]; then
             ip link set dev "${NETEM_DEV}" mtu "${orig_mtu}" >/dev/null 2>&1 || true
         fi

--- a/scripts/run-http3-soak.sh
+++ b/scripts/run-http3-soak.sh
@@ -138,7 +138,7 @@ trap clear_faults EXIT
 
 apply_faults() {
     clear_faults
-    if [[ -z "${orig_mtu}" && "${need_privileged}" -eq 1 ]]; then
+    if [[ -n "${MTU}" && -z "${orig_mtu}" && "${need_privileged}" -eq 1 ]]; then
         orig_mtu="$(ip -o link show dev "${NETEM_DEV}" | awk '{for (i = 1; i <= NF; i++) if ($i == "mtu") { print $(i + 1); exit }}')"
     fi
     case "${NETEM_PROFILE}" in

--- a/scripts/run-http3-soak.sh
+++ b/scripts/run-http3-soak.sh
@@ -96,8 +96,12 @@ if [[ "${NETEM_PROFILE}" != "none" || -n "${MTU}" ]]; then
     need_privileged=1
 fi
 if [[ "${need_privileged}" -eq 1 ]]; then
-    have tc || die "tc is required when --netem-profile is used"
-    have ip || die "ip is required when --mtu is used"
+    if [[ "${NETEM_PROFILE}" != "none" ]]; then
+        have tc || die "tc is required when --netem-profile is used"
+    fi
+    if [[ -n "${MTU}" ]]; then
+        have ip || die "ip is required when --mtu is used"
+    fi
     [[ "${EUID}" -eq 0 ]] || die "root privileges are required for netem/mtu operations"
 fi
 


### PR DESCRIPTION
This PR merges the validated follow-up fixes from the review replay branch back into `main` before publishing `v0.1.3-rc.11`.

Included:
- HTTP/3 review fixes from PR #43
- flaky 0-RTT test stabilization
- release/test script fixes
- helper doc comments and small test cleanups

Source review thread: #43