### PR TITLE
feat: add route response cache MVP

### DIFF
--- a/CACHE_SUPPORT_PLAN.md
+++ b/CACHE_SUPPORT_PLAN.md
@@ -1,0 +1,233 @@
+# rginx 缓存支持阶段计划
+
+## 当前实施状态
+
+- 阶段 0：已完成。第一版边界固定为 route 级反向代理响应缓存，默认关闭。
+- 阶段 1：已完成。缓存配置可 parse、validate、compile，并出现在
+  `rginx check` 摘要中。
+- 阶段 2：已完成 MVP。已实现内存 index + 磁盘 metadata/body 的缓存模块，
+  覆盖 key、TTL、存储策略、启动扫描、损坏 metadata 和对象大小限制。
+- 阶段 3：已完成 MVP。代理路径已接入 lookup/store，并输出 `X-Cache:
+  HIT`、`MISS`、`BYPASS`、`EXPIRED`。
+
+本文档按阶段规划 rginx 的缓存支持。第一目标是实现用户可配置的 HTTP
+反向代理响应缓存。现有内部缓存，例如 DNS 解析缓存、上游 client pool、
+HTTP/3 session、TLS session 和 OCSP staple cache，继续作为运行时实现细节；
+除非后续阶段明确扩展其配置或观测面。
+
+## 阶段 0：范围与边界
+
+目标：先确定第一版缓存边界，避免影响现有代理行为。
+
+决策：
+
+- 第一版只缓存反向代理响应。
+- 默认关闭缓存，只有 route 显式配置后才启用。
+- 初始只缓存 `GET` 和 `HEAD`。
+- 默认 bypass 带 `Authorization` 的请求。
+- 默认不存储带 `Set-Cookie` 的响应。
+- 第一版将 `Range` 请求视为 bypass。
+- 采用“内存 metadata/index + 磁盘 body”的存储方式。
+- 未启用缓存的 route 行为必须保持不变。
+
+验收标准：
+
+- 未配置缓存策略的 route 行为与当前完全一致。
+- 明确 cache key、TTL、bypass、store、stale 的第一版规则。
+- 不支持或无法安全判断的场景默认 bypass 或不写入缓存。
+
+## 阶段 1：配置模型与编译链路
+
+目标：先让缓存配置能 parse、validate、compile，并出现在 `rginx check`
+输出中；暂不接入真实代理数据路径。
+
+改动范围：
+
+- `crates/rginx-core`：新增运行时缓存模型，例如 `CacheZone` 和
+  `RouteCachePolicy`。
+- `crates/rginx-config/src/model`：新增 RON 配置结构。
+- `crates/rginx-config/src/validate`：校验 zone 名称、路径、TTL、容量、
+  单对象大小和 route 引用。
+- `crates/rginx-config/src/compile`：将 cache zones 和 route cache policy
+  编译进 `ConfigSnapshot`。
+- `crates/rginx-app/src/check`：渲染 cache zone 和 route cache 摘要。
+
+候选配置形态：
+
+```ron
+cache_zones: [
+    CacheZoneConfig(
+        name: "default",
+        path: "/var/cache/rginx/default",
+        max_size_bytes: Some(1073741824),
+        inactive_secs: Some(600),
+        default_ttl_secs: Some(60),
+        max_entry_bytes: Some(10485760),
+    ),
+]
+```
+
+```ron
+LocationConfig(
+    matcher: Prefix("/assets/"),
+    handler: Proxy(upstream: "app"),
+    cache: Some(CacheRouteConfig(
+        zone: "default",
+        methods: ["GET", "HEAD"],
+        statuses: [200, 301, 302, 404],
+        key: Some("{scheme}:{host}:{uri}"),
+        stale_if_error_secs: Some(60),
+    )),
+)
+```
+
+验收标准：
+
+- 合法缓存配置可以 parse、validate、compile。
+- route 引用不存在的 cache zone 时给出清晰错误。
+- 非法路径、容量、TTL、method、status 都能被校验拦截。
+- `rginx check` 能展示缓存 zone 和 route cache 策略。
+
+## 阶段 2：缓存存储模块
+
+目标：实现独立 `rginx-http/src/cache/` 模块，先不接入 proxy 主流程。
+
+建议模块布局：
+
+- `mod.rs`：模块门面和窄 public API。
+- `key.rs`：cache key 模板解析与渲染。
+- `policy.rs`：request/response 是否可缓存的判断。
+- `metadata.rs`：status、headers、时间戳、validator、body metadata。
+- `store.rs`：磁盘布局、原子写入、读取、删除和损坏处理。
+- `index.rs`：内存索引、字节统计、inactive 跟踪和淘汰候选选择。
+- `body.rs`：将缓存对象转换为 `HttpBody`。
+- `stats.rs`：HIT、MISS、BYPASS、EXPIRED、STALE、WRITE_ERROR、EVICT 计数。
+
+初始存储策略：
+
+- 使用 hash 后的 cache key 作为磁盘路径。
+- metadata 和 body 通过临时文件加 rename 做原子写入。
+- 超过 `max_entry_bytes` 的对象不写入。
+- metadata 损坏时忽略或清理，不 panic。
+- 内存 index 负责快速 lookup 和容量统计。
+- 启动或 reload 时扫描 metadata 重建 index，并清理无法验证的半成品文件。
+
+验收标准：
+
+- 单元测试覆盖 key 渲染、TTL 计算、header policy、原子写、metadata
+  解码失败和单对象大小限制。
+- 损坏缓存条目不会导致进程崩溃。
+- 中断写入不会生成可被当作有效缓存的半成品条目。
+
+## 阶段 3：接入代理数据路径 MVP
+
+目标：让 route 级缓存策略对真实代理请求生效。
+
+接入点：
+
+- 发送 upstream 请求前执行 cache lookup。
+- fresh hit 直接返回缓存响应。
+- 在请求上下文中记录 miss、bypass、expired、write 结果。
+- upstream 成功响应后判断是否写入缓存。
+- 增加 `X-Cache: HIT`、`MISS`、`BYPASS`、`EXPIRED` 或 `STALE`。
+
+MVP 行为：
+
+- 缓存 `GET` 和 `HEAD`。
+- 默认只存储配置允许的状态码，初始可为 `200`、`301`、`302`、`404`。
+- 尊重 `Cache-Control: no-store` 和 `private`。
+- 尊重 `Expires` 与 `Cache-Control: max-age`。
+- 上游没有显式 freshness 时使用 route `default_ttl`。
+- 过期的 `Expires` 明确表示 TTL 为 0，不回退到 `default_ttl`；上游时间戳错误会导致对应响应不写入缓存。
+- 无法从 body size hint 安全确认大小的响应不写入缓存，避免为缓存目的全量读取未知大小的流式响应。
+- 默认 bypass `Authorization` 请求。
+- 默认不存储 `Set-Cookie` 响应。
+- MVP 中 expired 先按 miss 处理，不返回 stale。
+
+验收标准：
+
+- 集成测试验证 cacheable `GET` 的 `MISS -> HIT`。
+- `HEAD` 能复用缓存 metadata，且不返回 body。
+- `Authorization`、`Set-Cookie`、`no-store`、`private`、`Range` 场景按规则
+  bypass 或不写入。
+- 未显式启用 stale 时，上游失败不会返回过期缓存。
+- 未启用缓存的 proxy 行为保持不变。
+
+## 阶段 4：观测与 Admin
+
+目标：把缓存行为接入现有 runtime inspection 和 admin 体系。
+
+改动范围：
+
+- `SharedState` 增加 cache registry 和 stats。
+- `rginx-http/src/state/snapshots` 增加 cache snapshot 结构。
+- admin snapshot 增加可选 `cache` module。
+- CLI 增加 cache stats 渲染，可以先做独立 `cache` 命令，也可以并入
+  `status` 和 `snapshot`。
+- access log 增加 `$cache_status`。
+
+指标：
+
+- zone 条目数。
+- zone 当前字节数。
+- hit、miss、bypass、expired、stale。
+- write success、write error。
+- eviction count。
+- zone 级视图稳定后，再考虑 route 级 cache counters。
+
+验收标准：
+
+- `snapshot --include cache` 返回结构化 JSON。
+- `status` 或独立 cache 命令能展示 zone 级缓存健康状态。
+- access log 可输出 cache status。
+- cache stats 更新不会造成过量 snapshot churn。
+
+## 阶段 5：HTTP 缓存语义增强
+
+目标：从基础响应缓存升级到更完整的 HTTP cache 语义。
+
+功能：
+
+- 支持基于 `ETag` 和 `Last-Modified` 的条件 revalidation。
+- revalidation 时发送 `If-None-Match` 和 `If-Modified-Since`。
+- 上游返回 `304 Not Modified` 时刷新 metadata 并复用缓存 body。
+- 请求 `Cache-Control: no-cache` 触发 revalidation。
+- 支持 `stale-if-error`。
+- 支持 `stale-while-revalidate`。
+- 支持 `Vary`，优先实现 `Accept-Encoding`。
+- 增加 cache lock，避免同 key 并发 miss 同时打 upstream。
+
+验收标准：
+
+- `304` 能刷新 freshness，且无需重写 body。
+- upstream timeout 或 5xx 只有在策略允许时才返回 stale。
+- 并发同 key miss 测试中，只有一个请求访问 upstream。
+- `Vary: Accept-Encoding` 不会返回不兼容的编码版本。
+
+## 阶段 6：运维与生命周期
+
+目标：让缓存具备长期运行和维护能力。
+
+功能：
+
+- 后台淘汰和 inactive cleanup 的长期运行策略。
+- admin purge：按 zone、精确 key、prefix 清理。
+- 明确 reload 时 cache zone 和 route cache policy 的行为。
+- 安装脚本创建 cache 目录。
+- 权限和磁盘布局问题给出清晰错误。
+- 磁盘空间不足时通过淘汰或受控 bypass 降级。
+
+验收标准：
+
+- reload 不丢弃仍可用的缓存数据。
+- purge 有集成测试覆盖。
+- cache 目录权限错误清晰可诊断。
+- 磁盘写入失败只降级缓存，不破坏未缓存代理流量。
+- 安装流程创建预期 cache 目录，并设置合理 owner 和权限。
+
+## 推荐交付顺序
+
+第一轮里程碑建议覆盖阶段 1 到阶段 3：配置模型、cache store skeleton、
+以及 route 级 `GET`/`HEAD` 基础 `HIT`/`MISS`/`BYPASS`。阶段 4 应紧随其后，
+确保缓存行为可观测后再扩展语义。阶段 5 和阶段 6 涉及 HTTP 正确性、并发
+和运维行为，建议继续拆成更小的 PR 推进。

