### PR TITLE
fix: pin fuzz scripts to the toolchain host target

### DIFF
--- a/scripts/fuzz-common.sh
+++ b/scripts/fuzz-common.sh
@@ -11,6 +11,12 @@ fuzz_toolchain_channel() {
     ' "${fuzz_dir}/rust-toolchain.toml"
 }
 
+fuzz_host_triple() {
+    local toolchain="$1"
+
+    rustup run "${toolchain}" rustc -vV | sed -n 's|host: ||p'
+}
+
 fuzz_stage_seed_corpus() {
     local fuzz_dir="$1"
     local target="$2"

--- a/scripts/run-fuzz-coverage.sh
+++ b/scripts/run-fuzz-coverage.sh
@@ -112,7 +112,7 @@ FUZZ_TOOLCHAIN="$(fuzz_toolchain_channel "${FUZZ_DIR}")"
 rustup toolchain list | grep -Fq "${FUZZ_TOOLCHAIN}" \
     || die "fuzz toolchain ${FUZZ_TOOLCHAIN} is not installed; run: rustup toolchain install ${FUZZ_TOOLCHAIN}"
 
-HOST_TRIPLE="$(rustup run "${FUZZ_TOOLCHAIN}" rustc -vV | sed -n 's|host: ||p')"
+HOST_TRIPLE="$(fuzz_host_triple "${FUZZ_TOOLCHAIN}")"
 [[ -n "${HOST_TRIPLE}" ]] || die "failed to detect host triple for ${FUZZ_TOOLCHAIN}"
 
 if [[ -z "${LLVM_BIN_DIR}" ]]; then
@@ -163,7 +163,7 @@ if [[ "${#target_options[@]}" -gt 0 ]]; then
 fi
 (
     cd "${FUZZ_DIR}"
-    coverage_cmd=(cargo "+${FUZZ_TOOLCHAIN}" fuzz coverage "${TARGET}" "${CORPUS_DIR}")
+    coverage_cmd=(cargo "+${FUZZ_TOOLCHAIN}" fuzz coverage --target "${HOST_TRIPLE}" "${TARGET}" "${CORPUS_DIR}")
     if [[ "${#coverage_options[@]}" -gt 0 ]]; then
         coverage_cmd+=(-- "${coverage_options[@]}")
     fi

--- a/scripts/run-fuzz-smoke.sh
+++ b/scripts/run-fuzz-smoke.sh
@@ -81,6 +81,8 @@ FUZZ_TOOLCHAIN="$(fuzz_toolchain_channel "${FUZZ_DIR}")"
 [[ -n "${FUZZ_TOOLCHAIN}" ]] || die "failed to resolve fuzz toolchain from ${FUZZ_DIR}/rust-toolchain.toml"
 rustup toolchain list | grep -Fq "${FUZZ_TOOLCHAIN}" \
     || die "fuzz toolchain ${FUZZ_TOOLCHAIN} is not installed; run: rustup toolchain install ${FUZZ_TOOLCHAIN}"
+HOST_TRIPLE="$(fuzz_host_triple "${FUZZ_TOOLCHAIN}")"
+[[ -n "${HOST_TRIPLE}" ]] || die "failed to detect host triple for ${FUZZ_TOOLCHAIN}"
 
 TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rginx-fuzz-smoke.XXXXXX")"
 
@@ -119,7 +121,9 @@ for target in "${targets[@]}"; do
         log "using target options ${FUZZ_DIR}/options/${target}.options"
         fuzz_args+=("${target_options[@]}")
     fi
-    fuzz_cmd=(cargo "+${FUZZ_TOOLCHAIN}" fuzz run "${target}" "${corpus_dir}")
+    # Always fuzz against the active toolchain host triple so CI-level target
+    # overrides do not force unsupported musl + sanitizer builds.
+    fuzz_cmd=(cargo "+${FUZZ_TOOLCHAIN}" fuzz run --target "${HOST_TRIPLE}" "${target}" "${corpus_dir}")
     if [[ "${#fuzz_args[@]}" -gt 0 ]]; then
         fuzz_cmd+=(-- "${fuzz_args[@]}")
     fi


### PR DESCRIPTION
## Summary
- pin fuzz smoke and coverage runs to the active nightly toolchain host triple
- avoid CI-level target overrides from forcing unsupported musl + sanitizer builds
- share host triple resolution in the common fuzz script helper

## Validation
- bash -n scripts/fuzz-common.sh scripts/run-fuzz-smoke.sh scripts/run-fuzz-coverage.sh
- CARGO_BUILD_TARGET=x86_64-unknown-linux-musl ./scripts/run-fuzz-smoke.sh --target certificate_inspect --seconds 1

## Context
The v0.1.3-rc.13 release workflow failed in `Run Prerelease Fuzz Smoke` because `cargo-fuzz` built for `x86_64-unknown-linux-musl`, which is incompatible with sanitizer-based fuzzing on the Ubuntu runner.