--- a/crates/rginx-app/src/check/render.rs
+++ b/crates/rginx-app/src/check/render.rs
@@ -9,12 +9,13 @@ pub(crate) fn print_check_success(config_path: &Path, summary: CheckSummary) {
     print_configuration_summary(config_path, &summary);
     listeners::print_listener_details(&summary);
     print_route_transport_details(&summary);
+    print_cache_zone_details(&summary);
     tls::print_tls_details(&summary);
 }
 
 fn print_configuration_summary(config_path: &Path, summary: &CheckSummary) {
     println!(
-        "configuration is valid: config={} listener_model={} listeners={} listener_bindings={} listen_addrs={} bind_addrs={} tls={} http3={} http3_early_data_enabled_listeners={} vhosts={} routes={} upstreams={} worker_threads={} accept_workers={}",
+        "configuration is valid: config={} listener_model={} listeners={} listener_bindings={} listen_addrs={} bind_addrs={} tls={} http3={} http3_early_data_enabled_listeners={} vhosts={} routes={} upstreams={} cache_zones={} cache_enabled_routes={} worker_threads={} accept_workers={}",
         config_path.display(),
         summary.listener_model,
         summary.listener_count,
@@ -27,6 +28,8 @@ fn print_configuration_summary(config_path: &Path, summary: &CheckSummary) {
         summary.total_vhost_count,
         summary.total_route_count,
         summary.upstream_count,
+        summary.cache_zone_count,
+        summary.cache_enabled_route_count,
         summary
             .worker_threads
             .map(|count: usize| count.to_string())
@@ -37,7 +40,7 @@ fn print_configuration_summary(config_path: &Path, summary: &CheckSummary) {
 
 fn print_route_transport_details(summary: &CheckSummary) {
     println!(
-        "route_transport_details=request_buffering_auto={} request_buffering_on={} request_buffering_off={} response_buffering_auto={} response_buffering_on={} response_buffering_off={} compression_auto={} compression_off={} compression_force={} custom_compression_min_bytes_routes={} custom_compression_content_types_routes={} streaming_response_idle_timeout_routes={}",
+        "route_transport_details=request_buffering_auto={} request_buffering_on={} request_buffering_off={} response_buffering_auto={} response_buffering_on={} response_buffering_off={} compression_auto={} compression_off={} compression_force={} custom_compression_min_bytes_routes={} custom_compression_content_types_routes={} streaming_response_idle_timeout_routes={} cache_enabled_routes={}",
         summary.route_transport.request_buffering_auto_routes,
         summary.route_transport.request_buffering_on_routes,
         summary.route_transport.request_buffering_off_routes,
@@ -50,7 +53,22 @@ fn print_route_transport_details(summary: &CheckSummary) {
         summary.route_transport.custom_compression_min_bytes_routes,
         summary.route_transport.custom_compression_content_types_routes,
         summary.route_transport.streaming_response_idle_timeout_routes,
+        summary.route_transport.cache_enabled_routes,
     );
+}
+
+fn print_cache_zone_details(summary: &CheckSummary) {
+    for zone in &summary.cache_zones {
+        println!(
+            "check_cache_zone name={} path={} max_size_bytes={} inactive_secs={} default_ttl_secs={} max_entry_bytes={}",
+            zone.name,
+            zone.path.display(),
+            zone.max_size_bytes.map(|value| value.to_string()).unwrap_or_else(|| "-".to_string()),
+            zone.inactive_secs,
+            zone.default_ttl_secs,
+            zone.max_entry_bytes,
+        );
+    }
 }
 
 fn render_listener_addrs(summary: &CheckSummary) -> String {

--- a/crates/rginx-app/src/check/routes.rs
+++ b/crates/rginx-app/src/check/routes.rs
@@ -12,6 +12,7 @@ pub(super) struct RouteTransportCheckDetails {
     pub(super) custom_compression_min_bytes_routes: usize,
     pub(super) custom_compression_content_types_routes: usize,
     pub(super) streaming_response_idle_timeout_routes: usize,
+    pub(super) cache_enabled_routes: usize,
 }
 
 pub(super) fn route_transport_check_details(
@@ -46,6 +47,9 @@ pub(super) fn route_transport_check_details(
         }
         if route.streaming_response_idle_timeout.is_some() {
             details.streaming_response_idle_timeout_routes += 1;
+        }
+        if route.cache.is_some() {
+            details.cache_enabled_routes += 1;
         }
     }
 

--- a/crates/rginx-app/src/check/summary.rs
+++ b/crates/rginx-app/src/check/summary.rs
@@ -14,10 +14,22 @@ pub(crate) struct CheckSummary {
     pub(super) total_vhost_count: usize,
     pub(super) total_route_count: usize,
     pub(super) upstream_count: usize,
+    pub(super) cache_zone_count: usize,
+    pub(super) cache_enabled_route_count: usize,
+    pub(super) cache_zones: Vec<CheckCacheZoneSummary>,
     pub(super) worker_threads: Option<usize>,
     pub(super) accept_workers: usize,
     pub(super) route_transport: RouteTransportCheckDetails,
     pub(super) tls: TlsCheckDetails,
+}
+
+pub(super) struct CheckCacheZoneSummary {
+    pub(super) name: String,
+    pub(super) path: PathBuf,
+    pub(super) max_size_bytes: Option<usize>,
+    pub(super) inactive_secs: u64,
+    pub(super) default_ttl_secs: u64,
+    pub(super) max_entry_bytes: usize,
 }
 
 pub(super) struct CheckListenerSummary {
@@ -54,6 +66,8 @@ pub(super) struct CheckListenerBindingSummary {
 }
 
 pub(crate) fn build_check_summary(config: &rginx_config::ConfigSnapshot) -> CheckSummary {
+    let route_transport = route_transport_check_details(config);
+
     CheckSummary {
         listener_model: listener_model(
             config.total_listener_count(),
@@ -76,11 +90,31 @@ pub(crate) fn build_check_summary(config: &rginx_config::ConfigSnapshot) -> Chec
         total_vhost_count: config.total_vhost_count(),
         total_route_count: config.total_route_count(),
         upstream_count: config.upstreams.len(),
+        cache_zone_count: config.cache_zones.len(),
+        cache_enabled_route_count: route_transport.cache_enabled_routes,
+        cache_zones: check_cache_zone_summaries(config),
         worker_threads: config.runtime.worker_threads,
         accept_workers: config.runtime.accept_workers,
-        route_transport: route_transport_check_details(config),
+        route_transport,
         tls: tls_check_details(config),
     }
+}
+
+fn check_cache_zone_summaries(config: &rginx_config::ConfigSnapshot) -> Vec<CheckCacheZoneSummary> {
+    let mut zones = config
+        .cache_zones
+        .values()
+        .map(|zone| CheckCacheZoneSummary {
+            name: zone.name.clone(),
+            path: zone.path.clone(),
+            max_size_bytes: zone.max_size_bytes,
+            inactive_secs: zone.inactive.as_secs(),
+            default_ttl_secs: zone.default_ttl.as_secs(),
+            max_entry_bytes: zone.max_entry_bytes,
+        })
+        .collect::<Vec<_>>();
+    zones.sort_by(|left, right| left.name.cmp(&right.name));
+    zones
 }
 
 fn listener_model<'a>(

--- a/crates/rginx-config/src/compile/cache.rs
+++ b/crates/rginx-config/src/compile/cache.rs
@@ -1,0 +1,113 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use http::{Method, StatusCode};
+use rginx_core::{CacheKeyTemplate, CacheZone, Error, Result, RouteCachePolicy};
+
+use crate::model::{CacheRouteConfig, CacheZoneConfig};
+
+const DEFAULT_CACHE_INACTIVE_SECS: u64 = 600;
+const DEFAULT_CACHE_TTL_SECS: u64 = 60;
+const DEFAULT_CACHE_MAX_ENTRY_BYTES: u64 = 10 * 1024 * 1024;
+const DEFAULT_CACHE_KEY: &str = "{scheme}:{host}:{uri}";
+
+pub(super) fn compile_cache_zones(
+    zones: Vec<CacheZoneConfig>,
+    base_dir: &Path,
+) -> Result<HashMap<String, Arc<CacheZone>>> {
+    zones
+        .into_iter()
+        .map(|zone| {
+            let name = zone.name.trim().to_string();
+            let path = super::path::resolve_path(base_dir, zone.path);
+            let max_size_bytes = zone.max_size_bytes.map(usize_from_u64).transpose()?;
+            let default_max_entry_bytes = usize_from_u64(DEFAULT_CACHE_MAX_ENTRY_BYTES)?;
+            let max_entry_bytes = match zone.max_entry_bytes {
+                Some(value) => usize_from_u64(value)?,
+                None => max_size_bytes
+                    .map(|max_size| default_max_entry_bytes.min(max_size))
+                    .unwrap_or(default_max_entry_bytes),
+            };
+            if let Some(max_size_bytes) = max_size_bytes
+                && max_entry_bytes > max_size_bytes
+            {
+                return Err(Error::Config(format!(
+                    "cache zone `{name}` max_entry_bytes must not exceed max_size_bytes"
+                )));
+            }
+            let compiled = CacheZone {
+                name: name.clone(),
+                path,
+                max_size_bytes,
+                inactive: Duration::from_secs(
+                    zone.inactive_secs.unwrap_or(DEFAULT_CACHE_INACTIVE_SECS),
+                ),
+                default_ttl: Duration::from_secs(
+                    zone.default_ttl_secs.unwrap_or(DEFAULT_CACHE_TTL_SECS),
+                ),
+                max_entry_bytes,
+            };
+            Ok((name, Arc::new(compiled)))
+        })
+        .collect()
+}
+
+pub(super) fn compile_route_cache(
+    cache: Option<CacheRouteConfig>,
+) -> Result<Option<RouteCachePolicy>> {
+    cache
+        .map(|cache| {
+            let methods = dedup_preserving_order(match cache.methods {
+                Some(methods) => methods
+                    .into_iter()
+                    .map(|method| {
+                        let normalized = method.trim().to_ascii_uppercase();
+                        normalized.parse::<Method>().map_err(|error| {
+                            Error::Config(format!("invalid cache method `{method}`: {error}"))
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                None => vec![Method::GET, Method::HEAD],
+            });
+            let statuses = dedup_preserving_order(match cache.statuses {
+                Some(statuses) => statuses
+                    .into_iter()
+                    .map(|status| StatusCode::from_u16(status).map_err(Error::from))
+                    .collect::<Result<Vec<_>>>()?,
+                None => vec![
+                    StatusCode::OK,
+                    StatusCode::MOVED_PERMANENTLY,
+                    StatusCode::FOUND,
+                    StatusCode::NOT_FOUND,
+                ],
+            });
+            let key =
+                CacheKeyTemplate::parse(cache.key.unwrap_or_else(|| DEFAULT_CACHE_KEY.to_string()))
+                    .map_err(|error| Error::Config(error.to_string()))?;
+            Ok(RouteCachePolicy {
+                zone: cache.zone.trim().to_string(),
+                methods,
+                statuses,
+                key,
+                stale_if_error: cache.stale_if_error_secs.map(Duration::from_secs),
+            })
+        })
+        .transpose()
+}
+
+fn usize_from_u64(value: u64) -> Result<usize> {
+    usize::try_from(value)
+        .map_err(|_| Error::Config(format!("cache size `{value}` does not fit into usize")))
+}
+
+fn dedup_preserving_order<T: PartialEq>(values: Vec<T>) -> Vec<T> {
+    let mut deduped = Vec::with_capacity(values.len());
+    for value in values {
+        if !deduped.contains(&value) {
+            deduped.push(value);
+        }
+    }
+    deduped
+}

--- a/crates/rginx-config/src/compile/mod.rs
+++ b/crates/rginx-config/src/compile/mod.rs
@@ -5,6 +5,7 @@ use rginx_core::{ConfigSnapshot, Result, VirtualHost};
 
 use crate::validate::validate;
 
+mod cache;
 mod path;
 mod route;
 mod runtime;
@@ -46,12 +47,14 @@ pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<Conf
     let Config {
         runtime,
         listeners: raw_listeners,
+        cache_zones: raw_cache_zones,
         server,
         upstreams: raw_upstreams,
         locations,
         servers: raw_servers,
     } = raw;
     let runtime = runtime::compile_runtime_settings(runtime)?;
+    let cache_zones = cache::compile_cache_zones(raw_cache_zones, base_dir)?;
     let any_vhost_tls = raw_servers.iter().any(|vhost| vhost.tls.is_some());
     let any_vhost_listen = raw_servers.iter().any(|vhost| !vhost.listen.is_empty());
     let (listeners, default_server_names) = if any_vhost_listen {
@@ -93,7 +96,7 @@ pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<Conf
         vhosts.push(compiled.vhost);
     }
 
-    Ok(ConfigSnapshot { runtime, listeners, default_vhost, vhosts, upstreams })
+    Ok(ConfigSnapshot { runtime, listeners, default_vhost, vhosts, cache_zones, upstreams })
 }
 #[cfg(test)]
 mod tests;

--- a/crates/rginx-config/src/compile/route.rs
+++ b/crates/rginx-config/src/compile/route.rs
@@ -65,6 +65,7 @@ fn compile_route(
         compression_min_bytes,
         compression_content_types,
         streaming_response_idle_timeout_secs,
+        cache,
     } = location;
 
     let matcher = match matcher {
@@ -118,6 +119,7 @@ fn compile_route(
         compression_content_types: compile_compression_content_types(compression_content_types),
         streaming_response_idle_timeout: streaming_response_idle_timeout_secs
             .map(Duration::from_secs),
+        cache: super::cache::compile_route_cache(cache)?,
     })
 }
 

--- a/crates/rginx-config/src/compile/tests.rs
+++ b/crates/rginx-config/src/compile/tests.rs
@@ -2,11 +2,12 @@ use std::fs;
 use std::time::Duration;
 
 use crate::model::{
-    Config, HandlerConfig, Http3Config, ListenerConfig, LocationConfig, MatcherConfig,
-    ProxyHeaderDynamicValueConfig, ProxyHeaderValueConfig, RouteBufferingPolicyConfig,
-    RouteCompressionPolicyConfig, RuntimeConfig, ServerConfig, ServerTlsConfig,
-    TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig, UpstreamConfig, UpstreamLoadBalanceConfig,
-    UpstreamPeerConfig, UpstreamProtocolConfig, UpstreamTlsConfig, VirtualHostConfig,
+    CacheRouteConfig, CacheZoneConfig, Config, HandlerConfig, Http3Config, ListenerConfig,
+    LocationConfig, MatcherConfig, ProxyHeaderDynamicValueConfig, ProxyHeaderValueConfig,
+    RouteBufferingPolicyConfig, RouteCompressionPolicyConfig, RuntimeConfig, ServerConfig,
+    ServerTlsConfig, TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig, UpstreamConfig,
+    UpstreamLoadBalanceConfig, UpstreamPeerConfig, UpstreamProtocolConfig, UpstreamTlsConfig,
+    VirtualHostConfig,
 };
 use tempfile::TempDir;
 
@@ -33,6 +34,7 @@ fn temp_base_dir(prefix: &str) -> TempDir {
 
 fn test_location(matcher: MatcherConfig, handler: HandlerConfig) -> LocationConfig {
     LocationConfig {
+        cache: None,
         matcher,
         handler,
         grpc_service: None,
@@ -51,6 +53,7 @@ fn test_location(matcher: MatcherConfig, handler: HandlerConfig) -> LocationConf
     }
 }
 
+mod cache;
 mod http3;
 mod listeners;
 mod route;

--- a/crates/rginx-config/src/compile/tests/cache.rs
+++ b/crates/rginx-config/src/compile/tests/cache.rs
@@ -1,0 +1,151 @@
+use super::*;
+
+#[test]
+fn compile_attaches_cache_zones_and_route_policy() {
+    let base_dir = temp_base_dir("rginx-cache-compile");
+    let mut config = Config {
+        cache_zones: vec![CacheZoneConfig {
+            name: "default".to_string(),
+            path: "cache/default".to_string(),
+            max_size_bytes: Some(1024 * 1024),
+            inactive_secs: Some(120),
+            default_ttl_secs: Some(30),
+            max_entry_bytes: Some(1024),
+        }],
+        runtime: RuntimeConfig {
+            shutdown_timeout_secs: 10,
+            worker_threads: None,
+            accept_workers: None,
+        },
+        listeners: Vec::new(),
+        server: ServerConfig {
+            listen: Some("127.0.0.1:8080".to_string()),
+            server_header: None,
+            proxy_protocol: None,
+            default_certificate: None,
+            server_names: Vec::new(),
+            trusted_proxies: Vec::new(),
+            client_ip_header: None,
+            keep_alive: None,
+            max_headers: None,
+            max_request_body_bytes: None,
+            max_connections: None,
+            header_read_timeout_secs: None,
+            request_body_read_timeout_secs: None,
+            response_write_timeout_secs: None,
+            access_log_format: None,
+            tls: None,
+            http3: None,
+        },
+        upstreams: vec![UpstreamConfig {
+            name: "backend".to_string(),
+            peers: vec![UpstreamPeerConfig {
+                url: "http://127.0.0.1:9000".to_string(),
+                weight: 1,
+                backup: false,
+            }],
+            tls: None,
+            dns: None,
+            protocol: UpstreamProtocolConfig::Auto,
+            load_balance: UpstreamLoadBalanceConfig::RoundRobin,
+            server_name: None,
+            server_name_override: None,
+            request_timeout_secs: None,
+            connect_timeout_secs: None,
+            read_timeout_secs: None,
+            write_timeout_secs: None,
+            idle_timeout_secs: None,
+            pool_idle_timeout_secs: None,
+            pool_max_idle_per_host: None,
+            tcp_keepalive_secs: None,
+            tcp_nodelay: None,
+            http2_keep_alive_interval_secs: None,
+            http2_keep_alive_timeout_secs: None,
+            http2_keep_alive_while_idle: None,
+            max_replayable_request_body_bytes: None,
+            unhealthy_after_failures: None,
+            unhealthy_cooldown_secs: None,
+            health_check_path: None,
+            health_check_grpc_service: None,
+            health_check_interval_secs: None,
+            health_check_timeout_secs: None,
+            healthy_successes_required: None,
+        }],
+        locations: vec![LocationConfig {
+            cache: Some(CacheRouteConfig {
+                zone: "default".to_string(),
+                methods: Some(vec!["GET".to_string(), "get".to_string(), " GET ".to_string()]),
+                statuses: Some(vec![200, 404, 200]),
+                key: Some("{scheme}:{host}:{uri}".to_string()),
+                stale_if_error_secs: Some(15),
+            }),
+            matcher: MatcherConfig::Prefix("/assets".to_string()),
+            handler: HandlerConfig::Proxy {
+                upstream: "backend".to_string(),
+                preserve_host: None,
+                strip_prefix: None,
+                proxy_set_headers: std::collections::HashMap::new(),
+            },
+            grpc_service: None,
+            grpc_method: None,
+            allow_cidrs: Vec::new(),
+            deny_cidrs: Vec::new(),
+            requests_per_sec: None,
+            burst: None,
+            allow_early_data: None,
+            request_buffering: None,
+            response_buffering: None,
+            compression: None,
+            compression_min_bytes: None,
+            compression_content_types: None,
+            streaming_response_idle_timeout_secs: None,
+        }],
+        servers: Vec::new(),
+    };
+
+    let snapshot =
+        compile_with_base(config.clone(), base_dir.path()).expect("cache config should compile");
+    let zone = snapshot.cache_zones.get("default").expect("cache zone should compile");
+    assert_eq!(zone.path, base_dir.path().join("cache/default"));
+    assert_eq!(zone.max_size_bytes, Some(1024 * 1024));
+    assert_eq!(zone.inactive, Duration::from_secs(120));
+    assert_eq!(zone.default_ttl, Duration::from_secs(30));
+    assert_eq!(zone.max_entry_bytes, 1024);
+
+    let policy =
+        snapshot.default_vhost.routes[0].cache.as_ref().expect("route cache policy should compile");
+    assert_eq!(policy.zone, "default");
+    assert_eq!(policy.methods, vec![http::Method::GET]);
+    assert_eq!(policy.statuses, vec![http::StatusCode::OK, http::StatusCode::NOT_FOUND]);
+    assert_eq!(policy.stale_if_error, Some(Duration::from_secs(15)));
+
+    config.locations[0].cache = Some(CacheRouteConfig {
+        zone: "default".to_string(),
+        methods: None,
+        statuses: None,
+        key: None,
+        stale_if_error_secs: None,
+    });
+    let snapshot = compile_with_base(config.clone(), base_dir.path())
+        .expect("default cache policy should compile");
+    let policy =
+        snapshot.default_vhost.routes[0].cache.as_ref().expect("route cache policy should compile");
+    assert_eq!(policy.methods, vec![http::Method::GET, http::Method::HEAD]);
+    assert_eq!(policy.key.as_str(), "{scheme}:{host}:{uri}");
+    assert_eq!(policy.stale_if_error, None);
+    assert_eq!(
+        policy.statuses,
+        vec![
+            http::StatusCode::OK,
+            http::StatusCode::MOVED_PERMANENTLY,
+            http::StatusCode::FOUND,
+            http::StatusCode::NOT_FOUND,
+        ]
+    );
+
+    config.cache_zones[0].max_size_bytes = Some(512);
+    config.cache_zones[0].max_entry_bytes = None;
+    let snapshot =
+        compile_with_base(config, base_dir.path()).expect("small cache zone should compile");
+    assert_eq!(snapshot.cache_zones["default"].max_entry_bytes, 512);
+}

--- a/crates/rginx-config/src/compile/tests/http3.rs
+++ b/crates/rginx-config/src/compile/tests/http3.rs
@@ -9,6 +9,7 @@ fn compile_http3_listener_defaults_to_tcp_listen_addr_and_default_alt_svc_policy
     fs::write(&key_path, "placeholder key").expect("key file should be written");
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -62,6 +63,7 @@ fn compile_http3_listener_defaults_to_tcp_listen_addr_and_default_alt_svc_policy
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,
@@ -112,6 +114,7 @@ fn compile_http3_applies_transport_settings_and_resolves_host_key_path() {
     fs::write(&key_path, b"placeholder").expect("server key should be written");
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 2,
             worker_threads: None,
@@ -165,6 +168,7 @@ fn compile_http3_applies_transport_settings_and_resolves_host_key_path() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,

--- a/crates/rginx-config/src/compile/tests/listeners.rs
+++ b/crates/rginx-config/src/compile/tests/listeners.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_supports_explicit_multi_listener_configs() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -69,6 +70,7 @@ fn compile_supports_explicit_multi_listener_configs() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,

--- a/crates/rginx-config/src/compile/tests/route.rs
+++ b/crates/rginx-config/src/compile/tests/route.rs
@@ -5,6 +5,7 @@ mod regex;
 #[test]
 fn compile_attaches_route_access_control() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -32,6 +33,7 @@ fn compile_attaches_route_access_control() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,
@@ -65,6 +67,7 @@ fn compile_attaches_route_access_control() {
 #[test]
 fn compile_attaches_route_rate_limit() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -92,6 +95,7 @@ fn compile_attaches_route_rate_limit() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/api".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,
@@ -127,6 +131,7 @@ fn compile_attaches_route_rate_limit() {
 #[test]
 fn compile_applies_route_transport_policy_defaults_and_overrides() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -163,6 +168,7 @@ fn compile_applies_route_transport_policy_defaults_and_overrides() {
                 },
             ),
             LocationConfig {
+                cache: None,
                 matcher: MatcherConfig::Exact("/custom".to_string()),
                 handler: HandlerConfig::Return {
                     status: 200,
@@ -224,6 +230,7 @@ fn compile_applies_route_transport_policy_defaults_and_overrides() {
 #[test]
 fn compile_generates_distinct_route_and_vhost_ids() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -288,6 +295,7 @@ fn compile_generates_distinct_route_and_vhost_ids() {
 #[test]
 fn compile_prioritizes_grpc_constrained_routes_with_same_path_matcher() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -324,6 +332,7 @@ fn compile_prioritizes_grpc_constrained_routes_with_same_path_matcher() {
                 },
             ),
             LocationConfig {
+                cache: None,
                 grpc_service: Some("grpc.health.v1.Health".to_string()),
                 grpc_method: Some("Check".to_string()),
                 ..test_location(

--- a/crates/rginx-config/src/compile/tests/route/regex.rs
+++ b/crates/rginx-config/src/compile/tests/route/regex.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_attaches_regex_matcher_and_dynamic_proxy_headers() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -118,6 +119,7 @@ fn compile_attaches_regex_matcher_and_dynamic_proxy_headers() {
 #[test]
 fn compile_preserves_declaration_order_for_overlapping_regex_routes() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,

--- a/crates/rginx-config/src/compile/tests/server_settings.rs
+++ b/crates/rginx-config/src/compile/tests/server_settings.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_applies_custom_server_header() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -47,6 +48,7 @@ fn compile_applies_custom_server_header() {
 #[test]
 fn compile_normalizes_trusted_proxy_ips_and_cidrs() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -74,6 +76,7 @@ fn compile_normalizes_trusted_proxy_ips_and_cidrs() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,
@@ -112,6 +115,7 @@ fn compile_normalizes_trusted_proxy_ips_and_cidrs() {
 #[test]
 fn compile_attaches_server_hardening_settings() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: Some(3),
@@ -139,6 +143,7 @@ fn compile_attaches_server_hardening_settings() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,
@@ -193,6 +198,7 @@ fn compile_attaches_server_hardening_settings() {
 #[test]
 fn compile_rejects_invalid_server_access_log_format() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -220,6 +226,7 @@ fn compile_rejects_invalid_server_access_log_format() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,

--- a/crates/rginx-config/src/compile/tests/server_tls.rs
+++ b/crates/rginx-config/src/compile/tests/server_tls.rs
@@ -9,6 +9,7 @@ fn compile_resolves_server_tls_paths_relative_to_config_base() {
     fs::write(&key_path, b"placeholder").expect("temp key file should be written");
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -51,6 +52,7 @@ fn compile_resolves_server_tls_paths_relative_to_config_base() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,
@@ -92,6 +94,7 @@ fn compile_preserves_server_tls_policy_fields() {
     fs::write(&key_path, b"placeholder").expect("temp key file should be written");
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -134,6 +137,7 @@ fn compile_preserves_server_tls_policy_fields() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,
@@ -181,6 +185,7 @@ fn compile_preserves_server_tls_ocsp_policy_fields() {
     fs::write(&ocsp_path, b"").expect("temp ocsp file should be written");
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -226,6 +231,7 @@ fn compile_preserves_server_tls_ocsp_policy_fields() {
         },
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,

--- a/crates/rginx-config/src/compile/tests/upstream_defaults.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_defaults.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_accepts_https_upstreams() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -115,6 +116,7 @@ fn compile_accepts_https_upstreams() {
 #[test]
 fn compile_defaults_grpc_health_check_path_when_service_is_set() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,

--- a/crates/rginx-config/src/compile/tests/upstream_fallbacks.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_fallbacks.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_accepts_backup_peers() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -70,6 +71,7 @@ fn compile_accepts_backup_peers() {
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "backend".to_string(),
@@ -123,6 +125,7 @@ fn compile_accepts_backup_peers() {
 #[test]
 fn compile_uses_legacy_request_timeout_fallbacks_and_disables_pool_idle_timeout() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -183,6 +186,7 @@ fn compile_uses_legacy_request_timeout_fallbacks_and_disables_pool_idle_timeout(
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "backend".to_string(),
@@ -230,6 +234,7 @@ fn compile_uses_legacy_request_timeout_fallbacks_and_disables_pool_idle_timeout(
 #[test]
 fn compile_uses_default_pool_idle_timeout() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -290,6 +295,7 @@ fn compile_uses_default_pool_idle_timeout() {
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "backend".to_string(),

--- a/crates/rginx-config/src/compile/tests/upstream_server_name.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_server_name.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_normalizes_server_name_override() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -63,6 +64,7 @@ fn compile_normalizes_server_name_override() {
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "secure-backend".to_string(),
@@ -101,6 +103,7 @@ fn compile_normalizes_server_name_override() {
 #[test]
 fn compile_preserves_upstream_server_name_toggle() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -168,6 +171,7 @@ fn compile_preserves_upstream_server_name_toggle() {
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "secure-backend".to_string(),
@@ -205,6 +209,7 @@ fn compile_preserves_upstream_server_name_toggle() {
 #[test]
 fn compile_rejects_invalid_server_name_override() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -265,6 +270,7 @@ fn compile_rejects_invalid_server_name_override() {
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "secure-backend".to_string(),

--- a/crates/rginx-config/src/compile/tests/upstream_tls.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_tls.rs
@@ -7,6 +7,7 @@ fn compile_resolves_custom_ca_relative_to_config_base() {
     fs::write(&ca_path, b"placeholder").expect("temp CA file should be written");
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -76,6 +77,7 @@ fn compile_resolves_custom_ca_relative_to_config_base() {
             healthy_successes_required: Some(4),
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "dev-backend".to_string(),
@@ -134,6 +136,7 @@ fn compile_resolves_custom_ca_relative_to_config_base() {
 #[test]
 fn compile_accepts_https_http3_upstreams() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -194,6 +197,7 @@ fn compile_accepts_https_http3_upstreams() {
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "h3-backend".to_string(),
@@ -238,6 +242,7 @@ fn compile_resolves_upstream_mtls_identity_and_tls_versions_relative_to_config_b
     fs::write(&client_key_path, b"placeholder").expect("temp client key file should be written");
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -307,6 +312,7 @@ fn compile_resolves_upstream_mtls_identity_and_tls_versions_relative_to_config_b
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "mtls-backend".to_string(),

--- a/crates/rginx-config/src/compile/tests/upstream_transport.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_transport.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_applies_granular_upstream_transport_settings() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -97,6 +98,7 @@ fn compile_applies_granular_upstream_transport_settings() {
 #[test]
 fn compile_accepts_least_conn_load_balance() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -164,6 +166,7 @@ fn compile_accepts_least_conn_load_balance() {
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "backend".to_string(),
@@ -202,6 +205,7 @@ fn compile_accepts_least_conn_load_balance() {
 #[test]
 fn compile_applies_peer_weights() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -269,6 +273,7 @@ fn compile_applies_peer_weights() {
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "backend".to_string(),

--- a/crates/rginx-config/src/compile/tests/vhosts.rs
+++ b/crates/rginx-config/src/compile/tests/vhosts.rs
@@ -10,6 +10,7 @@ fn compile_generates_deduplicated_listeners_from_vhost_listen() {
     fs::write(base_dir.path().join("api.key"), b"placeholder").expect("key should be written");
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -75,6 +76,7 @@ fn compile_generates_deduplicated_listeners_from_vhost_listen() {
 #[test]
 fn compile_uses_vhost_local_upstream_before_global_upstream() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -129,6 +131,7 @@ fn compile_applies_server_tls_defaults_only_to_vhost_ssl_listeners() {
     server.tls = Some(server_tls("default.crt", "default.key"));
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -180,6 +183,7 @@ fn compile_uses_first_tls_vhost_as_implicit_default_certificate() {
     }
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -208,6 +212,7 @@ fn compile_uses_first_tls_vhost_as_implicit_default_certificate() {
 #[test]
 fn compile_preserves_ipv6_vhost_listener_ids() {
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,

--- a/crates/rginx-config/src/compile/tests/vhosts/listener_conflicts.rs
+++ b/crates/rginx-config/src/compile/tests/vhosts/listener_conflicts.rs
@@ -44,6 +44,7 @@ fn compile_rejects_conflicting_shared_vhost_listener_flags() {
 
     for (servers, expected) in cases {
         let config = Config {
+            cache_zones: Vec::new(),
             runtime: RuntimeConfig {
                 shutdown_timeout_secs: 10,
                 worker_threads: None,

--- a/crates/rginx-config/src/compile/tests/vhosts/nezha.rs
+++ b/crates/rginx-config/src/compile/tests/vhosts/nezha.rs
@@ -25,6 +25,7 @@ fn compile_supports_nezha_dashboard_native_vhost_shape() {
     dashboard_http.write_timeout_secs = Some(3600);
 
     let config = Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -57,6 +58,7 @@ fn compile_supports_nezha_dashboard_native_vhost_shape() {
                     },
                 ),
                 LocationConfig {
+                    cache: None,
                     matcher: MatcherConfig::Regex {
                         pattern: "^/api/v1/ws/(server|terminal|file)(/.*)?$".to_string(),
                         case_insensitive: true,

--- a/crates/rginx-config/src/load/tests.rs
+++ b/crates/rginx-config/src/load/tests.rs
@@ -8,6 +8,28 @@ use proptest::prelude::*;
 use super::{expand_env_placeholders_in_ron_strings, load_from_path, load_from_str};
 
 #[test]
+fn load_from_str_deserializes_cache_zones_and_route_cache_policy() {
+    let config = load_from_str(
+        "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    cache_zones: [\n        CacheZoneConfig(\n            name: \"default\",\n            path: \"/var/cache/rginx/default\",\n            max_size_bytes: Some(1048576),\n            inactive_secs: Some(600),\n            default_ttl_secs: Some(60),\n            max_entry_bytes: Some(65536),\n        ),\n    ],\n    server: ServerConfig(\n        listen: \"127.0.0.1:18080\",\n    ),\n    upstreams: [\n        UpstreamConfig(\n            name: \"backend\",\n            peers: [UpstreamPeerConfig(url: \"http://127.0.0.1:9000\")],\n        ),\n    ],\n    locations: [\n        LocationConfig(\n            matcher: Prefix(\"/assets/\"),\n            handler: Proxy(upstream: \"backend\"),\n            cache: Some(CacheRouteConfig(\n                zone: \"default\",\n                methods: Some([\"GET\", \"HEAD\"]),\n                statuses: Some([200, 404]),\n                key: Some(\"{scheme}:{host}:{uri}\"),\n                stale_if_error_secs: Some(30),\n            )),\n        ),\n    ],\n)\n",
+        Path::new("inline.ron"),
+    )
+    .expect("cache config should deserialize");
+
+    assert_eq!(config.cache_zones.len(), 1);
+    assert_eq!(config.cache_zones[0].name, "default");
+    assert_eq!(config.cache_zones[0].inactive_secs, Some(600));
+    assert_eq!(config.cache_zones[0].default_ttl_secs, Some(60));
+    assert_eq!(config.cache_zones[0].max_entry_bytes, Some(65536));
+
+    let cache = config.locations[0].cache.as_ref().expect("route cache should deserialize");
+    assert_eq!(cache.zone, "default");
+    assert_eq!(cache.methods.as_deref(), Some(&["GET".to_string(), "HEAD".to_string()][..]));
+    assert_eq!(cache.statuses.as_deref(), Some(&[200, 404][..]));
+    assert_eq!(cache.key.as_deref(), Some("{scheme}:{host}:{uri}"));
+    assert_eq!(cache.stale_if_error_secs, Some(30));
+}
+
+#[test]
 fn load_from_str_expands_environment_placeholders_inside_strings() {
     let _guard = env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     unsafe {

--- a/crates/rginx-config/src/model.rs
+++ b/crates/rginx-config/src/model.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 
+mod cache;
 mod listener;
 mod route;
 mod runtime;
@@ -8,6 +9,7 @@ mod tls;
 mod upstream;
 mod vhost;
 
+pub use cache::{CacheRouteConfig, CacheZoneConfig};
 pub use listener::{Http3Config, ListenerConfig};
 pub use route::{
     HandlerConfig, LocationConfig, MatcherConfig, ProxyHeaderDynamicValueConfig,
@@ -31,6 +33,8 @@ pub struct Config {
     pub runtime: RuntimeConfig,
     #[serde(default)]
     pub listeners: Vec<ListenerConfig>,
+    #[serde(default)]
+    pub cache_zones: Vec<CacheZoneConfig>,
     pub server: ServerConfig,
     #[serde(default)]
     pub upstreams: Vec<UpstreamConfig>,

--- a/crates/rginx-config/src/model/cache.rs
+++ b/crates/rginx-config/src/model/cache.rs
@@ -1,0 +1,28 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CacheZoneConfig {
+    pub name: String,
+    pub path: String,
+    #[serde(default)]
+    pub max_size_bytes: Option<u64>,
+    #[serde(default)]
+    pub inactive_secs: Option<u64>,
+    #[serde(default)]
+    pub default_ttl_secs: Option<u64>,
+    #[serde(default)]
+    pub max_entry_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CacheRouteConfig {
+    pub zone: String,
+    #[serde(default)]
+    pub methods: Option<Vec<String>>,
+    #[serde(default)]
+    pub statuses: Option<Vec<u16>>,
+    #[serde(default)]
+    pub key: Option<String>,
+    #[serde(default)]
+    pub stale_if_error_secs: Option<u64>,
+}

--- a/crates/rginx-config/src/model/route.rs
+++ b/crates/rginx-config/src/model/route.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
+use super::CacheRouteConfig;
+
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
 pub enum RouteBufferingPolicyConfig {
     #[default]
@@ -48,6 +50,8 @@ pub struct LocationConfig {
     pub compression_content_types: Option<Vec<String>>,
     #[serde(default)]
     pub streaming_response_idle_timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub cache: Option<CacheRouteConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/rginx-config/src/validate.rs
+++ b/crates/rginx-config/src/validate.rs
@@ -4,6 +4,7 @@ use rginx_core::{Error, Result};
 
 use crate::model::{Config, LocationConfig, RouteBufferingPolicyConfig};
 
+mod cache;
 mod route;
 mod runtime;
 mod server;
@@ -22,8 +23,9 @@ pub fn validate(config: &Config) -> Result<()> {
     }
     server::validate_server(&config.server)?;
     server::validate_listeners(&config.listeners, &config.server, &config.servers)?;
+    let cache_zone_names = cache::validate_cache_zones(&config.cache_zones)?;
     let upstream_names = upstream::validate_upstreams(&config.upstreams)?;
-    route::validate_locations(None, &config.locations, &upstream_names)?;
+    route::validate_locations(None, &config.locations, &upstream_names, &cache_zone_names)?;
 
     let mut all_server_names = HashSet::new();
     server::validate_server_names("server", &config.server.server_names, &mut all_server_names)?;
@@ -33,6 +35,7 @@ pub fn validate(config: &Config) -> Result<()> {
         &mut all_server_names,
         config.servers.iter().any(|vhost| !vhost.listen.is_empty()),
         config.server.tls.as_ref(),
+        &cache_zone_names,
     )?;
     validate_request_buffering_limits(config)?;
 

--- a/crates/rginx-config/src/validate/cache.rs
+++ b/crates/rginx-config/src/validate/cache.rs
@@ -1,0 +1,120 @@
+use std::collections::HashSet;
+
+use rginx_core::{Error, Result};
+
+use crate::model::{CacheRouteConfig, CacheZoneConfig};
+
+pub(super) fn validate_cache_zones(zones: &[CacheZoneConfig]) -> Result<HashSet<String>> {
+    let mut names = HashSet::new();
+
+    for zone in zones {
+        let name = zone.name.trim();
+        if name.is_empty() {
+            return Err(Error::Config("cache_zones[].name must not be empty".to_string()));
+        }
+        if !names.insert(name.to_string()) {
+            return Err(Error::Config(format!("duplicate cache zone `{name}`")));
+        }
+        if zone.path.trim().is_empty() {
+            return Err(Error::Config(format!("cache zone `{name}` path must not be empty")));
+        }
+        validate_positive_optional(name, "max_size_bytes", zone.max_size_bytes)?;
+        validate_positive_optional(name, "inactive_secs", zone.inactive_secs)?;
+        validate_positive_optional(name, "default_ttl_secs", zone.default_ttl_secs)?;
+        validate_positive_optional(name, "max_entry_bytes", zone.max_entry_bytes)?;
+        if let (Some(max_size), Some(max_entry)) = (zone.max_size_bytes, zone.max_entry_bytes)
+            && max_entry > max_size
+        {
+            return Err(Error::Config(format!(
+                "cache zone `{name}` max_entry_bytes must not exceed max_size_bytes"
+            )));
+        }
+    }
+
+    Ok(names)
+}
+
+pub(super) fn validate_route_cache(
+    route_scope: &str,
+    cache: Option<&CacheRouteConfig>,
+    cache_zone_names: &HashSet<String>,
+) -> Result<()> {
+    let Some(cache) = cache else {
+        return Ok(());
+    };
+
+    let zone = cache.zone.trim();
+    if zone.is_empty() {
+        return Err(Error::Config(format!("{route_scope} cache.zone must not be empty")));
+    }
+    if !cache_zone_names.contains(zone) {
+        return Err(Error::Config(format!(
+            "{route_scope} references undefined cache zone `{}`",
+            zone
+        )));
+    }
+
+    if let Some(methods) = cache.methods.as_deref() {
+        if methods.is_empty() {
+            return Err(Error::Config(format!(
+                "{route_scope} cache.methods must not be empty when provided"
+            )));
+        }
+        let mut allows_get = false;
+        for method in methods {
+            match method.trim().to_ascii_uppercase().as_str() {
+                "GET" => allows_get = true,
+                "HEAD" => {}
+                other => {
+                    return Err(Error::Config(format!(
+                        "{route_scope} cache method `{other}` is not supported by the MVP"
+                    )));
+                }
+            }
+        }
+        if !allows_get {
+            return Err(Error::Config(format!(
+                "{route_scope} cache.methods must include GET so responses can populate the cache"
+            )));
+        }
+    }
+
+    if let Some(statuses) = cache.statuses.as_deref() {
+        if statuses.is_empty() {
+            return Err(Error::Config(format!(
+                "{route_scope} cache.statuses must not be empty when provided"
+            )));
+        }
+        for status in statuses {
+            if !(100..=599).contains(status) {
+                return Err(Error::Config(format!(
+                    "{route_scope} cache status `{status}` must be between 100 and 599"
+                )));
+            }
+        }
+    }
+
+    if let Some(key) = cache.key.as_deref() {
+        if key.trim().is_empty() {
+            return Err(Error::Config(format!("{route_scope} cache.key must not be empty")));
+        }
+        rginx_core::CacheKeyTemplate::parse(key).map_err(|error| {
+            Error::Config(format!("{route_scope} cache.key is invalid: {error}"))
+        })?;
+    }
+
+    if cache.stale_if_error_secs.is_some_and(|value| value == 0) {
+        return Err(Error::Config(format!(
+            "{route_scope} cache.stale_if_error_secs must be greater than 0"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_positive_optional(zone: &str, field: &str, value: Option<u64>) -> Result<()> {
+    if value.is_some_and(|value| value == 0) {
+        return Err(Error::Config(format!("cache zone `{zone}` {field} must be greater than 0")));
+    }
+    Ok(())
+}

--- a/crates/rginx-config/src/validate/route.rs
+++ b/crates/rginx-config/src/validate/route.rs
@@ -14,6 +14,7 @@ pub(super) fn validate_locations(
     scope_label: Option<&str>,
     locations: &[LocationConfig],
     upstream_names: &HashSet<String>,
+    cache_zone_names: &HashSet<String>,
 ) -> Result<()> {
     let mut exact_routes = HashSet::new();
 
@@ -90,8 +91,29 @@ pub(super) fn validate_locations(
             location.grpc_method.as_deref(),
         )?;
         handler::validate_handler(scope_label, &route_scope, &location.handler, upstream_names)?;
+        validate_cache_handler_compatibility(
+            &route_scope,
+            &location.handler,
+            location.cache.as_ref(),
+        )?;
+        super::cache::validate_route_cache(
+            &route_scope,
+            location.cache.as_ref(),
+            cache_zone_names,
+        )?;
     }
 
+    Ok(())
+}
+
+fn validate_cache_handler_compatibility(
+    route_scope: &str,
+    handler: &crate::model::HandlerConfig,
+    cache: Option<&crate::model::CacheRouteConfig>,
+) -> Result<()> {
+    if cache.is_some() && !matches!(handler, crate::model::HandlerConfig::Proxy { .. }) {
+        return Err(Error::Config(format!("{route_scope} cache requires a Proxy handler")));
+    }
     Ok(())
 }
 

--- a/crates/rginx-config/src/validate/tests.rs
+++ b/crates/rginx-config/src/validate/tests.rs
@@ -1,14 +1,15 @@
 use crate::model::{
-    Config, HandlerConfig, Http3Config, ListenerConfig, LocationConfig, MatcherConfig,
-    ProxyHeaderDynamicValueConfig, ProxyHeaderValueConfig, RouteBufferingPolicyConfig,
-    RouteCompressionPolicyConfig, RuntimeConfig, ServerConfig, ServerTlsConfig,
-    TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig, TlsVersionConfig, UpstreamConfig,
-    UpstreamLoadBalanceConfig, UpstreamPeerConfig, UpstreamProtocolConfig, VirtualHostConfig,
-    VirtualHostTlsConfig,
+    CacheRouteConfig, CacheZoneConfig, Config, HandlerConfig, Http3Config, ListenerConfig,
+    LocationConfig, MatcherConfig, ProxyHeaderDynamicValueConfig, ProxyHeaderValueConfig,
+    RouteBufferingPolicyConfig, RouteCompressionPolicyConfig, RuntimeConfig, ServerConfig,
+    ServerTlsConfig, TlsCipherSuiteConfig, TlsKeyExchangeGroupConfig, TlsVersionConfig,
+    UpstreamConfig, UpstreamLoadBalanceConfig, UpstreamPeerConfig, UpstreamProtocolConfig,
+    VirtualHostConfig, VirtualHostTlsConfig,
 };
 
 use super::{DEFAULT_GRPC_HEALTH_CHECK_PATH, validate};
 
+mod cache;
 mod listeners;
 mod route;
 mod runtime;
@@ -23,6 +24,7 @@ mod vhosts;
 
 fn base_config() -> Config {
     Config {
+        cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
             worker_threads: None,
@@ -83,6 +85,7 @@ fn base_config() -> Config {
             healthy_successes_required: None,
         }],
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Prefix("/".to_string()),
             handler: HandlerConfig::Proxy {
                 upstream: "backend".to_string(),
@@ -133,6 +136,7 @@ fn sample_vhost(server_names: Vec<&str>) -> VirtualHostConfig {
         server_names: server_names.into_iter().map(str::to_string).collect(),
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,

--- a/crates/rginx-config/src/validate/tests/cache.rs
+++ b/crates/rginx-config/src/validate/tests/cache.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+fn cache_zone(name: &str) -> CacheZoneConfig {
+    CacheZoneConfig {
+        name: name.to_string(),
+        path: format!("/tmp/rginx-cache/{name}"),
+        max_size_bytes: Some(1024 * 1024),
+        inactive_secs: Some(60),
+        default_ttl_secs: Some(30),
+        max_entry_bytes: Some(1024),
+    }
+}
+
+fn route_cache(zone: &str) -> CacheRouteConfig {
+    CacheRouteConfig {
+        zone: zone.to_string(),
+        methods: Some(vec!["GET".to_string(), "HEAD".to_string()]),
+        statuses: Some(vec![200, 301, 404]),
+        key: Some("{scheme}:{host}:{uri}".to_string()),
+        stale_if_error_secs: Some(10),
+    }
+}
+
+#[test]
+fn validate_accepts_cache_zone_and_proxy_route_policy() {
+    let mut config = base_config();
+    config.cache_zones = vec![cache_zone("default")];
+    config.locations[0].cache = Some(route_cache("default"));
+
+    validate(&config).expect("valid cache config should pass validation");
+}
+
+#[test]
+fn validate_rejects_route_cache_with_undefined_zone() {
+    let mut config = base_config();
+    config.locations[0].cache = Some(route_cache("missing"));
+
+    let error = validate(&config).expect_err("undefined cache zone should fail validation");
+    assert!(error.to_string().contains("references undefined cache zone `missing`"), "{error}");
+}
+
+#[test]
+fn validate_rejects_cache_policy_on_return_route() {
+    let mut config = base_config();
+    config.cache_zones = vec![cache_zone("default")];
+    config.locations[0].handler = HandlerConfig::Return {
+        status: 200,
+        location: String::new(),
+        body: Some("ok\n".to_string()),
+    };
+    config.locations[0].cache = Some(route_cache("default"));
+
+    let error = validate(&config).expect_err("return route cache should fail validation");
+    assert!(error.to_string().contains("cache requires a Proxy handler"), "{error}");
+}
+
+#[test]
+fn validate_rejects_max_entry_bytes_exceeding_max_size_bytes() {
+    let mut config = base_config();
+    config.cache_zones = vec![CacheZoneConfig {
+        max_entry_bytes: Some(2 * 1024),
+        max_size_bytes: Some(1024),
+        ..cache_zone("default")
+    }];
+    config.locations[0].cache = Some(route_cache("default"));
+
+    let error = validate(&config).expect_err("oversized max_entry should fail validation");
+    assert!(error.to_string().contains("max_entry_bytes must not exceed max_size_bytes"));
+}
+
+#[test]
+fn validate_rejects_unsupported_cache_method() {
+    let mut config = base_config();
+    config.cache_zones = vec![cache_zone("default")];
+    let mut policy = route_cache("default");
+    policy.methods = Some(vec!["POST".to_string()]);
+    config.locations[0].cache = Some(policy);
+
+    let error = validate(&config).expect_err("unsupported cache method should fail validation");
+    assert!(error.to_string().contains("cache method `POST` is not supported"));
+}
+
+#[test]
+fn validate_rejects_head_only_cache_methods() {
+    let mut config = base_config();
+    config.cache_zones = vec![cache_zone("default")];
+    let mut policy = route_cache("default");
+    policy.methods = Some(vec!["HEAD".to_string()]);
+    config.locations[0].cache = Some(policy);
+
+    let error = validate(&config).expect_err("HEAD-only cache methods should fail validation");
+    assert!(error.to_string().contains("cache.methods must include GET"), "{error}");
+}

--- a/crates/rginx-config/src/validate/tests/route.rs
+++ b/crates/rginx-config/src/validate/tests/route.rs
@@ -113,6 +113,7 @@ fn validate_allows_duplicate_exact_routes_when_grpc_constraints_differ() {
     let mut config = base_config();
     config.locations[0].matcher = MatcherConfig::Exact("/grpc.health.v1.Health/Check".to_string());
     config.locations.push(LocationConfig {
+        cache: None,
         matcher: MatcherConfig::Exact("/grpc.health.v1.Health/Check".to_string()),
         handler: HandlerConfig::Proxy {
             upstream: "backend".to_string(),

--- a/crates/rginx-config/src/validate/tests/vhosts.rs
+++ b/crates/rginx-config/src/validate/tests/vhosts.rs
@@ -144,6 +144,7 @@ fn validate_rejects_vhost_tls_without_any_tls_listener() {
         server_names: vec!["api.example.com".to_string()],
         upstreams: Vec::new(),
         locations: vec![LocationConfig {
+            cache: None,
             matcher: MatcherConfig::Exact("/".to_string()),
             handler: HandlerConfig::Return {
                 status: 200,

--- a/crates/rginx-config/src/validate/vhost.rs
+++ b/crates/rginx-config/src/validate/vhost.rs
@@ -10,6 +10,7 @@ pub(super) fn validate_virtual_hosts(
     all_server_names: &mut HashSet<String>,
     require_vhost_listen: bool,
     server_tls_defaults: Option<&ServerTlsConfig>,
+    cache_zone_names: &HashSet<String>,
 ) -> Result<()> {
     for (idx, vhost) in vhosts.iter().enumerate() {
         let vhost_label = format!("servers[{idx}]");
@@ -51,6 +52,7 @@ pub(super) fn validate_virtual_hosts(
             Some(&vhost_label),
             &vhost.locations,
             &visible_upstream_names,
+            cache_zone_names,
         )?;
     }
 

--- a/crates/rginx-core/src/config.rs
+++ b/crates/rginx-core/src/config.rs
@@ -1,4 +1,5 @@
 mod access_log;
+mod cache;
 mod listener;
 mod route;
 mod server;
@@ -9,6 +10,9 @@ mod upstream;
 mod virtual_host;
 
 pub use access_log::{AccessLogFormat, AccessLogValues};
+pub use cache::{
+    CacheKeyRenderContext, CacheKeyTemplate, CacheKeyTemplateError, CacheZone, RouteCachePolicy,
+};
 pub use listener::{
     Listener, ListenerApplicationProtocol, ListenerHttp3, ListenerTransportBinding,
     ListenerTransportKind,

--- a/crates/rginx-core/src/config/cache.rs
+++ b/crates/rginx-core/src/config/cache.rs
@@ -1,0 +1,152 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use http::{Method, StatusCode};
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct CacheZone {
+    pub name: String,
+    pub path: PathBuf,
+    pub max_size_bytes: Option<usize>,
+    pub inactive: Duration,
+    pub default_ttl: Duration,
+    pub max_entry_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct RouteCachePolicy {
+    pub zone: String,
+    pub methods: Vec<Method>,
+    pub statuses: Vec<StatusCode>,
+    pub key: CacheKeyTemplate,
+    pub stale_if_error: Option<Duration>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheKeyTemplate {
+    raw: String,
+    parts: Vec<CacheKeyTemplatePart>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CacheKeyTemplatePart {
+    Literal(String),
+    Variable(CacheKeyVariable),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CacheKeyVariable {
+    Scheme,
+    Host,
+    Uri,
+    Method,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CacheKeyRenderContext<'a> {
+    pub scheme: &'a str,
+    pub host: &'a str,
+    pub uri: &'a str,
+    pub method: &'a str,
+}
+
+impl CacheKeyTemplate {
+    pub fn parse(raw: impl Into<String>) -> Result<Self, CacheKeyTemplateError> {
+        let raw = raw.into();
+        let mut parts = Vec::new();
+        let mut literal = String::new();
+        let mut index = 0usize;
+
+        while index < raw.len() {
+            let remainder = &raw[index..];
+            if remainder.starts_with("{{") {
+                literal.push('{');
+                index += 2;
+                continue;
+            }
+            if remainder.starts_with("}}") {
+                literal.push('}');
+                index += 2;
+                continue;
+            }
+
+            let ch = remainder.chars().next().expect("index is inside raw string");
+            match ch {
+                '{' => {
+                    if !literal.is_empty() {
+                        parts.push(CacheKeyTemplatePart::Literal(std::mem::take(&mut literal)));
+                    }
+
+                    let after_start = &raw[index + 1..];
+                    let Some(end) = after_start.find('}') else {
+                        return Err(CacheKeyTemplateError::UnclosedVariable {
+                            template: raw.clone(),
+                        });
+                    };
+                    let variable = after_start[..end].trim();
+                    if variable.is_empty() {
+                        return Err(CacheKeyTemplateError::EmptyVariable { template: raw.clone() });
+                    }
+                    parts.push(CacheKeyTemplatePart::Variable(parse_cache_key_variable(variable)?));
+                    index += end + 2;
+                }
+                '}' => {
+                    return Err(CacheKeyTemplateError::UnescapedClose { template: raw.clone() });
+                }
+                _ => {
+                    literal.push(ch);
+                    index += ch.len_utf8();
+                }
+            }
+        }
+
+        if !literal.is_empty() {
+            parts.push(CacheKeyTemplatePart::Literal(literal));
+        }
+
+        Ok(Self { raw, parts })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn render(&self, context: &CacheKeyRenderContext<'_>) -> String {
+        let mut rendered = String::with_capacity(self.raw.len() + context.uri.len());
+        for part in &self.parts {
+            match part {
+                CacheKeyTemplatePart::Literal(value) => rendered.push_str(value),
+                CacheKeyTemplatePart::Variable(variable) => match variable {
+                    CacheKeyVariable::Scheme => rendered.push_str(context.scheme),
+                    CacheKeyVariable::Host => rendered.push_str(context.host),
+                    CacheKeyVariable::Uri => rendered.push_str(context.uri),
+                    CacheKeyVariable::Method => rendered.push_str(context.method),
+                },
+            }
+        }
+        rendered
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CacheKeyTemplateError {
+    #[error("cache key template `{template}` has an unclosed variable")]
+    UnclosedVariable { template: String },
+    #[error("cache key template `{template}` has an unescaped closing brace")]
+    UnescapedClose { template: String },
+    #[error("cache key template `{template}` has an empty variable")]
+    EmptyVariable { template: String },
+    #[error("cache key template variable `{name}` is not supported")]
+    UnknownVariable { name: String },
+}
+
+fn parse_cache_key_variable(name: &str) -> Result<CacheKeyVariable, CacheKeyTemplateError> {
+    match name {
+        "scheme" => Ok(CacheKeyVariable::Scheme),
+        "host" => Ok(CacheKeyVariable::Host),
+        "uri" => Ok(CacheKeyVariable::Uri),
+        "method" => Ok(CacheKeyVariable::Method),
+        _ => Err(CacheKeyTemplateError::UnknownVariable { name: name.to_string() }),
+    }
+}

--- a/crates/rginx-core/src/config/route.rs
+++ b/crates/rginx-core/src/config/route.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use http::{HeaderName, StatusCode};
 use ipnet::IpNet;
 
+use super::cache::RouteCachePolicy;
 use super::upstream::Upstream;
 
 mod proxy_header;
@@ -30,6 +31,7 @@ pub struct Route {
     pub compression_min_bytes: Option<usize>,
     pub compression_content_types: Vec<String>,
     pub streaming_response_idle_timeout: Option<Duration>,
+    pub cache: Option<RouteCachePolicy>,
 }
 
 impl Route {

--- a/crates/rginx-core/src/config/snapshot.rs
+++ b/crates/rginx-core/src/config/snapshot.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::{Listener, RuntimeSettings, Upstream, VirtualHost};
+use super::{CacheZone, Listener, RuntimeSettings, Upstream, VirtualHost};
 
 #[derive(Debug, Clone)]
 pub struct ConfigSnapshot {
@@ -9,6 +9,7 @@ pub struct ConfigSnapshot {
     pub listeners: Vec<Listener>,
     pub default_vhost: VirtualHost,
     pub vhosts: Vec<VirtualHost>,
+    pub cache_zones: HashMap<String, Arc<CacheZone>>,
     pub upstreams: HashMap<String, Arc<Upstream>>,
 }
 

--- a/crates/rginx-core/src/config/tests.rs
+++ b/crates/rginx-core/src/config/tests.rs
@@ -118,6 +118,7 @@ fn config_snapshot_counts_routes_across_all_vhosts() {
                 tls: None,
             },
         ],
+        cache_zones: HashMap::new(),
         upstreams: HashMap::new(),
     };
 
@@ -375,5 +376,6 @@ fn route(path: &str) -> Route {
         compression_min_bytes: None,
         compression_content_types: Vec::new(),
         streaming_response_idle_timeout: None,
+        cache: None,
     }
 }

--- a/crates/rginx-core/src/lib.rs
+++ b/crates/rginx-core/src/lib.rs
@@ -5,12 +5,13 @@ pub mod service;
 pub mod types;
 
 pub use config::{
-    AccessLogFormat, AccessLogValues, ActiveHealthCheck, ClientIdentity, ConfigSnapshot,
-    DEFAULT_SERVER_HEADER, GrpcRouteMatch, Listener, ListenerApplicationProtocol, ListenerHttp3,
-    ListenerTransportBinding, ListenerTransportKind, OcspConfig, OcspNonceMode,
-    OcspResponderPolicy, ProxyHeaderRenderContext, ProxyHeaderTemplate, ProxyHeaderTemplateError,
-    ProxyHeaderValue, ProxyTarget, ReturnAction, Route, RouteAccessControl, RouteAction,
-    RouteBufferingPolicy, RouteCompressionPolicy, RouteMatcher, RouteRateLimit, RouteRegexError,
+    AccessLogFormat, AccessLogValues, ActiveHealthCheck, CacheKeyRenderContext, CacheKeyTemplate,
+    CacheKeyTemplateError, CacheZone, ClientIdentity, ConfigSnapshot, DEFAULT_SERVER_HEADER,
+    GrpcRouteMatch, Listener, ListenerApplicationProtocol, ListenerHttp3, ListenerTransportBinding,
+    ListenerTransportKind, OcspConfig, OcspNonceMode, OcspResponderPolicy,
+    ProxyHeaderRenderContext, ProxyHeaderTemplate, ProxyHeaderTemplateError, ProxyHeaderValue,
+    ProxyTarget, ReturnAction, Route, RouteAccessControl, RouteAction, RouteBufferingPolicy,
+    RouteCachePolicy, RouteCompressionPolicy, RouteMatcher, RouteRateLimit, RouteRegexError,
     RouteRegexMatcher, RuntimeSettings, Server, ServerCertificateBundle, ServerClientAuthMode,
     ServerClientAuthPolicy, ServerNameMatch, ServerTls, TlsCipherSuite, TlsKeyExchangeGroup,
     TlsVersion, Upstream, UpstreamDnsPolicy, UpstreamLoadBalance, UpstreamPeer, UpstreamProtocol,

--- a/crates/rginx-http/Cargo.toml
+++ b/crates/rginx-http/Cargo.toml
@@ -38,6 +38,7 @@ rginx-core = { path = "../rginx-core" }
 rustls.workspace = true
 rustls-native-certs.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sha1.workspace = true
 sha2.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util"] }

--- a/crates/rginx-http/src/cache/entry.rs
+++ b/crates/rginx-http/src/cache/entry.rs
@@ -1,0 +1,237 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use bytes::Bytes;
+use http::header::{
+    CONNECTION, CONTENT_LENGTH, HeaderMap, HeaderName, HeaderValue, PROXY_AUTHENTICATE,
+    PROXY_AUTHORIZATION, TE, TRAILER, TRANSFER_ENCODING, UPGRADE,
+};
+use http::{Response, StatusCode};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::fs;
+
+use crate::handler::{HttpResponse, full_body};
+
+use super::{CACHE_STATUS_HEADER, CacheIndexEntry, CacheZoneRuntime};
+
+static CACHE_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct CacheMetadata {
+    #[serde(default)]
+    pub(super) key: String,
+    pub(super) status: u16,
+    headers: Vec<CachedHeader>,
+    pub(super) stored_at_unix_ms: u64,
+    pub(super) expires_at_unix_ms: u64,
+    pub(super) body_size_bytes: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CachedHeader {
+    name: String,
+    value: Vec<u8>,
+}
+
+pub(super) struct CachePaths {
+    pub(super) dir: PathBuf,
+    pub(super) metadata: PathBuf,
+    pub(super) body: PathBuf,
+}
+
+pub(super) fn cache_metadata(
+    key: String,
+    status: StatusCode,
+    headers: &HeaderMap,
+    stored_at_unix_ms: u64,
+    expires_at_unix_ms: u64,
+    body_size_bytes: usize,
+) -> CacheMetadata {
+    CacheMetadata {
+        key,
+        status: status.as_u16(),
+        headers: cached_headers(headers, body_size_bytes),
+        stored_at_unix_ms,
+        expires_at_unix_ms,
+        body_size_bytes,
+    }
+}
+
+pub(super) async fn read_cached_response(
+    zone: &CacheZoneRuntime,
+    entry: &CacheIndexEntry,
+    read_body: bool,
+) -> std::io::Result<HttpResponse> {
+    let paths = cache_paths(&zone.config.path, &entry.hash);
+    let metadata = fs::read(&paths.metadata).await?;
+    let metadata: CacheMetadata = serde_json::from_slice(&metadata)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let body = if read_body {
+        let body = fs::read(&paths.body).await?;
+        if body.len() != metadata.body_size_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "cached body length does not match metadata",
+            ));
+        }
+        body
+    } else {
+        Vec::new()
+    };
+
+    let status = StatusCode::from_u16(metadata.status)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let mut response = Response::builder().status(status);
+    let headers = response.headers_mut().expect("response builder should expose headers");
+    for header in metadata.headers {
+        let name = HeaderName::from_bytes(header.name.as_bytes())
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        let value = HeaderValue::from_bytes(&header.value)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        headers.append(name, value);
+    }
+
+    response
+        .body(full_body(Bytes::from(body)))
+        .map_err(|error| std::io::Error::other(error.to_string()))
+}
+
+pub(super) async fn write_cache_entry(
+    paths: &CachePaths,
+    metadata: &CacheMetadata,
+    body: &[u8],
+) -> std::io::Result<()> {
+    fs::create_dir_all(&paths.dir).await?;
+    let suffix = next_temp_suffix();
+    let metadata_tmp = sibling_temp_path(&paths.metadata, &suffix);
+    let body_tmp = sibling_temp_path(&paths.body, &suffix);
+    let metadata_bytes =
+        serde_json::to_vec(metadata).map_err(|error| std::io::Error::other(error.to_string()))?;
+
+    if let Err(error) = fs::write(&body_tmp, body).await {
+        cleanup_failed_write(paths, &body_tmp, &metadata_tmp, false).await;
+        return Err(error);
+    }
+    if let Err(error) = fs::write(&metadata_tmp, metadata_bytes).await {
+        cleanup_failed_write(paths, &body_tmp, &metadata_tmp, false).await;
+        return Err(error);
+    }
+    if let Err(error) = fs::rename(&body_tmp, &paths.body).await {
+        cleanup_failed_write(paths, &body_tmp, &metadata_tmp, false).await;
+        return Err(error);
+    }
+    if let Err(error) = fs::rename(&metadata_tmp, &paths.metadata).await {
+        cleanup_failed_write(paths, &body_tmp, &metadata_tmp, true).await;
+        return Err(error);
+    }
+    Ok(())
+}
+
+pub(super) fn cache_paths(base: &Path, hash: &str) -> CachePaths {
+    let prefix = hash.get(..2).unwrap_or("00");
+    let dir = base.join(prefix);
+    CachePaths {
+        metadata: dir.join(format!("{hash}.meta.json")),
+        body: dir.join(format!("{hash}.body")),
+        dir,
+    }
+}
+
+pub(super) fn cache_key_hash(key: &str) -> String {
+    let digest = Sha256::digest(key.as_bytes());
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+pub(super) fn unix_time_ms(time: SystemTime) -> u64 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+fn cached_headers(headers: &HeaderMap, body_size_bytes: usize) -> Vec<CachedHeader> {
+    let mut headers = headers.clone();
+    let had_content_length = headers.contains_key(CONTENT_LENGTH);
+    remove_cache_hop_by_hop_headers(&mut headers);
+    headers.remove(CACHE_STATUS_HEADER);
+    headers.remove(CONTENT_LENGTH);
+    if had_content_length || body_size_bytes > 0 {
+        headers.insert(
+            CONTENT_LENGTH,
+            HeaderValue::from_str(&body_size_bytes.to_string())
+                .expect("cache body length should fit in a header"),
+        );
+    }
+
+    headers
+        .iter()
+        .map(|(name, value)| CachedHeader {
+            name: name.as_str().to_string(),
+            value: value.as_bytes().to_vec(),
+        })
+        .collect()
+}
+
+fn remove_cache_hop_by_hop_headers(headers: &mut HeaderMap) {
+    let mut extra_headers = Vec::new();
+    for value in headers.get_all(CONNECTION) {
+        let Ok(value) = value.to_str() else {
+            continue;
+        };
+        for token in value.split(',').map(str::trim).filter(|token| !token.is_empty()) {
+            if let Ok(name) = HeaderName::from_bytes(token.as_bytes()) {
+                extra_headers.push(name);
+            }
+        }
+    }
+
+    for name in extra_headers {
+        headers.remove(name);
+    }
+    for name in [
+        CONNECTION,
+        PROXY_AUTHENTICATE,
+        PROXY_AUTHORIZATION,
+        TE,
+        TRAILER,
+        TRANSFER_ENCODING,
+        UPGRADE,
+    ] {
+        headers.remove(name);
+    }
+    headers.remove("keep-alive");
+    headers.remove("proxy-connection");
+}
+
+fn next_temp_suffix() -> String {
+    let counter = CACHE_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!(".tmp-{}-{counter}", std::process::id())
+}
+
+fn sibling_temp_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut file_name =
+        path.file_name().map_or_else(|| OsString::from("cache-entry"), |name| name.to_os_string());
+    file_name.push(suffix);
+    path.with_file_name(file_name)
+}
+
+async fn cleanup_failed_write(
+    paths: &CachePaths,
+    body_tmp: &Path,
+    metadata_tmp: &Path,
+    remove_final: bool,
+) {
+    let _ = fs::remove_file(body_tmp).await;
+    let _ = fs::remove_file(metadata_tmp).await;
+    if remove_final {
+        let _ = fs::remove_file(&paths.body).await;
+        let _ = fs::remove_file(&paths.metadata).await;
+    }
+}

--- a/crates/rginx-http/src/cache/load.rs
+++ b/crates/rginx-http/src/cache/load.rs
@@ -1,0 +1,170 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use rginx_core::CacheZone;
+use serde::Deserialize;
+
+use super::entry::{cache_key_hash, cache_paths, unix_time_ms};
+use super::store::eviction_candidates;
+use super::{CacheIndex, CacheIndexEntry};
+
+#[derive(Debug, Deserialize)]
+struct ScannedCacheMetadata {
+    #[serde(default)]
+    key: String,
+    #[serde(default)]
+    stored_at_unix_ms: u64,
+    expires_at_unix_ms: u64,
+    body_size_bytes: usize,
+}
+
+pub(super) fn load_index_from_disk(zone: &CacheZone) -> io::Result<CacheIndex> {
+    let mut index = CacheIndex::default();
+    if !zone.path.exists() {
+        return Ok(index);
+    }
+
+    let now = unix_time_ms(std::time::SystemTime::now());
+    for prefix_dir in fs::read_dir(&zone.path)? {
+        let prefix_dir = match prefix_dir {
+            Ok(prefix_dir) => prefix_dir,
+            Err(error) => {
+                tracing::warn!(
+                    path = %zone.path.display(),
+                    %error,
+                    "failed to read cache zone directory entry; skipping"
+                );
+                continue;
+            }
+        };
+        let Ok(file_type) = prefix_dir.file_type() else {
+            tracing::warn!(
+                path = %prefix_dir.path().display(),
+                "failed to read cache directory entry type; skipping"
+            );
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        scan_prefix_dir(zone, prefix_dir.path().as_path(), now, &mut index)?;
+    }
+
+    for hash in eviction_candidates(&mut index, zone.max_size_bytes) {
+        remove_cache_files(zone, &hash);
+    }
+
+    Ok(index)
+}
+
+fn scan_prefix_dir(
+    zone: &CacheZone,
+    dir: &Path,
+    now: u64,
+    index: &mut CacheIndex,
+) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                tracing::warn!(
+                    path = %dir.display(),
+                    %error,
+                    "failed to read cache prefix directory entry; skipping"
+                );
+                continue;
+            }
+        };
+        let path = entry.path();
+        let Some(hash) = metadata_hash(&path) else {
+            if let Some(hash) = body_hash(&path)
+                && !cache_paths(&zone.path, &hash).metadata.exists()
+            {
+                remove_cache_files(zone, &hash);
+            }
+            continue;
+        };
+        let Some((key, index_entry)) = load_cache_index_entry(zone, &hash, now) else {
+            continue;
+        };
+
+        if let Some(existing) = index.entries.insert(key, index_entry.clone()) {
+            index.current_size_bytes =
+                index.current_size_bytes.saturating_sub(existing.body_size_bytes);
+        }
+        index.current_size_bytes =
+            index.current_size_bytes.saturating_add(index_entry.body_size_bytes);
+    }
+    Ok(())
+}
+
+fn load_cache_index_entry(
+    zone: &CacheZone,
+    hash: &str,
+    now: u64,
+) -> Option<(String, CacheIndexEntry)> {
+    let paths = cache_paths(&zone.path, hash);
+    let Ok(metadata) = read_cache_metadata(&paths.metadata) else {
+        remove_cache_files(zone, hash);
+        return None;
+    };
+    if metadata.key.is_empty() || cache_key_hash(&metadata.key) != hash {
+        remove_cache_files(zone, hash);
+        return None;
+    }
+    if now > metadata.expires_at_unix_ms {
+        remove_cache_files(zone, hash);
+        return None;
+    }
+
+    let Ok(body_metadata) = fs::metadata(&paths.body) else {
+        remove_cache_files(zone, hash);
+        return None;
+    };
+    let body_size = body_metadata.len();
+    let Ok(body_size) = usize::try_from(body_size) else {
+        remove_cache_files(zone, hash);
+        return None;
+    };
+    if body_size != metadata.body_size_bytes {
+        remove_cache_files(zone, hash);
+        return None;
+    }
+
+    Some((
+        metadata.key,
+        CacheIndexEntry {
+            hash: hash.to_string(),
+            body_size_bytes: metadata.body_size_bytes,
+            expires_at_unix_ms: metadata.expires_at_unix_ms,
+            last_access_unix_ms: metadata.stored_at_unix_ms,
+        },
+    ))
+}
+
+fn read_cache_metadata(path: &Path) -> io::Result<ScannedCacheMetadata> {
+    let metadata = fs::read(path)?;
+    serde_json::from_slice(&metadata)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+fn metadata_hash(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    let hash = name.strip_suffix(".meta.json")?;
+    (hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .then(|| hash.to_string())
+}
+
+fn body_hash(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    let hash = name.strip_suffix(".body")?;
+    (hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .then(|| hash.to_string())
+}
+
+fn remove_cache_files(zone: &CacheZone, hash: &str) {
+    let paths = cache_paths(&zone.path, hash);
+    let _ = fs::remove_file(paths.metadata);
+    let _ = fs::remove_file(paths.body);
+}

--- a/crates/rginx-http/src/cache/mod.rs
+++ b/crates/rginx-http/src/cache/mod.rs
@@ -1,0 +1,290 @@
+//! Route-level HTTP response cache for proxied responses.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+use http::header::{HeaderMap, HeaderValue};
+use http::{Method, Request, StatusCode, Uri};
+use rginx_core::{CacheZone, ConfigSnapshot, Error, Result, RouteCachePolicy};
+use tokio::fs;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::handler::{HttpBody, HttpResponse};
+
+mod entry;
+mod load;
+mod policy;
+mod request;
+mod store;
+
+#[cfg(test)]
+use entry::{cache_key_hash, cache_metadata, write_cache_entry};
+use entry::{cache_paths, read_cached_response, unix_time_ms};
+use load::load_index_from_disk;
+#[cfg(test)]
+use policy::{response_is_storable, response_ttl};
+use request::{cache_request_bypass, render_cache_key};
+use store::{lock_index, remove_index_entry, store_response};
+
+const CACHE_STATUS_HEADER: &str = "x-cache";
+
+#[derive(Clone, Default)]
+pub(crate) struct CacheManager {
+    zones: Arc<HashMap<String, Arc<CacheZoneRuntime>>>,
+}
+
+pub(crate) struct CacheStoreContext {
+    zone: Arc<CacheZoneRuntime>,
+    policy: RouteCachePolicy,
+    key: String,
+    cache_status: CacheStatus,
+    store_response: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct CacheRequest {
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+}
+
+pub(crate) enum CacheLookup {
+    Hit(HttpResponse),
+    Miss(CacheStoreContext),
+    Bypass(CacheStatus),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CacheStatus {
+    Hit,
+    Miss,
+    Bypass,
+    Expired,
+}
+
+impl CacheStatus {
+    fn as_header_value(self) -> HeaderValue {
+        HeaderValue::from_static(match self {
+            Self::Hit => "HIT",
+            Self::Miss => "MISS",
+            Self::Bypass => "BYPASS",
+            Self::Expired => "EXPIRED",
+        })
+    }
+}
+
+struct CacheZoneRuntime {
+    config: Arc<CacheZone>,
+    index: Mutex<CacheIndex>,
+    io_lock: AsyncMutex<()>,
+}
+
+#[derive(Default)]
+struct CacheIndex {
+    entries: HashMap<String, CacheIndexEntry>,
+    current_size_bytes: usize,
+}
+
+#[derive(Clone)]
+struct CacheIndexEntry {
+    hash: String,
+    body_size_bytes: usize,
+    expires_at_unix_ms: u64,
+    last_access_unix_ms: u64,
+}
+
+impl CacheManager {
+    pub(crate) fn from_config(config: &ConfigSnapshot) -> Result<Self> {
+        let zones = config
+            .cache_zones
+            .iter()
+            .map(|(name, zone)| {
+                std::fs::create_dir_all(&zone.path).map_err(|error| {
+                    Error::Server(format!(
+                        "failed to create cache zone `{name}` directory `{}`: {error}",
+                        zone.path.display()
+                    ))
+                })?;
+                let index = load_index_from_disk(zone.as_ref()).map_err(|error| {
+                    Error::Server(format!(
+                        "failed to load cache zone `{name}` index from `{}`: {error}",
+                        zone.path.display()
+                    ))
+                })?;
+                Ok((
+                    name.clone(),
+                    Arc::new(CacheZoneRuntime {
+                        config: zone.clone(),
+                        index: Mutex::new(index),
+                        io_lock: AsyncMutex::new(()),
+                    }),
+                ))
+            })
+            .collect::<Result<HashMap<_, _>>>()?;
+
+        Ok(Self { zones: Arc::new(zones) })
+    }
+
+    pub(crate) async fn lookup(
+        &self,
+        request: CacheRequest,
+        downstream_scheme: &str,
+        policy: &RouteCachePolicy,
+    ) -> CacheLookup {
+        let Some(zone) = self.zones.get(&policy.zone).cloned() else {
+            tracing::warn!(
+                zone = %policy.zone,
+                "cache policy references unknown zone; bypassing cache"
+            );
+            return CacheLookup::Bypass(CacheStatus::Bypass);
+        };
+
+        if cache_request_bypass(&request, policy) {
+            return CacheLookup::Bypass(CacheStatus::Bypass);
+        }
+
+        let key = render_cache_key(
+            &request.method,
+            &request.uri,
+            &request.headers,
+            downstream_scheme,
+            policy,
+        );
+        let now = unix_time_ms(SystemTime::now());
+        let (lookup, expired_hash) = {
+            let mut index = lock_index(&zone.index);
+            match index.entries.get_mut(&key) {
+                Some(entry) if now > entry.expires_at_unix_ms => {
+                    let removed = index.entries.remove(&key);
+                    if let Some(entry) = removed {
+                        index.current_size_bytes =
+                            index.current_size_bytes.saturating_sub(entry.body_size_bytes);
+                        (Err(CacheStatus::Expired), Some(entry.hash))
+                    } else {
+                        (Err(CacheStatus::Expired), None)
+                    }
+                }
+                Some(entry) => {
+                    entry.last_access_unix_ms = now;
+                    (Ok(entry.clone()), None)
+                }
+                None => (Err(CacheStatus::Miss), None),
+            }
+        };
+        if let Some(hash) = expired_hash.as_deref() {
+            remove_cache_files_if_unindexed(&zone, &key, hash).await;
+        }
+        let entry = match lookup {
+            Ok(entry) => entry,
+            Err(status) => {
+                return CacheLookup::Miss(CacheStoreContext::new(
+                    zone,
+                    policy.clone(),
+                    key,
+                    status,
+                    request.method == Method::GET,
+                ));
+            }
+        };
+
+        let cached_response = {
+            let _io_guard = zone.io_lock.lock().await;
+            read_cached_response(&zone, &entry, request.method != Method::HEAD).await
+        };
+        match cached_response {
+            Ok(mut response) => {
+                response
+                    .headers_mut()
+                    .insert(CACHE_STATUS_HEADER, CacheStatus::Hit.as_header_value());
+                CacheLookup::Hit(response)
+            }
+            Err(error) => {
+                tracing::warn!(
+                    zone = %zone.config.name,
+                    key_hash = %entry.hash,
+                    %error,
+                    "failed to read cached response; treating as miss"
+                );
+                remove_index_entry(&zone, &key);
+                remove_cache_files_if_unindexed(&zone, &key, &entry.hash).await;
+                CacheLookup::Miss(CacheStoreContext::new(
+                    zone,
+                    policy.clone(),
+                    key,
+                    CacheStatus::Miss,
+                    request.method == Method::GET,
+                ))
+            }
+        }
+    }
+
+    pub(crate) async fn store_response(
+        &self,
+        context: CacheStoreContext,
+        response: HttpResponse,
+    ) -> HttpResponse {
+        let status = context.cache_status;
+        let response = if context.store_response {
+            match store_response(context, response).await {
+                Ok(response) => response,
+                Err(error) => {
+                    tracing::warn!(%error, "failed to store cached response");
+                    crate::handler::text_response(
+                        StatusCode::BAD_GATEWAY,
+                        "text/plain; charset=utf-8",
+                        format!("failed to read upstream response while caching: {error}\n"),
+                    )
+                }
+            }
+        } else {
+            response
+        };
+
+        with_cache_status(response, status)
+    }
+}
+
+impl CacheRequest {
+    pub(crate) fn from_request(request: &Request<HttpBody>) -> Self {
+        Self {
+            method: request.method().clone(),
+            uri: request.uri().clone(),
+            headers: request.headers().clone(),
+        }
+    }
+}
+
+impl CacheStoreContext {
+    fn new(
+        zone: Arc<CacheZoneRuntime>,
+        policy: RouteCachePolicy,
+        key: String,
+        cache_status: CacheStatus,
+        store_response: bool,
+    ) -> Self {
+        Self { zone, policy, key, cache_status, store_response }
+    }
+
+    pub(crate) fn cache_status(&self) -> CacheStatus {
+        self.cache_status
+    }
+}
+
+pub(crate) fn with_cache_status(mut response: HttpResponse, status: CacheStatus) -> HttpResponse {
+    response.headers_mut().insert(CACHE_STATUS_HEADER, status.as_header_value());
+    response
+}
+
+async fn remove_cache_files_if_unindexed(zone: &CacheZoneRuntime, key: &str, hash: &str) {
+    let _io_guard = zone.io_lock.lock().await;
+    if lock_index(&zone.index).entries.contains_key(key) {
+        return;
+    }
+    let paths = cache_paths(&zone.config.path, hash);
+    let _ = fs::remove_file(paths.metadata).await;
+    let _ = fs::remove_file(paths.body).await;
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rginx-http/src/cache/policy.rs
+++ b/crates/rginx-http/src/cache/policy.rs
@@ -1,0 +1,116 @@
+use std::time::{Duration, SystemTime};
+
+use http::StatusCode;
+use http::header::{
+    CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, EXPIRES, HeaderMap, SET_COOKIE,
+    VARY,
+};
+use hyper::body::Body as _;
+
+use crate::handler::HttpResponse;
+
+use super::CacheStoreContext;
+
+pub(super) fn response_is_storable(context: &CacheStoreContext, response: &HttpResponse) -> bool {
+    if !context.policy.statuses.iter().any(|status| *status == response.status()) {
+        return false;
+    }
+    if response.status() == StatusCode::PARTIAL_CONTENT
+        || response.headers().contains_key(CONTENT_RANGE)
+        || response.headers().contains_key(SET_COOKIE)
+        || response.headers().contains_key(VARY)
+    {
+        return false;
+    }
+    if response_is_grpc(response.headers()) {
+        return false;
+    }
+    if cache_control_contains(response.headers(), &["no-store", "private", "no-cache"]) {
+        return false;
+    }
+    if let Some(length) = parse_content_length(response.headers())
+        && length > context.zone.config.max_entry_bytes
+    {
+        return false;
+    }
+    if let Some(exact) = response.body().size_hint().exact()
+        && exact > context.zone.config.max_entry_bytes as u64
+    {
+        return false;
+    }
+    if !matches!(
+        response.body().size_hint().upper(),
+        Some(upper) if upper <= context.zone.config.max_entry_bytes as u64
+    ) {
+        return false;
+    }
+    true
+}
+
+fn response_is_grpc(headers: &HeaderMap) -> bool {
+    headers.get(CONTENT_TYPE).and_then(|value| value.to_str().ok()).is_some_and(|content_type| {
+        let mime = content_type.split(';').next().unwrap_or_default().trim().to_ascii_lowercase();
+        mime.eq_ignore_ascii_case("application/grpc")
+            || mime.starts_with("application/grpc+")
+            || mime.starts_with("application/grpc-web")
+    })
+}
+
+pub(super) fn response_ttl(headers: &HeaderMap, default_ttl: Duration) -> Duration {
+    cache_control_max_age(headers).or_else(|| expires_ttl(headers)).unwrap_or(default_ttl)
+}
+
+fn cache_control_max_age(headers: &HeaderMap) -> Option<Duration> {
+    let mut max_age = None;
+    for value in headers.get_all(CACHE_CONTROL) {
+        let Ok(value) = value.to_str() else {
+            continue;
+        };
+        for directive in value.split(',').map(str::trim) {
+            let Some((name, value)) = directive.split_once('=') else {
+                continue;
+            };
+            if name.trim().eq_ignore_ascii_case("s-maxage")
+                || name.trim().eq_ignore_ascii_case("max-age")
+            {
+                let Ok(seconds) = value.trim().trim_matches('"').parse::<u64>() else {
+                    continue;
+                };
+                let duration = Duration::from_secs(seconds);
+                if name.trim().eq_ignore_ascii_case("s-maxage") {
+                    return Some(duration);
+                }
+                if max_age.is_none() {
+                    max_age = Some(duration);
+                }
+            }
+        }
+    }
+    max_age
+}
+
+fn expires_ttl(headers: &HeaderMap) -> Option<Duration> {
+    let expires = headers.get(EXPIRES)?.to_str().ok()?;
+    let expires = httpdate::parse_http_date(expires).ok()?;
+    // An explicit stale Expires value means "do not cache"; default_ttl only applies
+    // when upstream sends no freshness metadata.
+    Some(expires.duration_since(SystemTime::now()).unwrap_or(Duration::ZERO))
+}
+
+fn cache_control_contains(headers: &HeaderMap, directives: &[&str]) -> bool {
+    headers.get_all(CACHE_CONTROL).iter().any(|value| {
+        value.to_str().ok().is_some_and(|value| {
+            value.split(',').any(|directive| {
+                let name = directive.split_once('=').map_or(directive, |(name, _)| name).trim();
+                directives.iter().any(|expected| name.eq_ignore_ascii_case(expected))
+            })
+        })
+    })
+}
+
+fn parse_content_length(headers: &HeaderMap) -> Option<usize> {
+    headers
+        .get(CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<usize>().ok())
+}

--- a/crates/rginx-http/src/cache/request.rs
+++ b/crates/rginx-http/src/cache/request.rs
@@ -1,0 +1,51 @@
+use http::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, RANGE};
+use http::{Method, Uri};
+use rginx_core::{CacheKeyRenderContext, RouteCachePolicy};
+
+use super::CacheRequest;
+
+pub(super) fn cache_request_bypass(request: &CacheRequest, policy: &RouteCachePolicy) -> bool {
+    if !policy.methods.contains(&request.method) {
+        return true;
+    }
+
+    if !matches!(request.method, Method::GET | Method::HEAD) {
+        return true;
+    }
+
+    if request.headers.contains_key(AUTHORIZATION) || request.headers.contains_key(RANGE) {
+        return true;
+    }
+
+    request.headers.get(CONTENT_TYPE).and_then(|value| value.to_str().ok()).is_some_and(
+        |content_type| {
+            let mime =
+                content_type.split(';').next().unwrap_or_default().trim().to_ascii_lowercase();
+            mime == "application/grpc"
+                || mime.starts_with("application/grpc+")
+                || mime.starts_with("application/grpc-web")
+        },
+    )
+}
+
+pub(super) fn render_cache_key(
+    method: &Method,
+    uri: &Uri,
+    headers: &HeaderMap,
+    scheme: &str,
+    policy: &RouteCachePolicy,
+) -> String {
+    let request_uri = uri.path_and_query().map(|value| value.as_str()).unwrap_or("/");
+    let host = headers
+        .get(http::header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| uri.authority().map(|authority| authority.as_str()))
+        .unwrap_or("-");
+    policy.key.render(&CacheKeyRenderContext {
+        scheme,
+        host,
+        uri: request_uri,
+        method: method.as_str(),
+    })
+}

--- a/crates/rginx-http/src/cache/store.rs
+++ b/crates/rginx-http/src/cache/store.rs
@@ -1,0 +1,162 @@
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use http::Response;
+use http_body_util::BodyExt;
+use tokio::fs;
+
+use crate::handler::{HttpResponse, full_body};
+
+use super::entry::{cache_key_hash, cache_metadata, cache_paths, unix_time_ms, write_cache_entry};
+use super::policy::{response_is_storable, response_ttl};
+use super::{CacheIndex, CacheIndexEntry, CacheStoreContext, CacheZoneRuntime};
+
+pub(super) struct CacheStoreError {
+    source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl std::fmt::Display for CacheStoreError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.source)
+    }
+}
+
+impl std::fmt::Debug for CacheStoreError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("CacheStoreError").field("source", &self.source).finish()
+    }
+}
+
+impl std::error::Error for CacheStoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+pub(super) async fn store_response(
+    context: CacheStoreContext,
+    response: HttpResponse,
+) -> std::result::Result<HttpResponse, CacheStoreError> {
+    if !response_is_storable(&context, &response) {
+        return Ok(response);
+    }
+
+    let (parts, body) = response.into_parts();
+    let collected = match body.collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(error) => {
+            return Err(CacheStoreError { source: error });
+        }
+    };
+
+    if collected.len() > context.zone.config.max_entry_bytes {
+        return Ok(Response::from_parts(parts, full_body(collected)));
+    }
+
+    let now = unix_time_ms(SystemTime::now());
+    let ttl = response_ttl(&parts.headers, context.zone.config.default_ttl);
+    if ttl.is_zero() {
+        return Ok(Response::from_parts(parts, full_body(collected)));
+    }
+    let expires_at_unix_ms = now.saturating_add(duration_to_ms(ttl));
+    let metadata = cache_metadata(
+        context.key.clone(),
+        parts.status,
+        &parts.headers,
+        now,
+        expires_at_unix_ms,
+        collected.len(),
+    );
+    let hash = cache_key_hash(&context.key);
+    let paths = cache_paths(&context.zone.config.path, &hash);
+    let _io_guard = context.zone.io_lock.lock().await;
+
+    if let Err(error) = write_cache_entry(&paths, &metadata, &collected).await {
+        tracing::warn!(
+            zone = %context.zone.config.name,
+            key_hash = %hash,
+            %error,
+            "failed to write cache entry"
+        );
+    } else {
+        update_index_after_store(
+            &context.zone,
+            context.key,
+            CacheIndexEntry {
+                hash,
+                body_size_bytes: metadata.body_size_bytes,
+                expires_at_unix_ms,
+                last_access_unix_ms: now,
+            },
+        )
+        .await;
+    }
+
+    Ok(Response::from_parts(parts, full_body(collected)))
+}
+
+async fn update_index_after_store(
+    zone: &Arc<CacheZoneRuntime>,
+    key: String,
+    entry: CacheIndexEntry,
+) {
+    let evictions = {
+        let mut index = lock_index(&zone.index);
+        if let Some(existing) = index.entries.insert(key, entry.clone()) {
+            index.current_size_bytes =
+                index.current_size_bytes.saturating_sub(existing.body_size_bytes);
+        }
+        index.current_size_bytes = index.current_size_bytes.saturating_add(entry.body_size_bytes);
+        eviction_candidates(&mut index, zone.config.max_size_bytes)
+    };
+
+    for hash in evictions {
+        let paths = cache_paths(&zone.config.path, &hash);
+        let _ = fs::remove_file(paths.metadata).await;
+        let _ = fs::remove_file(paths.body).await;
+    }
+}
+
+pub(super) fn eviction_candidates(
+    index: &mut CacheIndex,
+    max_size_bytes: Option<usize>,
+) -> Vec<String> {
+    let Some(max_size_bytes) = max_size_bytes else {
+        return Vec::new();
+    };
+    if index.current_size_bytes <= max_size_bytes {
+        return Vec::new();
+    }
+
+    let mut entries =
+        index.entries.iter().map(|(key, entry)| (key.clone(), entry.clone())).collect::<Vec<_>>();
+    entries.sort_by_key(|(_, entry)| entry.last_access_unix_ms);
+
+    let mut evicted = Vec::new();
+    for (key, entry) in entries {
+        if index.current_size_bytes <= max_size_bytes {
+            break;
+        }
+        if index.entries.remove(&key).is_some() {
+            index.current_size_bytes =
+                index.current_size_bytes.saturating_sub(entry.body_size_bytes);
+            evicted.push(entry.hash);
+        }
+    }
+    evicted
+}
+
+pub(super) fn remove_index_entry(zone: &CacheZoneRuntime, key: &str) {
+    let mut index = lock_index(&zone.index);
+    if let Some(entry) = index.entries.remove(key) {
+        index.current_size_bytes = index.current_size_bytes.saturating_sub(entry.body_size_bytes);
+    }
+}
+
+fn duration_to_ms(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+pub(super) fn lock_index(mutex: &Mutex<CacheIndex>) -> std::sync::MutexGuard<'_, CacheIndex> {
+    mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/crates/rginx-http/src/cache/tests.rs
+++ b/crates/rginx-http/src/cache/tests.rs
@@ -1,0 +1,399 @@
+use super::*;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use bytes::Bytes;
+use futures_util::stream;
+use http::header::{AUTHORIZATION, CACHE_CONTROL, CONTENT_TYPE, EXPIRES};
+use http::{Method, Request, Response, StatusCode};
+use http_body_util::{BodyExt, StreamBody};
+use hyper::body::Frame;
+use rginx_core::{CacheZone, RouteCachePolicy};
+
+use crate::handler::{BoxError, boxed_body, full_body};
+
+fn test_zone(path: PathBuf, max_entry_bytes: usize) -> Arc<CacheZoneRuntime> {
+    Arc::new(CacheZoneRuntime {
+        config: Arc::new(CacheZone {
+            name: "default".to_string(),
+            path,
+            max_size_bytes: Some(1024 * 1024),
+            inactive: Duration::from_secs(60),
+            default_ttl: Duration::from_secs(60),
+            max_entry_bytes,
+        }),
+        index: Mutex::new(CacheIndex::default()),
+        io_lock: AsyncMutex::new(()),
+    })
+}
+
+fn test_manager(path: PathBuf, max_entry_bytes: usize) -> CacheManager {
+    CacheManager {
+        zones: Arc::new(HashMap::from([("default".to_string(), test_zone(path, max_entry_bytes))])),
+    }
+}
+
+fn test_policy() -> RouteCachePolicy {
+    RouteCachePolicy {
+        zone: "default".to_string(),
+        methods: vec![Method::GET, Method::HEAD],
+        statuses: vec![StatusCode::OK],
+        key: rginx_core::CacheKeyTemplate::parse("{scheme}:{host}:{uri}")
+            .expect("key should parse"),
+        stale_if_error: None,
+    }
+}
+
+#[test]
+fn cache_key_template_renders_request_parts() {
+    let template =
+        rginx_core::CacheKeyTemplate::parse("{scheme}:{host}:{uri}").expect("key should parse");
+    let policy = RouteCachePolicy {
+        zone: "default".to_string(),
+        methods: vec![Method::GET],
+        statuses: vec![StatusCode::OK],
+        key: template,
+        stale_if_error: None,
+    };
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/assets/app.js?v=1")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+
+    assert_eq!(
+        render_cache_key(request.method(), request.uri(), request.headers(), "https", &policy),
+        "https:example.com:/assets/app.js?v=1"
+    );
+}
+
+#[test]
+fn authorization_request_bypasses_cache() {
+    let policy = RouteCachePolicy {
+        zone: "default".to_string(),
+        methods: vec![Method::GET],
+        statuses: vec![StatusCode::OK],
+        key: rginx_core::CacheKeyTemplate::parse("{uri}").expect("key should parse"),
+        stale_if_error: None,
+    };
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/")
+        .header(AUTHORIZATION, "Bearer token")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    let request = CacheRequest::from_request(&request);
+
+    assert!(cache_request_bypass(&request, &policy));
+}
+
+#[tokio::test]
+async fn cache_manager_returns_miss_then_hit_for_cacheable_get() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let policy = test_policy();
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/assets/app.js?v=1")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+
+    let context = match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await
+    {
+        CacheLookup::Miss(context) => context,
+        CacheLookup::Hit(_) => panic!("empty cache should miss"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    };
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(CACHE_CONTROL, "max-age=60")
+        .header(CONTENT_TYPE, "text/javascript")
+        .body(full_body("cached body"))
+        .expect("response should build");
+    let stored = manager.store_response(context, response).await;
+    assert_eq!(stored.headers().get(CACHE_STATUS_HEADER).unwrap(), "MISS");
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Hit(response) => {
+            assert_eq!(response.headers().get(CACHE_STATUS_HEADER).unwrap(), "HIT");
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body.as_ref(), b"cached body");
+        }
+        CacheLookup::Miss(_) => panic!("stored response should hit"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cache_manager_treats_corrupt_metadata_as_miss() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let policy = test_policy();
+    let key = "https:example.com:/broken";
+    let hash = cache_key_hash(key);
+    let paths = cache_paths(temp.path(), &hash);
+    tokio::fs::create_dir_all(&paths.dir).await.expect("cache dir should be created");
+    tokio::fs::write(&paths.metadata, b"{not-json").await.expect("metadata should be written");
+    tokio::fs::write(&paths.body, b"cached").await.expect("body should be written");
+
+    let zone = manager.zones.get("default").expect("zone should exist");
+    {
+        let mut index = lock_index(&zone.index);
+        index.entries.insert(
+            key.to_string(),
+            CacheIndexEntry {
+                hash,
+                body_size_bytes: 6,
+                expires_at_unix_ms: unix_time_ms(SystemTime::now()) + 60_000,
+                last_access_unix_ms: unix_time_ms(SystemTime::now()),
+            },
+        );
+        index.current_size_bytes = 6;
+    }
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/broken")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Miss(_) => {}
+        CacheLookup::Hit(_) => panic!("corrupt metadata must not be served"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    }
+
+    let zone = manager.zones.get("default").expect("zone should exist");
+    assert!(!lock_index(&zone.index).entries.contains_key(key));
+}
+
+#[tokio::test]
+async fn cache_manager_removes_expired_entries_on_lookup() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let policy = test_policy();
+    let key = "https:example.com:/expired";
+    let hash = cache_key_hash(key);
+    let paths = cache_paths(temp.path(), &hash);
+    let now = unix_time_ms(SystemTime::now());
+    let metadata = cache_metadata(
+        key.to_string(),
+        StatusCode::OK,
+        &http::HeaderMap::new(),
+        now.saturating_sub(2_000),
+        now.saturating_sub(1_000),
+        7,
+    );
+    write_cache_entry(&paths, &metadata, b"expired").await.expect("entry should be written");
+    let zone = manager.zones.get("default").expect("zone should exist");
+    {
+        let mut index = lock_index(&zone.index);
+        index.entries.insert(
+            key.to_string(),
+            CacheIndexEntry {
+                hash: hash.clone(),
+                body_size_bytes: 7,
+                expires_at_unix_ms: now.saturating_sub(1_000),
+                last_access_unix_ms: now.saturating_sub(2_000),
+            },
+        );
+        index.current_size_bytes = 7;
+    }
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/expired")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Miss(context) => assert_eq!(context.cache_status(), CacheStatus::Expired),
+        CacheLookup::Hit(_) => panic!("expired response must not be served"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    }
+
+    let zone = manager.zones.get("default").expect("zone should exist");
+    let index = lock_index(&zone.index);
+    assert!(!index.entries.contains_key(key));
+    assert_eq!(index.current_size_bytes, 0);
+    assert!(!paths.metadata.exists());
+    assert!(!paths.body.exists());
+}
+
+#[tokio::test]
+async fn cache_manager_does_not_store_entries_over_max_entry_size() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 4);
+    let policy = test_policy();
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/large")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    let context = match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await
+    {
+        CacheLookup::Miss(context) => context,
+        CacheLookup::Hit(_) => panic!("empty cache should miss"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    };
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .body(full_body("too large"))
+        .expect("response should build");
+    let stored = manager.store_response(context, response).await;
+    assert_eq!(stored.headers().get(CACHE_STATUS_HEADER).unwrap(), "MISS");
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Miss(_) => {}
+        CacheLookup::Hit(_) => panic!("oversized response should not be cached"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cache_manager_skips_unknown_size_response_without_consuming_body() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let policy = test_policy();
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/streamed")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    let context = match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await
+    {
+        CacheLookup::Miss(context) => context,
+        CacheLookup::Hit(_) => panic!("empty cache should miss"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    };
+
+    let stream = stream::iter([Ok::<Frame<Bytes>, BoxError>(Frame::data(Bytes::from_static(
+        b"streamed body",
+    )))]);
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .body(boxed_body(StreamBody::new(stream)))
+        .expect("response should build");
+    let stored = manager.store_response(context, response).await;
+    let body = stored.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(body.as_ref(), b"streamed body");
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Miss(_) => {}
+        CacheLookup::Hit(_) => panic!("unknown-size response should not be cached"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cache_manager_serves_head_hit_without_reading_body_file() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let policy = test_policy();
+    let get_request = Request::builder()
+        .method(Method::GET)
+        .uri("/head")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    let context = match manager
+        .lookup(CacheRequest::from_request(&get_request), "https", &policy)
+        .await
+    {
+        CacheLookup::Miss(context) => context,
+        CacheLookup::Hit(_) => panic!("empty cache should miss"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    };
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .body(full_body("cached body"))
+        .expect("response should build");
+    let _ = manager.store_response(context, response).await;
+
+    let hash = cache_key_hash("https:example.com:/head");
+    let paths = cache_paths(temp.path(), &hash);
+    tokio::fs::remove_file(paths.body).await.expect("body file should be removable");
+
+    let head_request = Request::builder()
+        .method(Method::HEAD)
+        .uri("/head")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    match manager.lookup(CacheRequest::from_request(&head_request), "https", &policy).await {
+        CacheLookup::Hit(response) => {
+            assert_eq!(response.headers().get(CACHE_STATUS_HEADER).unwrap(), "HIT");
+            assert_eq!(response.headers().get(http::header::CONTENT_LENGTH).unwrap(), "11");
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert!(body.is_empty());
+        }
+        CacheLookup::Miss(_) => panic!("HEAD should not need the cached body file"),
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    }
+}
+
+#[test]
+fn response_ttl_respects_explicit_zero_or_expired_freshness() {
+    let mut headers = HeaderMap::new();
+    headers.insert(CACHE_CONTROL, HeaderValue::from_static("max-age=0"));
+    assert_eq!(response_ttl(&headers, Duration::from_secs(60)), Duration::ZERO);
+
+    let mut headers = HeaderMap::new();
+    headers.insert(CACHE_CONTROL, HeaderValue::from_static("max-age=60, s-maxage=10"));
+    assert_eq!(response_ttl(&headers, Duration::from_secs(1)), Duration::from_secs(10));
+
+    let mut headers = HeaderMap::new();
+    headers.insert(CACHE_CONTROL, HeaderValue::from_static("max-age=invalid, s-maxage=120"));
+    assert_eq!(response_ttl(&headers, Duration::from_secs(1)), Duration::from_secs(120));
+
+    let mut headers = HeaderMap::new();
+    headers.insert(EXPIRES, HeaderValue::from_static("Wed, 21 Oct 2015 07:28:00 GMT"));
+    assert_eq!(response_ttl(&headers, Duration::from_secs(60)), Duration::ZERO);
+}
+
+#[test]
+fn no_store_response_is_not_storable() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let zone = Arc::new(CacheZoneRuntime {
+        config: Arc::new(CacheZone {
+            name: "default".to_string(),
+            path: temp.path().to_path_buf(),
+            max_size_bytes: None,
+            inactive: Duration::from_secs(60),
+            default_ttl: Duration::from_secs(60),
+            max_entry_bytes: 1024,
+        }),
+        index: Mutex::new(CacheIndex::default()),
+        io_lock: AsyncMutex::new(()),
+    });
+    let context = CacheStoreContext {
+        zone,
+        policy: RouteCachePolicy {
+            zone: "default".to_string(),
+            methods: vec![Method::GET],
+            statuses: vec![StatusCode::OK],
+            key: rginx_core::CacheKeyTemplate::parse("{uri}").expect("key should parse"),
+            stale_if_error: None,
+        },
+        key: "/".to_string(),
+        cache_status: CacheStatus::Miss,
+        store_response: true,
+    };
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(CACHE_CONTROL, "no-store")
+        .header(CONTENT_TYPE, "text/plain")
+        .body(full_body("hello"))
+        .expect("response should build");
+
+    assert!(!response_is_storable(&context, &response));
+}

--- a/crates/rginx-http/src/handler/dispatch/mod.rs
+++ b/crates/rginx-http/src/handler/dispatch/mod.rs
@@ -49,6 +49,7 @@ struct RouteExecutionContext {
     action: RouteAction,
     request_buffering: rginx_core::RouteBufferingPolicy,
     streaming_response_idle_timeout: Option<std::time::Duration>,
+    cache: Option<rginx_core::RouteCachePolicy>,
 }
 
 pub async fn handle(
@@ -165,6 +166,7 @@ pub async fn handle(
                         action: route.action.clone(),
                         request_buffering: route.request_buffering,
                         streaming_response_idle_timeout: route.streaming_response_idle_timeout,
+                        cache: route.cache.clone(),
                     },
                     active,
                     listener_context,

--- a/crates/rginx-http/src/handler/dispatch/route.rs
+++ b/crates/rginx-http/src/handler/dispatch/route.rs
@@ -31,7 +31,7 @@ pub(super) async fn build_route_response(
             let downstream_proto = if listener.listener_tls_enabled { "https" } else { "http" };
             crate::proxy::forward_request(
                 state,
-                active.clients,
+                active,
                 request,
                 listener.listener_id,
                 proxy,
@@ -45,6 +45,7 @@ pub(super) async fn build_route_response(
                         max_request_body_bytes: listener.max_request_body_bytes,
                         request_buffering: route.request_buffering,
                         streaming_response_idle_timeout: route.streaming_response_idle_timeout,
+                        cache: route.cache,
                     },
                 },
             )

--- a/crates/rginx-http/src/handler/tests/routing/authorize.rs
+++ b/crates/rginx-http/src/handler/tests/routing/authorize.rs
@@ -3,6 +3,7 @@ use super::super::*;
 #[test]
 fn authorize_route_rejects_disallowed_remote_addr() {
     let route = Route {
+        cache: None,
         id: "server/routes[0]|exact:/protected".to_string(),
         matcher: RouteMatcher::Exact("/protected".to_string()),
         grpc_match: None,
@@ -44,6 +45,7 @@ fn authorize_route_rejects_disallowed_remote_addr() {
 #[test]
 fn authorize_route_returns_grpc_permission_denied_for_grpc_requests() {
     let route = Route {
+        cache: None,
         id: "server/routes[0]|exact:/protected".to_string(),
         matcher: RouteMatcher::Exact("/protected".to_string()),
         grpc_match: None,

--- a/crates/rginx-http/src/handler/tests/routing/handle.rs
+++ b/crates/rginx-http/src/handler/tests/routing/handle.rs
@@ -43,6 +43,7 @@ async fn handle_serves_requests_for_retired_listener_runtime() {
 #[tokio::test]
 async fn handle_return_route_uses_numeric_body_and_ignores_non_redirect_location() {
     let route = Route {
+        cache: None,
         id: "server/routes[0]|exact:/custom".to_string(),
         matcher: RouteMatcher::Exact("/custom".to_string()),
         grpc_match: None,

--- a/crates/rginx-http/src/handler/tests/routing/selection.rs
+++ b/crates/rginx-http/src/handler/tests/routing/selection.rs
@@ -137,6 +137,7 @@ fn select_route_for_request_prefers_grpc_specific_route() {
             vec![
                 test_route("server/routes[0]|prefix:/", RouteMatcher::Prefix("/".to_string())),
                 Route {
+                    cache: None,
                     id: "server/routes[1]|prefix:/|grpc:service=grpc.health.v1.Health,method=Check"
                         .to_string(),
                     matcher: RouteMatcher::Prefix("/".to_string()),
@@ -182,6 +183,7 @@ fn select_route_for_request_does_not_match_grpc_specific_route_for_plain_http_re
             "server",
             Vec::new(),
             vec![Route {
+                cache: None,
                 id: "server/routes[0]|prefix:/|grpc:service=grpc.health.v1.Health".to_string(),
                 matcher: RouteMatcher::Prefix("/".to_string()),
                 grpc_match: Some(GrpcRouteMatch {

--- a/crates/rginx-http/src/handler/tests/support.rs
+++ b/crates/rginx-http/src/handler/tests/support.rs
@@ -30,6 +30,7 @@ pub(crate) fn test_config(default_vhost: VirtualHost, vhosts: Vec<VirtualHost>) 
         tls: None,
     };
     ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
             worker_threads: None,
@@ -60,6 +61,7 @@ pub(crate) fn test_vhost(id: &str, server_names: Vec<&str>, routes: Vec<Route>) 
 
 pub(crate) fn test_route(id: &str, matcher: RouteMatcher) -> Route {
     Route {
+        cache: None,
         id: id.to_string(),
         matcher,
         grpc_match: None,

--- a/crates/rginx-http/src/lib.rs
+++ b/crates/rginx-http/src/lib.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+mod cache;
 mod client_ip;
 mod compression;
 pub mod handler;

--- a/crates/rginx-http/src/proxy/clients/tests.rs
+++ b/crates/rginx-http/src/proxy/clients/tests.rs
@@ -104,6 +104,7 @@ async fn peer_health_snapshot_delegates_to_registry() {
         tls: None,
     };
     let snapshot = ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
             worker_threads: None,

--- a/crates/rginx-http/src/proxy/forward/attempt.rs
+++ b/crates/rginx-http/src/proxy/forward/attempt.rs
@@ -2,25 +2,40 @@ use super::*;
 
 pub async fn forward_request(
     state: SharedState,
-    clients: ProxyClients,
+    active: crate::state::ActiveState,
     request: Request<HttpBody>,
     listener_id: &str,
     target: &ProxyTarget,
     client_address: ClientAddress,
     downstream: DownstreamRequestContext<'_>,
 ) -> HttpResponse {
+    let cache_manager = active.cache.clone();
+    let clients = active.clients;
+    let cache_request = crate::cache::CacheRequest::from_request(&request);
+    let mut cache = match lookup_forward_cache(
+        &cache_manager,
+        cache_request,
+        downstream.downstream_proto,
+        downstream.options.cache.as_ref(),
+    )
+    .await
+    {
+        ForwardCacheLookup::Hit(response) => return response,
+        ForwardCacheLookup::Proceed(cache) => cache,
+    };
+
     let prepared = match prepare_forward_request(
         &state,
         &clients,
         request,
         target,
         &client_address,
-        downstream,
+        &downstream,
     )
     .await
     {
         Ok(prepared) => prepared,
-        Err(response) => return response,
+        Err(response) => return cache.mark_response(response),
     };
 
     let setup::PreparedForwardRequest {
@@ -49,21 +64,14 @@ pub async fn forward_request(
         ) {
             Ok(request) => request,
             Err(error) => {
-                tracing::warn!(
-                    request_id = %downstream.request_id,
-                    upstream = %target.upstream_name,
-                    peer = %peer.display_url,
-                    logical_peer = %peer.logical_peer_url,
-                    upstream_sni_enabled = target.upstream.server_name,
-                    upstream_server_name = target.upstream.server_name_override.as_deref().unwrap_or("-"),
-                    upstream_verify = super::upstream_tls_verify_label(&target.upstream.tls),
-                    %error,
-                    "failed to build upstream request"
-                );
-                state.record_upstream_bad_gateway_response(&target.upstream_name);
-                return bad_gateway(
+                return failed_to_build_request_response(
+                    &state,
                     &request_headers,
-                    format!("failed to build upstream request for `{}`\n", target.upstream_name),
+                    target,
+                    peer,
+                    &downstream,
+                    error,
+                    &cache,
                 );
             }
         };
@@ -87,11 +95,11 @@ pub async fn forward_request(
                     &request_headers,
                     target,
                     peer,
-                    downstream,
+                    &downstream,
                 )
                 .await
                 {
-                    return response;
+                    return cache.mark_response(response);
                 }
                 state.record_upstream_peer_success(&target.upstream_name, &peer.logical_peer_url);
                 state.record_upstream_completed_response(&target.upstream_name);
@@ -128,8 +136,12 @@ pub async fn forward_request(
                         response_idle_timeout,
                         grpc_response_deadline,
                         grpc_web_mode: grpc_web_mode.as_ref(),
+                        cache_manager: cache_manager.clone(),
+                        cache_store: cache.store.take(),
+                        cache_status: cache.status,
                     },
-                );
+                )
+                .await;
             }
             Ok(Err(error))
                 if can_retry_peer_request(&prepared_request, peers.len(), attempt_index) =>
@@ -170,12 +182,12 @@ pub async fn forward_request(
                         "rejecting streamed request body that exceeds configured server limit"
                     );
                     state.record_upstream_payload_too_large_response(&target.upstream_name);
-                    return payload_too_large(
-                        &request_headers,
-                        format!(
-                            "request body exceeds server.max_request_body_bytes ({max_request_body_bytes} bytes)\n"
-                        ),
-                    );
+                    return cache.mark_response(payload_too_large(
+                            &request_headers,
+                            format!(
+                                "request body exceeds server.max_request_body_bytes ({max_request_body_bytes} bytes)\n"
+                            ),
+                        ));
                 }
                 if invalid_downstream_request_body_error(&error) {
                     tracing::warn!(
@@ -191,10 +203,10 @@ pub async fn forward_request(
                         "downstream request body was invalid while proxying upstream request"
                     );
                     state.record_upstream_bad_request_response(&target.upstream_name);
-                    return bad_request(
+                    return cache.mark_response(bad_request(
                         &request_headers,
                         format!("invalid downstream request body: {error}\n"),
-                    );
+                    ));
                 }
                 state.record_upstream_peer_failure(&target.upstream_name, &peer.logical_peer_url);
                 let tls_failure = super::classify_upstream_tls_failure(&error);
@@ -216,10 +228,10 @@ pub async fn forward_request(
                     "upstream request failed"
                 );
                 state.record_upstream_bad_gateway_response(&target.upstream_name);
-                return bad_gateway(
+                return cache.mark_response(bad_gateway(
                     &request_headers,
                     format!("upstream `{}` is unavailable\n", target.upstream_name),
-                );
+                ));
             }
             Err(error) if can_retry_peer_request(&prepared_request, peers.len(), attempt_index) => {
                 state.record_upstream_peer_timeout(&target.upstream_name, &peer.logical_peer_url);
@@ -264,17 +276,16 @@ pub async fn forward_request(
                     "upstream request timed out"
                 );
                 state.record_upstream_gateway_timeout_response(&target.upstream_name);
-                return gateway_timeout(
+                return cache.mark_response(gateway_timeout(
                     &request_headers,
                     format!(
                         "{}\n",
                         grpc_timeout_message(&target.upstream_name, upstream_request_timeout)
                     ),
-                );
+                ));
             }
         }
     }
 
-    state.record_upstream_bad_gateway_response(&target.upstream_name);
-    bad_gateway(&request_headers, format!("upstream `{}` is unavailable\n", target.upstream_name))
+    upstream_unavailable_response(&state, &request_headers, target, &cache)
 }

--- a/crates/rginx-http/src/proxy/forward/cache.rs
+++ b/crates/rginx-http/src/proxy/forward/cache.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+pub(super) struct ForwardCacheContext {
+    pub(super) store: Option<crate::cache::CacheStoreContext>,
+    pub(super) status: Option<crate::cache::CacheStatus>,
+}
+
+pub(super) enum ForwardCacheLookup {
+    Hit(HttpResponse),
+    Proceed(ForwardCacheContext),
+}
+
+pub(super) async fn lookup_forward_cache(
+    cache_manager: &crate::cache::CacheManager,
+    request: crate::cache::CacheRequest,
+    downstream_scheme: &str,
+    policy: Option<&rginx_core::RouteCachePolicy>,
+) -> ForwardCacheLookup {
+    let Some(policy) = policy else {
+        return ForwardCacheLookup::Proceed(ForwardCacheContext { store: None, status: None });
+    };
+
+    match cache_manager.lookup(request, downstream_scheme, policy).await {
+        crate::cache::CacheLookup::Hit(response) => ForwardCacheLookup::Hit(response),
+        crate::cache::CacheLookup::Miss(context) => {
+            let status = context.cache_status();
+            ForwardCacheLookup::Proceed(ForwardCacheContext {
+                store: Some(context),
+                status: Some(status),
+            })
+        }
+        crate::cache::CacheLookup::Bypass(status) => {
+            ForwardCacheLookup::Proceed(ForwardCacheContext { store: None, status: Some(status) })
+        }
+    }
+}
+
+impl ForwardCacheContext {
+    pub(super) fn mark_response(&self, response: HttpResponse) -> HttpResponse {
+        if let Some(status) = self.status {
+            crate::cache::with_cache_status(response, status)
+        } else {
+            response
+        }
+    }
+}

--- a/crates/rginx-http/src/proxy/forward/failure.rs
+++ b/crates/rginx-http/src/proxy/forward/failure.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+pub(super) fn failed_to_build_request_response<E: std::fmt::Display>(
+    state: &SharedState,
+    request_headers: &HeaderMap,
+    target: &ProxyTarget,
+    peer: &ResolvedUpstreamPeer,
+    downstream: &DownstreamRequestContext<'_>,
+    error: E,
+    cache: &ForwardCacheContext,
+) -> HttpResponse {
+    tracing::warn!(
+        request_id = %downstream.request_id,
+        upstream = %target.upstream_name,
+        peer = %peer.display_url,
+        logical_peer = %peer.logical_peer_url,
+        upstream_sni_enabled = target.upstream.server_name,
+        upstream_server_name = target.upstream.server_name_override.as_deref().unwrap_or("-"),
+        upstream_verify = super::upstream_tls_verify_label(&target.upstream.tls),
+        %error,
+        "failed to build upstream request"
+    );
+    state.record_upstream_bad_gateway_response(&target.upstream_name);
+    cache.mark_response(bad_gateway(
+        request_headers,
+        format!("failed to build upstream request for `{}`\n", target.upstream_name),
+    ))
+}
+
+pub(super) fn upstream_unavailable_response(
+    state: &SharedState,
+    request_headers: &HeaderMap,
+    target: &ProxyTarget,
+    cache: &ForwardCacheContext,
+) -> HttpResponse {
+    state.record_upstream_bad_gateway_response(&target.upstream_name);
+    cache.mark_response(bad_gateway(
+        request_headers,
+        format!("upstream `{}` is unavailable\n", target.upstream_name),
+    ))
+}

--- a/crates/rginx-http/src/proxy/forward/mod.rs
+++ b/crates/rginx-http/src/proxy/forward/mod.rs
@@ -5,7 +5,9 @@ use super::upgrade::proxy_upgraded_connection;
 use super::*;
 
 mod attempt;
+mod cache;
 mod error;
+mod failure;
 mod grpc;
 mod response;
 mod setup;
@@ -13,10 +15,12 @@ mod streaming;
 mod success;
 mod types;
 
+use cache::{ForwardCacheContext, ForwardCacheLookup, lookup_forward_cache};
 use error::{
     bad_gateway, bad_request, downstream_request_body_limit, gateway_timeout, grpc_timeout_message,
     invalid_downstream_request_body_error, payload_too_large, unsupported_media_type,
 };
+use failure::{failed_to_build_request_response, upstream_unavailable_response};
 use grpc::grpc_response_deadline;
 use response::build_downstream_response;
 use setup::prepare_forward_request;

--- a/crates/rginx-http/src/proxy/forward/setup.rs
+++ b/crates/rginx-http/src/proxy/forward/setup.rs
@@ -18,7 +18,7 @@ pub(super) async fn prepare_forward_request(
     mut request: Request<HttpBody>,
     target: &ProxyTarget,
     client_address: &ClientAddress,
-    downstream: DownstreamRequestContext<'_>,
+    downstream: &DownstreamRequestContext<'_>,
 ) -> Result<PreparedForwardRequest, HttpResponse> {
     let request_headers = request.headers().clone();
     let response_idle_timeout =

--- a/crates/rginx-http/src/proxy/forward/streaming.rs
+++ b/crates/rginx-http/src/proxy/forward/streaming.rs
@@ -6,7 +6,7 @@ pub(super) async fn finalize_streaming_request_body(
     request_headers: &HeaderMap,
     target: &ProxyTarget,
     peer: &ResolvedUpstreamPeer,
-    downstream: DownstreamRequestContext<'_>,
+    downstream: &DownstreamRequestContext<'_>,
 ) -> Result<(), HttpResponse> {
     let Some(body_completion) = body_completion else {
         return Ok(());

--- a/crates/rginx-http/src/proxy/forward/success.rs
+++ b/crates/rginx-http/src/proxy/forward/success.rs
@@ -10,9 +10,12 @@ pub(super) struct UpstreamSuccessContext<'a> {
     pub(super) response_idle_timeout: Duration,
     pub(super) grpc_response_deadline: Option<super::response::GrpcResponseDeadline>,
     pub(super) grpc_web_mode: Option<&'a GrpcWebMode>,
+    pub(super) cache_manager: crate::cache::CacheManager,
+    pub(super) cache_store: Option<crate::cache::CacheStoreContext>,
+    pub(super) cache_status: Option<crate::cache::CacheStatus>,
 }
 
-pub(super) fn finalize_upstream_success(
+pub(super) async fn finalize_upstream_success(
     mut response: Response<HttpBody>,
     context: UpstreamSuccessContext<'_>,
 ) -> HttpResponse {
@@ -36,7 +39,7 @@ pub(super) fn finalize_upstream_success(
             context.active_peer,
             connection_guard,
         ));
-        return build_downstream_response(
+        let response = build_downstream_response(
             response,
             &context.target.upstream_name,
             &context.peer.display_url,
@@ -45,9 +48,11 @@ pub(super) fn finalize_upstream_success(
             context.grpc_web_mode,
             None,
         );
+        return apply_cache_store(&context.cache_manager, None, context.cache_status, response)
+            .await;
     }
 
-    build_downstream_response(
+    let response = build_downstream_response(
         response,
         &context.target.upstream_name,
         &context.peer.display_url,
@@ -55,5 +60,22 @@ pub(super) fn finalize_upstream_success(
         context.grpc_response_deadline,
         context.grpc_web_mode,
         Some(context.active_peer),
-    )
+    );
+    apply_cache_store(&context.cache_manager, context.cache_store, context.cache_status, response)
+        .await
+}
+
+async fn apply_cache_store(
+    cache_manager: &crate::cache::CacheManager,
+    cache_store: Option<crate::cache::CacheStoreContext>,
+    cache_status: Option<crate::cache::CacheStatus>,
+    response: HttpResponse,
+) -> HttpResponse {
+    if let Some(cache_store) = cache_store {
+        cache_manager.store_response(cache_store, response).await
+    } else if let Some(cache_status) = cache_status {
+        crate::cache::with_cache_status(response, cache_status)
+    } else {
+        response
+    }
 }

--- a/crates/rginx-http/src/proxy/forward/types.rs
+++ b/crates/rginx-http/src/proxy/forward/types.rs
@@ -1,14 +1,15 @@
 use super::*;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct DownstreamRequestOptions {
     pub request_body_read_timeout: Option<Duration>,
     pub max_request_body_bytes: Option<usize>,
     pub request_buffering: RouteBufferingPolicy,
     pub streaming_response_idle_timeout: Option<Duration>,
+    pub cache: Option<rginx_core::RouteCachePolicy>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct DownstreamRequestContext<'a> {
     pub listener_id: &'a str,
     pub downstream_proto: &'a str,

--- a/crates/rginx-http/src/proxy/health/registry/tests.rs
+++ b/crates/rginx-http/src/proxy/health/registry/tests.rs
@@ -122,6 +122,7 @@ fn snapshot_reports_passive_and_active_health_state() {
         tls: None,
     };
     let config = rginx_core::ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
             worker_threads: None,

--- a/crates/rginx-http/src/proxy/tests/cache.rs
+++ b/crates/rginx-http/src/proxy/tests/cache.rs
@@ -1,0 +1,165 @@
+use super::*;
+
+fn cache_policy() -> rginx_core::RouteCachePolicy {
+    rginx_core::RouteCachePolicy {
+        zone: "default".to_string(),
+        methods: vec![Method::GET, Method::HEAD],
+        statuses: vec![StatusCode::OK],
+        key: rginx_core::CacheKeyTemplate::parse("{scheme}:{host}:{uri}")
+            .expect("cache key should parse"),
+        stale_if_error: None,
+    }
+}
+
+fn client_address() -> ClientAddress {
+    ClientAddress {
+        peer_addr: "198.51.100.10:49152".parse().unwrap(),
+        client_ip: "198.51.100.10".parse().unwrap(),
+        forwarded_for: "198.51.100.10".to_string(),
+        source: ClientIpSource::SocketPeer,
+    }
+}
+
+fn downstream_context<'a>(
+    request_id: &'a str,
+    cache: Option<rginx_core::RouteCachePolicy>,
+) -> crate::proxy::DownstreamRequestContext<'a> {
+    crate::proxy::DownstreamRequestContext {
+        listener_id: "default",
+        downstream_proto: "http",
+        request_id,
+        options: crate::proxy::DownstreamRequestOptions {
+            request_body_read_timeout: None,
+            max_request_body_bytes: None,
+            request_buffering: rginx_core::RouteBufferingPolicy::Auto,
+            streaming_response_idle_timeout: None,
+            cache,
+        },
+    }
+}
+
+fn proxy_target(upstream: Arc<Upstream>) -> rginx_core::ProxyTarget {
+    rginx_core::ProxyTarget {
+        upstream_name: "backend".to_string(),
+        upstream,
+        preserve_host: false,
+        strip_prefix: None,
+        proxy_set_headers: Vec::new(),
+    }
+}
+
+fn get_request(path: &str) -> http::Request<crate::handler::HttpBody> {
+    http::Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .header(HOST, HeaderValue::from_static("example.com"))
+        .body(crate::handler::full_body(Bytes::new()))
+        .expect("request should build")
+}
+
+#[tokio::test]
+async fn forward_request_uses_route_cache_for_miss_then_hit() {
+    let statuses =
+        Arc::new(Mutex::new(VecDeque::from([StatusCode::OK, StatusCode::INTERNAL_SERVER_ERROR])));
+    let _server = spawn_status_server(statuses.clone()).await;
+    let upstream = Arc::new(Upstream::new(
+        "backend".to_string(),
+        vec![peer(&format!("http://{}", _server.listen_addr))],
+        rginx_core::UpstreamTls::NativeRoots,
+        upstream_settings(UpstreamProtocol::Auto),
+    ));
+    let mut snapshot = snapshot_with_upstream("backend", upstream.clone());
+    let temp = TempDir::new().expect("cache temp dir should exist");
+    snapshot.cache_zones.insert(
+        "default".to_string(),
+        Arc::new(rginx_core::CacheZone {
+            name: "default".to_string(),
+            path: temp.path().to_path_buf(),
+            max_size_bytes: Some(1024 * 1024),
+            inactive: Duration::from_secs(60),
+            default_ttl: Duration::from_secs(60),
+            max_entry_bytes: 1024,
+        }),
+    );
+    let state = crate::state::SharedState::from_config(snapshot).expect("state should build");
+    let active = state.snapshot().await;
+    let target = proxy_target(upstream);
+
+    let first = crate::proxy::forward_request(
+        state.clone(),
+        active.clone(),
+        get_request("/cached"),
+        "default",
+        &target,
+        client_address(),
+        downstream_context("cache-miss", Some(cache_policy())),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(first.headers().get("x-cache").unwrap(), "MISS");
+    let first_body = first.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(first_body.as_ref(), b"ok");
+
+    let second = crate::proxy::forward_request(
+        state,
+        active,
+        get_request("/cached"),
+        "default",
+        &target,
+        client_address(),
+        downstream_context("cache-hit", Some(cache_policy())),
+    )
+    .await;
+    assert_eq!(second.status(), StatusCode::OK);
+    assert_eq!(second.headers().get("x-cache").unwrap(), "HIT");
+    let second_body = second.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(second_body.as_ref(), b"ok");
+}
+
+#[tokio::test]
+async fn forward_request_marks_authorization_request_as_cache_bypass() {
+    let statuses = Arc::new(Mutex::new(VecDeque::from([StatusCode::OK])));
+    let _server = spawn_status_server(statuses).await;
+    let upstream = Arc::new(Upstream::new(
+        "backend".to_string(),
+        vec![peer(&format!("http://{}", _server.listen_addr))],
+        rginx_core::UpstreamTls::NativeRoots,
+        upstream_settings(UpstreamProtocol::Auto),
+    ));
+    let mut snapshot = snapshot_with_upstream("backend", upstream.clone());
+    let temp = TempDir::new().expect("cache temp dir should exist");
+    snapshot.cache_zones.insert(
+        "default".to_string(),
+        Arc::new(rginx_core::CacheZone {
+            name: "default".to_string(),
+            path: temp.path().to_path_buf(),
+            max_size_bytes: Some(1024 * 1024),
+            inactive: Duration::from_secs(60),
+            default_ttl: Duration::from_secs(60),
+            max_entry_bytes: 1024,
+        }),
+    );
+    let state = crate::state::SharedState::from_config(snapshot).expect("state should build");
+    let active = state.snapshot().await;
+    let target = proxy_target(upstream);
+    let request = http::Request::builder()
+        .method(Method::GET)
+        .uri("/private")
+        .header(HOST, HeaderValue::from_static("example.com"))
+        .header(http::header::AUTHORIZATION, HeaderValue::from_static("Bearer token"))
+        .body(crate::handler::full_body(Bytes::new()))
+        .expect("request should build");
+
+    let response = crate::proxy::forward_request(
+        state,
+        active,
+        request,
+        "default",
+        &target,
+        client_address(),
+        downstream_context("cache-bypass", Some(cache_policy())),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers().get("x-cache").unwrap(), "BYPASS");
+}

--- a/crates/rginx-http/src/proxy/tests/mod.rs
+++ b/crates/rginx-http/src/proxy/tests/mod.rs
@@ -52,6 +52,7 @@ use super::{
 use crate::client_ip::{ClientAddress, ClientIpSource};
 use tempfile::TempDir;
 
+mod cache;
 mod client_profiles;
 mod grpc;
 mod peer_recovery;
@@ -198,6 +199,7 @@ fn snapshot_with_upstreams_map(
 ) -> rginx_core::ConfigSnapshot {
     let server = default_server();
     rginx_core::ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
             worker_threads: None,

--- a/crates/rginx-http/src/router/tests.rs
+++ b/crates/rginx-http/src/router/tests.rs
@@ -10,6 +10,7 @@ use super::{
 
 fn make_route(path: &str, body: &str) -> Route {
     Route {
+        cache: None,
         id: format!("test|prefix:{path}"),
         matcher: RouteMatcher::Prefix(path.to_string()),
         grpc_match: None,
@@ -47,6 +48,7 @@ fn make_vhost(server_names: Vec<&str>, routes: Vec<Route>) -> VirtualHost {
 fn exact_routes_beat_prefix_routes() {
     let routes = vec![
         Route {
+            cache: None,
             id: "test|exact:/api".to_string(),
             matcher: RouteMatcher::Exact("/api".to_string()),
             grpc_match: None,
@@ -66,6 +68,7 @@ fn exact_routes_beat_prefix_routes() {
             streaming_response_idle_timeout: None,
         },
         Route {
+            cache: None,
             id: "test|prefix:/".to_string(),
             matcher: RouteMatcher::Prefix("/".to_string()),
             grpc_match: None,
@@ -93,6 +96,7 @@ fn exact_routes_beat_prefix_routes() {
 #[test]
 fn prefix_routes_respect_segment_boundaries() {
     let routes = vec![Route {
+        cache: None,
         id: "test|prefix:/api".to_string(),
         matcher: RouteMatcher::Prefix("/api".to_string()),
         grpc_match: None,
@@ -176,6 +180,7 @@ fn select_route_by_host_combines_host_and_path() {
 fn grpc_specific_routes_beat_generic_routes_for_same_path() {
     let routes = vec![
         Route {
+            cache: None,
             id: "test|prefix:/|grpc:service=grpc.health.v1.Health,method=Check".to_string(),
             matcher: RouteMatcher::Prefix("/".to_string()),
             grpc_match: Some(GrpcRouteMatch {
@@ -198,6 +203,7 @@ fn grpc_specific_routes_beat_generic_routes_for_same_path() {
             streaming_response_idle_timeout: None,
         },
         Route {
+            cache: None,
             id: "test|prefix:/".to_string(),
             matcher: RouteMatcher::Prefix("/".to_string()),
             grpc_match: None,
@@ -229,6 +235,7 @@ fn grpc_specific_routes_beat_generic_routes_for_same_path() {
 #[test]
 fn grpc_specific_routes_require_grpc_request_context() {
     let routes = vec![Route {
+        cache: None,
         id: "test|prefix:/|grpc:service=grpc.health.v1.Health".to_string(),
         matcher: RouteMatcher::Prefix("/".to_string()),
         grpc_match: Some(GrpcRouteMatch {
@@ -268,6 +275,7 @@ fn select_route_by_host_with_context_respects_grpc_constraints() {
         vec!["api.example.com"],
         vec![
             Route {
+                cache: None,
                 id: "test|prefix:/|grpc:service=grpc.health.v1.Health".to_string(),
                 matcher: RouteMatcher::Prefix("/".to_string()),
                 grpc_match: Some(GrpcRouteMatch {

--- a/crates/rginx-http/src/state/helpers.rs
+++ b/crates/rginx-http/src/state/helpers.rs
@@ -5,11 +5,13 @@ pub(super) fn prepare_state(
     let config = Arc::new(config);
     let clients =
         ProxyClients::from_config_with_health_notifier(config.as_ref(), peer_health_notifier)?;
+    let cache = CacheManager::from_config(config.as_ref())?;
     let listener_tls_acceptors = prepare_listener_tls_acceptors(config.as_ref())?;
 
     Ok(PreparedState {
         config,
         clients,
+        cache,
         listener_tls_acceptors,
         retired_listeners: Vec::new(),
     })

--- a/crates/rginx-http/src/state/lifecycle/reload.rs
+++ b/crates/rginx-http/src/state/lifecycle/reload.rs
@@ -120,6 +120,7 @@ impl SharedState {
             state.revision = next_revision;
             state.config = prepared.config.clone();
             state.clients = prepared.clients;
+            state.cache = prepared.cache;
             next_revision
         };
 

--- a/crates/rginx-http/src/state/mod.rs
+++ b/crates/rginx-http/src/state/mod.rs
@@ -11,6 +11,7 @@ use tokio::sync::{Notify, RwLock, watch};
 use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
 
+use crate::cache::CacheManager;
 use crate::proxy::{HealthChangeNotifier, ProxyClients, UpstreamHealthSnapshot};
 use crate::rate_limit::RateLimiters;
 use crate::tls::build_tls_acceptor;
@@ -33,6 +34,7 @@ const TLS_EXPIRY_WARNING_DAYS: i64 = 30;
 pub(super) struct PreparedState {
     config: Arc<ConfigSnapshot>,
     clients: ProxyClients,
+    cache: CacheManager,
     listener_tls_acceptors: HashMap<String, Option<TlsAcceptor>>,
     retired_listeners: Vec<Listener>,
 }
@@ -150,6 +152,7 @@ impl SharedState {
                 revision,
                 config: prepared.config,
                 clients: prepared.clients,
+                cache: prepared.cache,
             })),
             revisions,
             rate_limiters,

--- a/crates/rginx-http/src/state/snapshots/active.rs
+++ b/crates/rginx-http/src/state/snapshots/active.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use rginx_core::ConfigSnapshot;
 
+use crate::cache::CacheManager;
 use crate::proxy::ProxyClients;
 
 #[derive(Clone)]
@@ -9,4 +10,5 @@ pub struct ActiveState {
     pub revision: u64,
     pub config: Arc<ConfigSnapshot>,
     pub clients: ProxyClients,
+    pub(crate) cache: CacheManager,
 }

--- a/crates/rginx-http/src/state/tests/support.rs
+++ b/crates/rginx-http/src/state/tests/support.rs
@@ -18,6 +18,7 @@ pub(crate) fn snapshot(listen: &str) -> ConfigSnapshot {
         tls: None,
     };
     ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(10),
             worker_threads: None,
@@ -90,6 +91,7 @@ pub(crate) fn snapshot_with_upstream(listen: &str) -> ConfigSnapshot {
 pub(crate) fn snapshot_with_routes(listen: &str) -> ConfigSnapshot {
     let mut snapshot = snapshot(listen);
     snapshot.default_vhost.routes = vec![Route {
+        cache: None,
         id: "server/routes[0]|exact:/".to_string(),
         matcher: RouteMatcher::Exact("/".to_string()),
         grpc_match: None,
@@ -114,6 +116,7 @@ pub(crate) fn snapshot_with_routes(listen: &str) -> ConfigSnapshot {
 pub(crate) fn snapshot_with_routes_and_upstream(listen: &str) -> ConfigSnapshot {
     let mut snapshot = snapshot_with_upstream(listen);
     snapshot.default_vhost.routes = vec![Route {
+        cache: None,
         id: "server/routes[0]|exact:/".to_string(),
         matcher: RouteMatcher::Exact("/".to_string()),
         grpc_match: None,

--- a/crates/rginx-http/src/state/tls_runtime/bindings/tests.rs
+++ b/crates/rginx-http/src/state/tls_runtime/bindings/tests.rs
@@ -98,6 +98,7 @@ fn certificates(scopes: &[&str]) -> Vec<TlsCertificateStatusSnapshot> {
 #[test]
 fn listener_certificate_is_default_when_no_explicit_default_is_configured() {
     let config = ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
             worker_threads: None,
@@ -136,6 +137,7 @@ fn listener_certificate_is_default_when_no_explicit_default_is_configured() {
 #[test]
 fn single_named_vhost_certificate_becomes_implicit_default_without_listener_tls() {
     let config = ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
             worker_threads: None,

--- a/crates/rginx-http/src/transition/tests.rs
+++ b/crates/rginx-http/src/transition/tests.rs
@@ -26,6 +26,7 @@ fn snapshot(listen: &str) -> ConfigSnapshot {
         tls: None,
     };
     ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(10),
             worker_threads: None,

--- a/crates/rginx-runtime/src/bootstrap/listeners/tests.rs
+++ b/crates/rginx-runtime/src/bootstrap/listeners/tests.rs
@@ -36,6 +36,7 @@ fn listener(id: &str, name: &str, listen_addr: SocketAddr) -> Listener {
 
 fn config_with_listeners(listeners: Vec<Listener>) -> ConfigSnapshot {
     ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: std::time::Duration::from_secs(1),
             worker_threads: None,

--- a/crates/rginx-runtime/src/bootstrap/shutdown/tests.rs
+++ b/crates/rginx-runtime/src/bootstrap/shutdown/tests.rs
@@ -16,6 +16,7 @@ use super::*;
 
 fn snapshot() -> ConfigSnapshot {
     ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
             worker_threads: None,
@@ -48,6 +49,7 @@ fn snapshot() -> ConfigSnapshot {
             id: "server".to_string(),
             server_names: Vec::new(),
             routes: vec![Route {
+                cache: None,
                 id: "server/routes[0]|exact:/".to_string(),
                 matcher: RouteMatcher::Exact("/".to_string()),
                 grpc_match: None,

--- a/crates/rginx-runtime/src/health/tests.rs
+++ b/crates/rginx-runtime/src/health/tests.rs
@@ -52,6 +52,7 @@ async fn collect_probe_targets_only_includes_enabled_upstreams() {
         tls: None,
     };
     let snapshot = ConfigSnapshot {
+        cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
             worker_threads: None,


### PR DESCRIPTION
## Summary
- add cache zone and route cache policy models across core/config/check output
- implement the route-level HTTP response cache MVP with disk metadata/body storage and in-memory index
- wire proxy lookup/store flow with X-Cache HIT/MISS/BYPASS/EXPIRED markers
- document the cache support phase plan and current phase 0-3 completion status

## Verification
- cargo test --workspace --locked --quiet
- cargo check --workspace --all-targets --message-format short
- git diff --check