### PR TITLE
feat(cache): implement P1 nginx parity support

### DIFF
--- a/CACHE_SUPPORT_PLAN.md
+++ b/CACHE_SUPPORT_PLAN.md
@@ -33,9 +33,11 @@ HTTP/3 session、TLS session 和 OCSP staple cache，继续作为运行时实现
 - `P0` 中的 `cache_bypass` / `no_cache`、按状态 TTL + `X-Accel-Expires`、
   通用 `Vary`、`background_update` / `use_stale` / `lock_timeout` /
   `lock_age` / `UPDATING` 已完成并已落地。
+- `P1` 中的 `cache_min_uses`、可配置的精确单段 `Range`/`206` 缓存、
+  `proxy_ignore_headers` 和 loader / manager / path tunables 已完成并已落地。
 - 下文保留这些条目，是为了把“已交付能力”和“下一轮继续补齐的剩余差距”放在同一张
   对标清单里，避免后续阶段重复整理。
-- `P1` / `P2` 仍是后续规划项，当前 PR 不覆盖。
+- `P2` 仍是后续规划项，当前文档的主用途已经切换为记录“已交付边界 + 剩余架构级差距”。
 
 对标范围：
 
@@ -102,7 +104,7 @@ HTTP/3 session、TLS session 和 OCSP staple cache，继续作为运行时实现
 - 热点 key 过期时可选择前台返回 stale、后台刷新，并暴露 `UPDATING` 或等价状态。
 - 并发同 key 过期测试中，不会出现无界等待，也不会放大 upstream 压力。
 
-### P1：补齐大对象场景和维护控制面（当前状态：规划中）
+### P1：补齐大对象场景和维护控制面（当前状态：本 PR 已完成）
 
 目标：支持更接近 NGINX 中大型生产缓存部署的行为，特别是长尾控制、大对象和后台维护。
 
@@ -114,14 +116,17 @@ HTTP/3 session、TLS session 和 OCSP staple cache，继续作为运行时实现
 - Range / `206` / slice 缓存
   - 目标：支持范围请求和切片缓存，而不是简单 bypass `Range`。
   - 价值：补齐安装包、媒体、超大静态资源这类缓存场景。
-  - 当前差距：当前 `Range` 请求默认 bypass，`206` 和 `Content-Range` 响应不缓存。
+  - 本轮交付边界：已支持 route 级可配置的精确单段 bounded range 缓存，
+    即 `Range: bytes=start-end` 命中独立 cache key，并允许对应 `206` 落盘；
+    multi-range、suffix range、open-ended range 和 slice 仍保留为后续增强项。
 - `proxy_ignore_headers` 等价能力
   - 目标：允许在 route 级覆盖上游的部分缓存相关响应头。
   - 价值：适配缓存头不规范、历史包袱较重的上游系统。
 - cache loader / manager / path tunables
   - 目标：让磁盘扫描、批次加载、后台清理和目录布局可配置。
   - 价值：改善大 cache 目录、冷启动、慢磁盘和大规模部署时的运行体验。
-  - 当前差距：当前 loader、inactive cleanup 和驱逐策略基本固定，调优面较少。
+  - 本轮交付边界：已开放 `path_levels`、loader / manager batch 与 sleep 参数，以及
+    `inactive_cleanup_interval`；同步写路径上的容量驱逐仍保持即时淘汰模型。
 
 建议改动范围：
 
@@ -144,6 +149,8 @@ HTTP/3 session、TLS session 和 OCSP staple cache，继续作为运行时实现
 - route 可以有选择地忽略 `Cache-Control`、`Expires`、`Set-Cookie`、`Vary`
   等缓存相关头。
 - 大目录冷启动时，扫描和加载行为可通过配置调优，而不是单一固定策略。
+- `manager_batch_entries` / `manager_sleep` 对后台 inactive cleanup 生效，
+  `loader_batch_entries` / `loader_sleep` 对冷启动扫描生效，`path_levels` 可调整磁盘目录布局。
 
 ### P2：架构级追平项（当前状态：规划中）
 
@@ -158,7 +165,8 @@ HTTP/3 session、TLS session 和 OCSP staple cache，继续作为运行时实现
   - 目标：进一步细化 `GET`/`HEAD` 的互通规则和 admission policy。
 - 未知大小流式响应和 partial-body caching
   - 目标：评估是否在不破坏流式代理行为的前提下支持更复杂的缓存写入模型。
-  - 当前差距：当前无法安全确认 body size 的响应不会写入缓存。
+  - 当前差距：当前无法安全确认 body size 的响应不会写入缓存，也未实现完整 slice
+    或更通用的 partial-body caching 模型。
 - 更广协议族缓存
   - 目标：仅在产品边界明确扩展时，再考虑是否引入 `fastcgi_cache`、
     `uwsgi_cache`、`scgi_cache` 这类能力。
@@ -195,21 +203,17 @@ HTTP/3 session、TLS session 和 OCSP staple cache，继续作为运行时实现
 
 建议下一轮按以下顺序推进：
 
-1. `P0-1`：`cache_bypass` / `no_cache`
-2. `P0-2`：按状态 TTL + `X-Accel-Expires`
-3. `P0-3`：通用 `Vary` + 更强 key 模型
-4. `P0-4`：后台更新、等待超时和 `UPDATING`
-5. `P1-1`：`cache_min_uses`
-6. `P1-2`：Range / `206` / slice
-7. `P1-3`：`proxy_ignore_headers`
-8. `P1-4`：loader / manager tunables
+1. `P2-1`：`keys_zone` 等价的共享索引 / 多进程协调
+2. `P2-2`：`proxy_cache_convert_head` 和更完整的方法语义
+3. `P2-3`：完整 slice / partial-body / 未知大小流式响应缓存模型
+4. `P2-4`：仅在产品边界明确后，再评估更广协议族缓存
 
 交付原则：
 
 - 每个子项都应先补配置模型、再补运行时、最后补 admin/status 和测试。
 - `P0-3` 与 `P0-4` 变更较大，建议分别拆成独立设计文档和多阶段 PR。
-- `P1-2` 不建议以“先支持一部分 `206`”的方式快速落地；若要做，应直接设计成
-  可长期维护的 slice 或等价分片模型。
+- 已交付的 `P1-2` 采用“精确单段 bounded range 独立 key”模型；若继续向完整
+  slice 演进，必须同时定义 purge、reload、一致性和 partial-body 失败恢复语义。
 
 ## 阶段 0：范围与边界
 

--- a/crates/rginx-config/src/compile/cache.rs
+++ b/crates/rginx-config/src/compile/cache.rs
@@ -6,12 +6,13 @@ use std::time::Duration;
 use http::header::HeaderName;
 use http::{Method, StatusCode};
 use rginx_core::{
-    CacheKeyTemplate, CachePredicate, CacheStatusTtlRule, CacheUseStaleCondition, CacheZone, Error,
-    Result, RouteCachePolicy,
+    CacheIgnoreHeader, CacheKeyTemplate, CachePredicate, CacheRangeRequestPolicy,
+    CacheStatusTtlRule, CacheUseStaleCondition, CacheZone, Error, Result, RouteCachePolicy,
 };
 
 use crate::model::{
-    CachePredicateConfig, CacheRouteConfig, CacheUseStaleConditionConfig, CacheZoneConfig,
+    CacheIgnoreHeaderConfig, CachePredicateConfig, CacheRangeRequestPolicyConfig, CacheRouteConfig,
+    CacheUseStaleConditionConfig, CacheZoneConfig,
 };
 
 const DEFAULT_CACHE_INACTIVE_SECS: u64 = 600;
@@ -20,6 +21,13 @@ const DEFAULT_CACHE_MAX_ENTRY_BYTES: u64 = 10 * 1024 * 1024;
 const DEFAULT_CACHE_KEY: &str = "{scheme}:{host}:{uri}";
 const DEFAULT_CACHE_LOCK_TIMEOUT_SECS: u64 = 5;
 const DEFAULT_CACHE_LOCK_AGE_SECS: u64 = 5;
+const DEFAULT_CACHE_PATH_LEVELS: &[u8] = &[2];
+const DEFAULT_CACHE_LOADER_BATCH_ENTRIES: u64 = 100;
+const DEFAULT_CACHE_LOADER_SLEEP_MILLIS: u64 = 50;
+const DEFAULT_CACHE_MANAGER_BATCH_ENTRIES: u64 = 100;
+const DEFAULT_CACHE_MANAGER_SLEEP_MILLIS: u64 = 50;
+const DEFAULT_CACHE_INACTIVE_CLEANUP_INTERVAL_SECS: u64 = 60;
+const DEFAULT_CACHE_MIN_USES: u64 = 1;
 
 pub(super) fn compile_cache_zones(
     zones: Vec<CacheZoneConfig>,
@@ -56,6 +64,28 @@ pub(super) fn compile_cache_zones(
                     zone.default_ttl_secs.unwrap_or(DEFAULT_CACHE_TTL_SECS),
                 ),
                 max_entry_bytes,
+                path_levels: zone
+                    .path_levels
+                    .unwrap_or_else(|| DEFAULT_CACHE_PATH_LEVELS.to_vec())
+                    .into_iter()
+                    .map(usize::from)
+                    .collect(),
+                loader_batch_entries: usize_from_u64(
+                    zone.loader_batch_entries.unwrap_or(DEFAULT_CACHE_LOADER_BATCH_ENTRIES),
+                )?,
+                loader_sleep: Duration::from_millis(
+                    zone.loader_sleep_millis.unwrap_or(DEFAULT_CACHE_LOADER_SLEEP_MILLIS),
+                ),
+                manager_batch_entries: usize_from_u64(
+                    zone.manager_batch_entries.unwrap_or(DEFAULT_CACHE_MANAGER_BATCH_ENTRIES),
+                )?,
+                manager_sleep: Duration::from_millis(
+                    zone.manager_sleep_millis.unwrap_or(DEFAULT_CACHE_MANAGER_SLEEP_MILLIS),
+                ),
+                inactive_cleanup_interval: Duration::from_secs(
+                    zone.inactive_cleanup_interval_secs
+                        .unwrap_or(DEFAULT_CACHE_INACTIVE_CLEANUP_INTERVAL_SECS),
+                ),
             };
             Ok((name, Arc::new(compiled)))
         })
@@ -134,6 +164,19 @@ pub(super) fn compile_route_cache(
                 lock_age: Duration::from_secs(
                     cache.lock_age_secs.unwrap_or(DEFAULT_CACHE_LOCK_AGE_SECS),
                 ),
+                min_uses: cache.min_uses.unwrap_or(DEFAULT_CACHE_MIN_USES),
+                ignore_headers: dedup_preserving_order(
+                    cache
+                        .ignore_headers
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(compile_ignore_header)
+                        .collect::<Vec<_>>(),
+                ),
+                range_requests: cache
+                    .range_requests
+                    .map(compile_range_request_policy)
+                    .unwrap_or(CacheRangeRequestPolicy::Bypass),
             })
         })
         .transpose()
@@ -200,6 +243,23 @@ fn compile_use_stale_condition(condition: CacheUseStaleConditionConfig) -> Cache
         CacheUseStaleConditionConfig::Http502 => CacheUseStaleCondition::Http502,
         CacheUseStaleConditionConfig::Http503 => CacheUseStaleCondition::Http503,
         CacheUseStaleConditionConfig::Http504 => CacheUseStaleCondition::Http504,
+    }
+}
+
+fn compile_ignore_header(header: CacheIgnoreHeaderConfig) -> CacheIgnoreHeader {
+    match header {
+        CacheIgnoreHeaderConfig::XAccelExpires => CacheIgnoreHeader::XAccelExpires,
+        CacheIgnoreHeaderConfig::Expires => CacheIgnoreHeader::Expires,
+        CacheIgnoreHeaderConfig::CacheControl => CacheIgnoreHeader::CacheControl,
+        CacheIgnoreHeaderConfig::SetCookie => CacheIgnoreHeader::SetCookie,
+        CacheIgnoreHeaderConfig::Vary => CacheIgnoreHeader::Vary,
+    }
+}
+
+fn compile_range_request_policy(policy: CacheRangeRequestPolicyConfig) -> CacheRangeRequestPolicy {
+    match policy {
+        CacheRangeRequestPolicyConfig::Bypass => CacheRangeRequestPolicy::Bypass,
+        CacheRangeRequestPolicyConfig::Cache => CacheRangeRequestPolicy::Cache,
     }
 }
 

--- a/crates/rginx-config/src/compile/tests.rs
+++ b/crates/rginx-config/src/compile/tests.rs
@@ -54,6 +54,7 @@ fn test_location(matcher: MatcherConfig, handler: HandlerConfig) -> LocationConf
 }
 
 mod cache;
+mod cache_p1;
 mod http3;
 mod listeners;
 mod route;

--- a/crates/rginx-config/src/compile/tests/cache.rs
+++ b/crates/rginx-config/src/compile/tests/cache.rs
@@ -11,6 +11,12 @@ fn compile_attaches_cache_zones_and_route_policy() {
             inactive_secs: Some(120),
             default_ttl_secs: Some(30),
             max_entry_bytes: Some(1024),
+            path_levels: None,
+            loader_batch_entries: None,
+            loader_sleep_millis: None,
+            manager_batch_entries: None,
+            manager_sleep_millis: None,
+            inactive_cleanup_interval_secs: None,
         }],
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -85,6 +91,9 @@ fn compile_attaches_cache_zones_and_route_policy() {
                 background_update: None,
                 lock_timeout_secs: None,
                 lock_age_secs: None,
+                min_uses: None,
+                ignore_headers: None,
+                range_requests: None,
             }),
             matcher: MatcherConfig::Prefix("/assets".to_string()),
             handler: HandlerConfig::Proxy {
@@ -143,6 +152,9 @@ fn compile_attaches_cache_zones_and_route_policy() {
         background_update: None,
         lock_timeout_secs: None,
         lock_age_secs: None,
+        min_uses: None,
+        ignore_headers: None,
+        range_requests: None,
     });
     let snapshot = compile_with_base(config.clone(), base_dir.path())
         .expect("default cache policy should compile");
@@ -181,6 +193,12 @@ fn compile_cache_policy_supports_p0_controls() {
             inactive_secs: Some(120),
             default_ttl_secs: Some(30),
             max_entry_bytes: Some(1024),
+            path_levels: None,
+            loader_batch_entries: None,
+            loader_sleep_millis: None,
+            manager_batch_entries: None,
+            manager_sleep_millis: None,
+            inactive_cleanup_interval_secs: None,
         }],
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -265,6 +283,9 @@ fn compile_cache_policy_supports_p0_controls() {
                 background_update: Some(true),
                 lock_timeout_secs: Some(2),
                 lock_age_secs: Some(3),
+                min_uses: None,
+                ignore_headers: None,
+                range_requests: None,
             }),
             matcher: MatcherConfig::Prefix("/assets".to_string()),
             handler: HandlerConfig::Proxy {

--- a/crates/rginx-config/src/compile/tests/cache_p1.rs
+++ b/crates/rginx-config/src/compile/tests/cache_p1.rs
@@ -1,0 +1,143 @@
+use super::*;
+
+#[test]
+fn compile_cache_policy_supports_p1_controls() {
+    let base_dir = temp_base_dir("rginx-cache-compile-p1");
+    let config = Config {
+        cache_zones: vec![CacheZoneConfig {
+            name: "default".to_string(),
+            path: "cache/default".to_string(),
+            max_size_bytes: Some(1024 * 1024),
+            inactive_secs: Some(120),
+            default_ttl_secs: Some(30),
+            max_entry_bytes: Some(1024),
+            path_levels: Some(vec![1, 2]),
+            loader_batch_entries: Some(25),
+            loader_sleep_millis: Some(5),
+            manager_batch_entries: Some(50),
+            manager_sleep_millis: Some(7),
+            inactive_cleanup_interval_secs: Some(11),
+        }],
+        runtime: RuntimeConfig {
+            shutdown_timeout_secs: 10,
+            worker_threads: None,
+            accept_workers: None,
+        },
+        listeners: Vec::new(),
+        server: ServerConfig {
+            listen: Some("127.0.0.1:8080".to_string()),
+            server_header: None,
+            proxy_protocol: None,
+            default_certificate: None,
+            server_names: Vec::new(),
+            trusted_proxies: Vec::new(),
+            client_ip_header: None,
+            keep_alive: None,
+            max_headers: None,
+            max_request_body_bytes: None,
+            max_connections: None,
+            header_read_timeout_secs: None,
+            request_body_read_timeout_secs: None,
+            response_write_timeout_secs: None,
+            access_log_format: None,
+            tls: None,
+            http3: None,
+        },
+        upstreams: vec![UpstreamConfig {
+            name: "backend".to_string(),
+            peers: vec![UpstreamPeerConfig {
+                url: "http://127.0.0.1:9000".to_string(),
+                weight: 1,
+                backup: false,
+            }],
+            tls: None,
+            dns: None,
+            protocol: UpstreamProtocolConfig::Auto,
+            load_balance: UpstreamLoadBalanceConfig::RoundRobin,
+            server_name: None,
+            server_name_override: None,
+            request_timeout_secs: None,
+            connect_timeout_secs: None,
+            read_timeout_secs: None,
+            write_timeout_secs: None,
+            idle_timeout_secs: None,
+            pool_idle_timeout_secs: None,
+            pool_max_idle_per_host: None,
+            tcp_keepalive_secs: None,
+            tcp_nodelay: None,
+            http2_keep_alive_interval_secs: None,
+            http2_keep_alive_timeout_secs: None,
+            http2_keep_alive_while_idle: None,
+            max_replayable_request_body_bytes: None,
+            unhealthy_after_failures: None,
+            unhealthy_cooldown_secs: None,
+            health_check_path: None,
+            health_check_grpc_service: None,
+            health_check_interval_secs: None,
+            health_check_timeout_secs: None,
+            healthy_successes_required: None,
+        }],
+        locations: vec![LocationConfig {
+            cache: Some(CacheRouteConfig {
+                zone: "default".to_string(),
+                methods: Some(vec!["GET".to_string(), "HEAD".to_string()]),
+                statuses: Some(vec![200]),
+                ttl_secs_by_status: None,
+                key: Some("{scheme}:{host}:{uri}".to_string()),
+                cache_bypass: None,
+                no_cache: None,
+                stale_if_error_secs: None,
+                use_stale: None,
+                background_update: None,
+                lock_timeout_secs: None,
+                lock_age_secs: None,
+                min_uses: Some(3),
+                ignore_headers: Some(vec![
+                    crate::model::CacheIgnoreHeaderConfig::SetCookie,
+                    crate::model::CacheIgnoreHeaderConfig::Vary,
+                ]),
+                range_requests: Some(crate::model::CacheRangeRequestPolicyConfig::Cache),
+            }),
+            matcher: MatcherConfig::Prefix("/assets".to_string()),
+            handler: HandlerConfig::Proxy {
+                upstream: "backend".to_string(),
+                preserve_host: None,
+                strip_prefix: None,
+                proxy_set_headers: std::collections::HashMap::new(),
+            },
+            grpc_service: None,
+            grpc_method: None,
+            allow_cidrs: Vec::new(),
+            deny_cidrs: Vec::new(),
+            requests_per_sec: None,
+            burst: None,
+            allow_early_data: None,
+            request_buffering: None,
+            response_buffering: None,
+            compression: None,
+            compression_min_bytes: None,
+            compression_content_types: None,
+            streaming_response_idle_timeout_secs: None,
+        }],
+        servers: Vec::new(),
+    };
+
+    let snapshot =
+        compile_with_base(config, base_dir.path()).expect("p1 cache policy should compile");
+    let zone = snapshot.cache_zones.get("default").expect("cache zone should compile");
+    assert_eq!(zone.path_levels, vec![1, 2]);
+    assert_eq!(zone.loader_batch_entries, 25);
+    assert_eq!(zone.loader_sleep, Duration::from_millis(5));
+    assert_eq!(zone.manager_batch_entries, 50);
+    assert_eq!(zone.manager_sleep, Duration::from_millis(7));
+    assert_eq!(zone.inactive_cleanup_interval, Duration::from_secs(11));
+
+    let policy =
+        snapshot.default_vhost.routes[0].cache.as_ref().expect("route cache policy should compile");
+    assert_eq!(policy.min_uses, 3);
+    assert_eq!(
+        policy.ignore_headers,
+        vec![rginx_core::CacheIgnoreHeader::SetCookie, rginx_core::CacheIgnoreHeader::Vary]
+    );
+    assert_eq!(policy.range_requests, rginx_core::CacheRangeRequestPolicy::Cache);
+}

--- a/crates/rginx-config/src/model.rs
+++ b/crates/rginx-config/src/model.rs
@@ -10,8 +10,8 @@ mod upstream;
 mod vhost;
 
 pub use cache::{
-    CachePredicateConfig, CacheRouteConfig, CacheStatusTtlConfig, CacheUseStaleConditionConfig,
-    CacheZoneConfig,
+    CacheIgnoreHeaderConfig, CachePredicateConfig, CacheRangeRequestPolicyConfig, CacheRouteConfig,
+    CacheStatusTtlConfig, CacheUseStaleConditionConfig, CacheZoneConfig,
 };
 pub use listener::{Http3Config, ListenerConfig};
 pub use route::{

--- a/crates/rginx-config/src/model/cache.rs
+++ b/crates/rginx-config/src/model/cache.rs
@@ -12,6 +12,18 @@ pub struct CacheZoneConfig {
     pub default_ttl_secs: Option<u64>,
     #[serde(default)]
     pub max_entry_bytes: Option<u64>,
+    #[serde(default)]
+    pub path_levels: Option<Vec<u8>>,
+    #[serde(default)]
+    pub loader_batch_entries: Option<u64>,
+    #[serde(default)]
+    pub loader_sleep_millis: Option<u64>,
+    #[serde(default)]
+    pub manager_batch_entries: Option<u64>,
+    #[serde(default)]
+    pub manager_sleep_millis: Option<u64>,
+    #[serde(default)]
+    pub inactive_cleanup_interval_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -39,6 +51,12 @@ pub struct CacheRouteConfig {
     pub lock_timeout_secs: Option<u64>,
     #[serde(default)]
     pub lock_age_secs: Option<u64>,
+    #[serde(default)]
+    pub min_uses: Option<u64>,
+    #[serde(default)]
+    pub ignore_headers: Option<Vec<CacheIgnoreHeaderConfig>>,
+    #[serde(default)]
+    pub range_requests: Option<CacheRangeRequestPolicyConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -72,4 +90,19 @@ pub enum CacheUseStaleConditionConfig {
     Http502,
     Http503,
     Http504,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub enum CacheIgnoreHeaderConfig {
+    XAccelExpires,
+    Expires,
+    CacheControl,
+    SetCookie,
+    Vary,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub enum CacheRangeRequestPolicyConfig {
+    Bypass,
+    Cache,
 }

--- a/crates/rginx-config/src/validate/cache.rs
+++ b/crates/rginx-config/src/validate/cache.rs
@@ -1,9 +1,12 @@
 use std::collections::HashSet;
 
-use http::{HeaderName, Method};
 use rginx_core::{Error, Result};
 
-use crate::model::{CachePredicateConfig, CacheRouteConfig, CacheStatusTtlConfig, CacheZoneConfig};
+use crate::model::{CacheRouteConfig, CacheStatusTtlConfig, CacheZoneConfig};
+
+mod predicate;
+
+use predicate::{PredicateValidationMode, validate_cache_predicate};
 
 pub(super) fn validate_cache_zones(zones: &[CacheZoneConfig]) -> Result<HashSet<String>> {
     let mut names = HashSet::new();
@@ -23,6 +26,18 @@ pub(super) fn validate_cache_zones(zones: &[CacheZoneConfig]) -> Result<HashSet<
         validate_positive_optional(name, "inactive_secs", zone.inactive_secs)?;
         validate_positive_optional(name, "default_ttl_secs", zone.default_ttl_secs)?;
         validate_positive_optional(name, "max_entry_bytes", zone.max_entry_bytes)?;
+        validate_positive_optional(name, "loader_batch_entries", zone.loader_batch_entries)?;
+        validate_positive_optional(name, "loader_sleep_millis", zone.loader_sleep_millis)?;
+        validate_positive_optional(name, "manager_batch_entries", zone.manager_batch_entries)?;
+        validate_positive_optional(name, "manager_sleep_millis", zone.manager_sleep_millis)?;
+        validate_positive_optional(
+            name,
+            "inactive_cleanup_interval_secs",
+            zone.inactive_cleanup_interval_secs,
+        )?;
+        if let Some(levels) = zone.path_levels.as_deref() {
+            validate_path_levels(name, levels)?;
+        }
         if let (Some(max_size), Some(max_entry)) = (zone.max_size_bytes, zone.max_entry_bytes)
             && max_entry > max_size
         {
@@ -140,6 +155,34 @@ pub(super) fn validate_route_cache(
         )));
     }
 
+    if cache.min_uses.is_some_and(|value| value == 0) {
+        return Err(Error::Config(format!("{route_scope} cache.min_uses must be greater than 0")));
+    }
+
+    if let Some(ignore_headers) = cache.ignore_headers.as_deref()
+        && ignore_headers.is_empty()
+    {
+        return Err(Error::Config(format!(
+            "{route_scope} cache.ignore_headers must not be empty when provided"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_path_levels(zone: &str, levels: &[u8]) -> Result<()> {
+    if levels.is_empty() {
+        return Err(Error::Config(format!(
+            "cache zone `{zone}` path_levels must not be empty when provided"
+        )));
+    }
+    for level in levels {
+        if *level == 0 {
+            return Err(Error::Config(format!(
+                "cache zone `{zone}` path_levels entries must be greater than 0"
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -177,92 +220,9 @@ fn validate_statuses(route_scope: &str, field: &str, statuses: &[u16]) -> Result
     Ok(())
 }
 
-fn validate_cache_predicate(
-    route_scope: &str,
-    field: &str,
-    predicate: &CachePredicateConfig,
-    mode: PredicateValidationMode,
-) -> Result<()> {
-    match predicate {
-        CachePredicateConfig::Any(predicates) | CachePredicateConfig::All(predicates) => {
-            if predicates.is_empty() {
-                return Err(Error::Config(format!(
-                    "{route_scope} {field} composite predicates must not be empty"
-                )));
-            }
-            for predicate in predicates {
-                validate_cache_predicate(route_scope, field, predicate, mode)?;
-            }
-        }
-        CachePredicateConfig::Not(predicate) => {
-            validate_cache_predicate(route_scope, field, predicate, mode)?;
-        }
-        CachePredicateConfig::Method(method) => {
-            method.trim().to_ascii_uppercase().parse::<Method>().map_err(|error| {
-                Error::Config(format!(
-                    "{route_scope} {field} method `{method}` is invalid: {error}"
-                ))
-            })?;
-        }
-        CachePredicateConfig::HeaderExists(name)
-        | CachePredicateConfig::QueryExists(name)
-        | CachePredicateConfig::CookieExists(name) => {
-            validate_non_empty(route_scope, field, name, "name")?;
-            if matches!(predicate, CachePredicateConfig::HeaderExists(_)) {
-                validate_header_name(route_scope, field, name)?;
-            }
-        }
-        CachePredicateConfig::HeaderEquals { name, .. } => {
-            validate_non_empty(route_scope, field, name, "name")?;
-            validate_header_name(route_scope, field, name)?;
-        }
-        CachePredicateConfig::QueryEquals { name, .. }
-        | CachePredicateConfig::CookieEquals { name, .. } => {
-            validate_non_empty(route_scope, field, name, "name")?;
-        }
-        CachePredicateConfig::Status(status) => {
-            validate_statuses(route_scope, field, &[*status])?;
-            if mode == PredicateValidationMode::RequestOnly {
-                return Err(Error::Config(format!(
-                    "{route_scope} {field} cannot match response status"
-                )));
-            }
-        }
-        CachePredicateConfig::Statuses(statuses) => {
-            validate_statuses(route_scope, field, statuses)?;
-            if mode == PredicateValidationMode::RequestOnly {
-                return Err(Error::Config(format!(
-                    "{route_scope} {field} cannot match response status"
-                )));
-            }
-        }
-    }
-    Ok(())
-}
-
-fn validate_non_empty(route_scope: &str, field: &str, value: &str, part: &str) -> Result<()> {
-    if value.trim().is_empty() {
-        return Err(Error::Config(format!("{route_scope} {field} {part} must not be empty")));
-    }
-    Ok(())
-}
-
-fn validate_header_name(route_scope: &str, field: &str, name: &str) -> Result<()> {
-    name.parse::<HeaderName>().map_err(|error| {
-        Error::Config(format!("{route_scope} {field} header `{name}` is invalid: {error}"))
-    })?;
-    Ok(())
-}
-
 fn validate_positive_optional(zone: &str, field: &str, value: Option<u64>) -> Result<()> {
     if value.is_some_and(|value| value == 0) {
         return Err(Error::Config(format!("cache zone `{zone}` {field} must be greater than 0")));
     }
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PredicateValidationMode {
-    RequestOnly,
-    RequestOrResponse,
 }

--- a/crates/rginx-config/src/validate/cache.rs
+++ b/crates/rginx-config/src/validate/cache.rs
@@ -171,17 +171,26 @@ pub(super) fn validate_route_cache(
 }
 
 fn validate_path_levels(zone: &str, levels: &[u8]) -> Result<()> {
+    const CACHE_KEY_HASH_HEX_LEN: usize = 64;
+
     if levels.is_empty() {
         return Err(Error::Config(format!(
             "cache zone `{zone}` path_levels must not be empty when provided"
         )));
     }
+    let mut total_level_len = 0usize;
     for level in levels {
         if *level == 0 {
             return Err(Error::Config(format!(
                 "cache zone `{zone}` path_levels entries must be greater than 0"
             )));
         }
+        total_level_len = total_level_len.saturating_add(usize::from(*level));
+    }
+    if total_level_len > CACHE_KEY_HASH_HEX_LEN {
+        return Err(Error::Config(format!(
+            "cache zone `{zone}` path_levels total length `{total_level_len}` exceeds cache hash length `{CACHE_KEY_HASH_HEX_LEN}`"
+        )));
     }
     Ok(())
 }

--- a/crates/rginx-config/src/validate/cache/predicate.rs
+++ b/crates/rginx-config/src/validate/cache/predicate.rs
@@ -1,0 +1,87 @@
+use http::{HeaderName, Method};
+use rginx_core::{Error, Result};
+
+use crate::model::CachePredicateConfig;
+
+pub(super) fn validate_cache_predicate(
+    route_scope: &str,
+    field: &str,
+    predicate: &CachePredicateConfig,
+    mode: PredicateValidationMode,
+) -> Result<()> {
+    match predicate {
+        CachePredicateConfig::Any(predicates) | CachePredicateConfig::All(predicates) => {
+            if predicates.is_empty() {
+                return Err(Error::Config(format!(
+                    "{route_scope} {field} composite predicates must not be empty"
+                )));
+            }
+            for predicate in predicates {
+                validate_cache_predicate(route_scope, field, predicate, mode)?;
+            }
+        }
+        CachePredicateConfig::Not(predicate) => {
+            validate_cache_predicate(route_scope, field, predicate, mode)?;
+        }
+        CachePredicateConfig::Method(method) => {
+            method.trim().to_ascii_uppercase().parse::<Method>().map_err(|error| {
+                Error::Config(format!(
+                    "{route_scope} {field} method `{method}` is invalid: {error}"
+                ))
+            })?;
+        }
+        CachePredicateConfig::HeaderExists(name)
+        | CachePredicateConfig::QueryExists(name)
+        | CachePredicateConfig::CookieExists(name) => {
+            validate_non_empty(route_scope, field, name, "name")?;
+            if matches!(predicate, CachePredicateConfig::HeaderExists(_)) {
+                validate_header_name(route_scope, field, name)?;
+            }
+        }
+        CachePredicateConfig::HeaderEquals { name, .. } => {
+            validate_non_empty(route_scope, field, name, "name")?;
+            validate_header_name(route_scope, field, name)?;
+        }
+        CachePredicateConfig::QueryEquals { name, .. }
+        | CachePredicateConfig::CookieEquals { name, .. } => {
+            validate_non_empty(route_scope, field, name, "name")?;
+        }
+        CachePredicateConfig::Status(status) => {
+            super::validate_statuses(route_scope, field, &[*status])?;
+            if mode == PredicateValidationMode::RequestOnly {
+                return Err(Error::Config(format!(
+                    "{route_scope} {field} cannot match response status"
+                )));
+            }
+        }
+        CachePredicateConfig::Statuses(statuses) => {
+            super::validate_statuses(route_scope, field, statuses)?;
+            if mode == PredicateValidationMode::RequestOnly {
+                return Err(Error::Config(format!(
+                    "{route_scope} {field} cannot match response status"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_non_empty(route_scope: &str, field: &str, value: &str, part: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(Error::Config(format!("{route_scope} {field} {part} must not be empty")));
+    }
+    Ok(())
+}
+
+fn validate_header_name(route_scope: &str, field: &str, name: &str) -> Result<()> {
+    name.parse::<HeaderName>().map_err(|error| {
+        Error::Config(format!("{route_scope} {field} header `{name}` is invalid: {error}"))
+    })?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PredicateValidationMode {
+    RequestOnly,
+    RequestOrResponse,
+}

--- a/crates/rginx-config/src/validate/tests/cache.rs
+++ b/crates/rginx-config/src/validate/tests/cache.rs
@@ -165,3 +165,26 @@ fn validate_rejects_empty_path_levels() {
     let error = validate(&config).expect_err("empty path_levels should fail validation");
     assert!(error.to_string().contains("path_levels must not be empty"), "{error}");
 }
+
+#[test]
+fn validate_rejects_zero_path_level() {
+    let mut config = base_config();
+    config.cache_zones =
+        vec![CacheZoneConfig { path_levels: Some(vec![0]), ..cache_zone("default") }];
+    config.locations[0].cache = Some(route_cache("default"));
+
+    let error = validate(&config).expect_err("zero path_levels entry should fail validation");
+    assert!(error.to_string().contains("path_levels entries must be greater than 0"), "{error}");
+}
+
+#[test]
+fn validate_rejects_path_levels_longer_than_cache_hash() {
+    let mut config = base_config();
+    config.cache_zones =
+        vec![CacheZoneConfig { path_levels: Some(vec![32, 33]), ..cache_zone("default") }];
+    config.locations[0].cache = Some(route_cache("default"));
+
+    let error =
+        validate(&config).expect_err("path_levels longer than cache hash should fail validation");
+    assert!(error.to_string().contains("exceeds cache hash length"), "{error}");
+}

--- a/crates/rginx-config/src/validate/tests/cache.rs
+++ b/crates/rginx-config/src/validate/tests/cache.rs
@@ -8,6 +8,12 @@ fn cache_zone(name: &str) -> CacheZoneConfig {
         inactive_secs: Some(60),
         default_ttl_secs: Some(30),
         max_entry_bytes: Some(1024),
+        path_levels: None,
+        loader_batch_entries: None,
+        loader_sleep_millis: None,
+        manager_batch_entries: None,
+        manager_sleep_millis: None,
+        inactive_cleanup_interval_secs: None,
     }
 }
 
@@ -25,6 +31,9 @@ fn route_cache(zone: &str) -> CacheRouteConfig {
         background_update: None,
         lock_timeout_secs: None,
         lock_age_secs: None,
+        min_uses: None,
+        ignore_headers: None,
+        range_requests: None,
     }
 }
 
@@ -120,4 +129,39 @@ fn validate_accepts_status_match_in_no_cache() {
     config.locations[0].cache = Some(policy);
 
     validate(&config).expect("status-based no_cache should pass validation");
+}
+
+#[test]
+fn validate_rejects_zero_min_uses() {
+    let mut config = base_config();
+    config.cache_zones = vec![cache_zone("default")];
+    let mut policy = route_cache("default");
+    policy.min_uses = Some(0);
+    config.locations[0].cache = Some(policy);
+
+    let error = validate(&config).expect_err("zero min_uses should fail validation");
+    assert!(error.to_string().contains("cache.min_uses must be greater than 0"), "{error}");
+}
+
+#[test]
+fn validate_rejects_empty_ignore_headers() {
+    let mut config = base_config();
+    config.cache_zones = vec![cache_zone("default")];
+    let mut policy = route_cache("default");
+    policy.ignore_headers = Some(Vec::new());
+    config.locations[0].cache = Some(policy);
+
+    let error = validate(&config).expect_err("empty ignore_headers should fail validation");
+    assert!(error.to_string().contains("cache.ignore_headers must not be empty"), "{error}");
+}
+
+#[test]
+fn validate_rejects_empty_path_levels() {
+    let mut config = base_config();
+    config.cache_zones =
+        vec![CacheZoneConfig { path_levels: Some(Vec::new()), ..cache_zone("default") }];
+    config.locations[0].cache = Some(route_cache("default"));
+
+    let error = validate(&config).expect_err("empty path_levels should fail validation");
+    assert!(error.to_string().contains("path_levels must not be empty"), "{error}");
 }

--- a/crates/rginx-core/src/config.rs
+++ b/crates/rginx-core/src/config.rs
@@ -11,9 +11,9 @@ mod virtual_host;
 
 pub use access_log::{AccessLogFormat, AccessLogValues};
 pub use cache::{
-    CacheKeyRenderContext, CacheKeyTemplate, CacheKeyTemplateError, CachePredicate,
-    CachePredicateRequestContext, CacheStatusTtlRule, CacheUseStaleCondition, CacheZone,
-    RouteCachePolicy,
+    CacheIgnoreHeader, CacheKeyRenderContext, CacheKeyTemplate, CacheKeyTemplateError,
+    CachePredicate, CachePredicateRequestContext, CacheRangeRequestPolicy, CacheStatusTtlRule,
+    CacheUseStaleCondition, CacheZone, RouteCachePolicy,
 };
 pub use listener::{
     Listener, ListenerApplicationProtocol, ListenerHttp3, ListenerTransportBinding,

--- a/crates/rginx-core/src/config/cache.rs
+++ b/crates/rginx-core/src/config/cache.rs
@@ -16,6 +16,12 @@ pub struct CacheZone {
     pub inactive: Duration,
     pub default_ttl: Duration,
     pub max_entry_bytes: usize,
+    pub path_levels: Vec<usize>,
+    pub loader_batch_entries: usize,
+    pub loader_sleep: Duration,
+    pub manager_batch_entries: usize,
+    pub manager_sleep: Duration,
+    pub inactive_cleanup_interval: Duration,
 }
 
 #[derive(Debug, Clone)]
@@ -32,6 +38,9 @@ pub struct RouteCachePolicy {
     pub background_update: bool,
     pub lock_timeout: Duration,
     pub lock_age: Duration,
+    pub min_uses: u64,
+    pub ignore_headers: Vec<CacheIgnoreHeader>,
+    pub range_requests: CacheRangeRequestPolicy,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -64,6 +73,21 @@ pub enum CacheUseStaleCondition {
     Http502,
     Http503,
     Http504,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheIgnoreHeader {
+    XAccelExpires,
+    Expires,
+    CacheControl,
+    SetCookie,
+    Vary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheRangeRequestPolicy {
+    Bypass,
+    Cache,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/rginx-core/src/lib.rs
+++ b/crates/rginx-core/src/lib.rs
@@ -5,18 +5,18 @@ pub mod service;
 pub mod types;
 
 pub use config::{
-    AccessLogFormat, AccessLogValues, ActiveHealthCheck, CacheKeyRenderContext, CacheKeyTemplate,
-    CacheKeyTemplateError, CachePredicate, CachePredicateRequestContext, CacheStatusTtlRule,
-    CacheUseStaleCondition, CacheZone, ClientIdentity, ConfigSnapshot, DEFAULT_SERVER_HEADER,
-    GrpcRouteMatch, Listener, ListenerApplicationProtocol, ListenerHttp3, ListenerTransportBinding,
-    ListenerTransportKind, OcspConfig, OcspNonceMode, OcspResponderPolicy,
-    ProxyHeaderRenderContext, ProxyHeaderTemplate, ProxyHeaderTemplateError, ProxyHeaderValue,
-    ProxyTarget, ReturnAction, Route, RouteAccessControl, RouteAction, RouteBufferingPolicy,
-    RouteCachePolicy, RouteCompressionPolicy, RouteMatcher, RouteRateLimit, RouteRegexError,
-    RouteRegexMatcher, RuntimeSettings, Server, ServerCertificateBundle, ServerClientAuthMode,
-    ServerClientAuthPolicy, ServerNameMatch, ServerTls, TlsCipherSuite, TlsKeyExchangeGroup,
-    TlsVersion, Upstream, UpstreamDnsPolicy, UpstreamLoadBalance, UpstreamPeer, UpstreamProtocol,
-    UpstreamSettings, UpstreamTls, VirtualHost, VirtualHostTls, best_matching_server_name_pattern,
-    default_server_header, match_server_name,
+    AccessLogFormat, AccessLogValues, ActiveHealthCheck, CacheIgnoreHeader, CacheKeyRenderContext,
+    CacheKeyTemplate, CacheKeyTemplateError, CachePredicate, CachePredicateRequestContext,
+    CacheRangeRequestPolicy, CacheStatusTtlRule, CacheUseStaleCondition, CacheZone, ClientIdentity,
+    ConfigSnapshot, DEFAULT_SERVER_HEADER, GrpcRouteMatch, Listener, ListenerApplicationProtocol,
+    ListenerHttp3, ListenerTransportBinding, ListenerTransportKind, OcspConfig, OcspNonceMode,
+    OcspResponderPolicy, ProxyHeaderRenderContext, ProxyHeaderTemplate, ProxyHeaderTemplateError,
+    ProxyHeaderValue, ProxyTarget, ReturnAction, Route, RouteAccessControl, RouteAction,
+    RouteBufferingPolicy, RouteCachePolicy, RouteCompressionPolicy, RouteMatcher, RouteRateLimit,
+    RouteRegexError, RouteRegexMatcher, RuntimeSettings, Server, ServerCertificateBundle,
+    ServerClientAuthMode, ServerClientAuthPolicy, ServerNameMatch, ServerTls, TlsCipherSuite,
+    TlsKeyExchangeGroup, TlsVersion, Upstream, UpstreamDnsPolicy, UpstreamLoadBalance,
+    UpstreamPeer, UpstreamProtocol, UpstreamSettings, UpstreamTls, VirtualHost, VirtualHostTls,
+    best_matching_server_name_pattern, default_server_header, match_server_name,
 };
 pub use error::{Error, Result};

--- a/crates/rginx-http/src/cache/entry.rs
+++ b/crates/rginx-http/src/cache/entry.rs
@@ -104,7 +104,7 @@ pub(super) async fn read_cached_response(
     entry: &CacheIndexEntry,
     read_body: bool,
 ) -> std::io::Result<HttpResponse> {
-    let paths = cache_paths(&zone.config.path, &entry.hash);
+    let paths = cache_paths_for_zone(zone.config.as_ref(), &entry.hash);
     let metadata = read_cache_metadata(&paths.metadata).await?;
     if metadata.key != key {
         return Err(std::io::Error::new(
@@ -201,9 +201,24 @@ pub(super) async fn write_cache_metadata(
     Ok(())
 }
 
+#[cfg(test)]
 pub(super) fn cache_paths(base: &Path, hash: &str) -> CachePaths {
-    let prefix = hash.get(..2).unwrap_or("00");
-    let dir = base.join(prefix);
+    cache_paths_with_levels(base, &[2], hash)
+}
+
+pub(super) fn cache_paths_for_zone(zone: &rginx_core::CacheZone, hash: &str) -> CachePaths {
+    cache_paths_with_levels(&zone.path, &zone.path_levels, hash)
+}
+
+fn cache_paths_with_levels(base: &Path, levels: &[usize], hash: &str) -> CachePaths {
+    let mut dir = base.to_path_buf();
+    let mut offset = 0usize;
+    for level in levels {
+        let next = offset.saturating_add(*level);
+        let prefix = hash.get(offset..next).unwrap_or("00");
+        dir = dir.join(prefix);
+        offset = next;
+    }
     CachePaths {
         metadata: dir.join(format!("{hash}.meta.json")),
         body: dir.join(format!("{hash}.body")),

--- a/crates/rginx-http/src/cache/entry.rs
+++ b/crates/rginx-http/src/cache/entry.rs
@@ -214,16 +214,20 @@ fn cache_paths_with_levels(base: &Path, levels: &[usize], hash: &str) -> CachePa
     let mut dir = base.to_path_buf();
     let mut offset = 0usize;
     for level in levels {
-        let next = offset.saturating_add(*level);
-        let prefix = hash.get(offset..next).unwrap_or("00");
-        dir = dir.join(prefix);
-        offset = next;
+        dir = dir.join(cache_path_segment(hash, offset, *level));
+        offset = offset.saturating_add(*level);
     }
     CachePaths {
         metadata: dir.join(format!("{hash}.meta.json")),
         body: dir.join(format!("{hash}.body")),
         dir,
     }
+}
+
+fn cache_path_segment(hash: &str, offset: usize, level_len: usize) -> String {
+    hash.get(offset..offset.saturating_add(level_len)).map(str::to_string).unwrap_or_else(|| {
+        format!("{:0<width$}", hash.get(offset..).unwrap_or(""), width = level_len)
+    })
 }
 
 impl CacheMetadata {

--- a/crates/rginx-http/src/cache/load.rs
+++ b/crates/rginx-http/src/cache/load.rs
@@ -1,11 +1,12 @@
 use std::fs;
 use std::io;
 use std::path::Path;
+use std::thread;
 
 use rginx_core::CacheZone;
 use serde::Deserialize;
 
-use super::entry::{cache_key_hash, cache_paths};
+use super::entry::{cache_key_hash, cache_paths_for_zone};
 use super::store::eviction_candidates;
 use super::{CacheIndex, CacheIndexEntry, CachedVaryHeaderValue};
 
@@ -42,30 +43,8 @@ pub(super) fn load_index_from_disk(zone: &CacheZone) -> io::Result<CacheIndex> {
         return Ok(index);
     }
 
-    for prefix_dir in fs::read_dir(&zone.path)? {
-        let prefix_dir = match prefix_dir {
-            Ok(prefix_dir) => prefix_dir,
-            Err(error) => {
-                tracing::warn!(
-                    path = %zone.path.display(),
-                    %error,
-                    "failed to read cache zone directory entry; skipping"
-                );
-                continue;
-            }
-        };
-        let Ok(file_type) = prefix_dir.file_type() else {
-            tracing::warn!(
-                path = %prefix_dir.path().display(),
-                "failed to read cache directory entry type; skipping"
-            );
-            continue;
-        };
-        if !file_type.is_dir() {
-            continue;
-        }
-        scan_prefix_dir(zone, prefix_dir.path().as_path(), &mut index)?;
-    }
+    let mut loader = LoaderState::default();
+    scan_cache_dir(zone, zone.path.as_path(), &mut index, &mut loader)?;
 
     for (key, entry) in eviction_candidates(&mut index, zone.max_size_bytes) {
         remove_variant_key(&mut index.variants, &entry.base_key, &key);
@@ -75,7 +54,12 @@ pub(super) fn load_index_from_disk(zone: &CacheZone) -> io::Result<CacheIndex> {
     Ok(index)
 }
 
-fn scan_prefix_dir(zone: &CacheZone, dir: &Path, index: &mut CacheIndex) -> io::Result<()> {
+fn scan_cache_dir(
+    zone: &CacheZone,
+    dir: &Path,
+    index: &mut CacheIndex,
+    loader: &mut LoaderState,
+) -> io::Result<()> {
     for entry in fs::read_dir(dir)? {
         let entry = match entry {
             Ok(entry) => entry,
@@ -88,10 +72,19 @@ fn scan_prefix_dir(zone: &CacheZone, dir: &Path, index: &mut CacheIndex) -> io::
                 continue;
             }
         };
+        loader.maybe_sleep(zone);
         let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            tracing::warn!(path = %path.display(), "failed to read cache directory entry type; skipping");
+            continue;
+        };
+        if file_type.is_dir() {
+            scan_cache_dir(zone, path.as_path(), index, loader)?;
+            continue;
+        }
         let Some(hash) = metadata_hash(&path) else {
             if let Some(hash) = body_hash(&path)
-                && !cache_paths(&zone.path, &hash).metadata.exists()
+                && !cache_paths_for_zone(zone, &hash).metadata.exists()
             {
                 remove_cache_files(zone, &hash);
             }
@@ -114,7 +107,7 @@ fn scan_prefix_dir(zone: &CacheZone, dir: &Path, index: &mut CacheIndex) -> io::
 }
 
 fn load_cache_index_entry(zone: &CacheZone, hash: &str) -> Option<(String, CacheIndexEntry)> {
-    let paths = cache_paths(&zone.path, hash);
+    let paths = cache_paths_for_zone(zone, hash);
     let Ok(metadata) = read_cache_metadata(&paths.metadata) else {
         remove_cache_files(zone, hash);
         return None;
@@ -200,9 +193,27 @@ fn body_hash(path: &Path) -> Option<String> {
 }
 
 fn remove_cache_files(zone: &CacheZone, hash: &str) {
-    let paths = cache_paths(&zone.path, hash);
+    let paths = cache_paths_for_zone(zone, hash);
     let _ = fs::remove_file(paths.metadata);
     let _ = fs::remove_file(paths.body);
+}
+
+#[derive(Default)]
+struct LoaderState {
+    processed_entries: usize,
+}
+
+impl LoaderState {
+    fn maybe_sleep(&mut self, zone: &CacheZone) {
+        self.processed_entries = self.processed_entries.saturating_add(1);
+        if zone.loader_batch_entries == 0
+            || zone.loader_sleep.is_zero()
+            || !self.processed_entries.is_multiple_of(zone.loader_batch_entries)
+        {
+            return;
+        }
+        thread::sleep(zone.loader_sleep);
+    }
 }
 
 fn add_variant_key(

--- a/crates/rginx-http/src/cache/load.rs
+++ b/crates/rginx-http/src/cache/load.rs
@@ -60,7 +60,14 @@ fn scan_cache_dir(
     index: &mut CacheIndex,
     loader: &mut LoaderState,
 ) -> io::Result<()> {
-    for entry in fs::read_dir(dir)? {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            tracing::warn!(path = %dir.display(), %error, "failed to read cache directory; skipping");
+            return Ok(());
+        }
+    };
+    for entry in entries {
         let entry = match entry {
             Ok(entry) => entry,
             Err(error) => {
@@ -79,7 +86,13 @@ fn scan_cache_dir(
             continue;
         };
         if file_type.is_dir() {
-            scan_cache_dir(zone, path.as_path(), index, loader)?;
+            if let Err(error) = scan_cache_dir(zone, path.as_path(), index, loader) {
+                tracing::warn!(
+                    path = %path.display(),
+                    %error,
+                    "failed to scan cache subdirectory; skipping"
+                );
+            }
             continue;
         }
         let Some(hash) = metadata_hash(&path) else {
@@ -210,6 +223,12 @@ impl LoaderState {
             || zone.loader_sleep.is_zero()
             || !self.processed_entries.is_multiple_of(zone.loader_batch_entries)
         {
+            return;
+        }
+        if let Ok(handle) = tokio::runtime::Handle::try_current()
+            && handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread
+        {
+            tokio::task::block_in_place(|| thread::sleep(zone.loader_sleep));
             return;
         }
         thread::sleep(zone.loader_sleep);

--- a/crates/rginx-http/src/cache/lookup.rs
+++ b/crates/rginx-http/src/cache/lookup.rs
@@ -88,7 +88,7 @@ impl CacheManager {
     ) -> Option<(CacheMetadata, Option<CacheConditionalHeaders>)> {
         let metadata = {
             let _io_guard = zone.io_lock.lock().await;
-            let paths = cache_paths(&zone.config.path, &entry.hash);
+            let paths = cache_paths_for_zone(zone.config.as_ref(), &entry.hash);
             read_cache_metadata(&paths.metadata).await
         };
         let metadata = match metadata {
@@ -145,7 +145,7 @@ impl CacheManager {
     ) -> Option<HttpResponse> {
         let (metadata, response) = {
             let _io_guard = zone.io_lock.lock().await;
-            let paths = cache_paths(&zone.config.path, &entry.hash);
+            let paths = cache_paths_for_zone(zone.config.as_ref(), &entry.hash);
             let metadata = read_cache_metadata(&paths.metadata).await.ok()?;
             let response =
                 build_cached_response(&paths.body, &metadata, read_cached_body).await.ok()?;

--- a/crates/rginx-http/src/cache/manager.rs
+++ b/crates/rginx-http/src/cache/manager.rs
@@ -31,6 +31,7 @@ impl CacheManager {
                         io_lock: AsyncMutex::new(()),
                         fill_locks: Arc::new(Mutex::new(HashMap::new())),
                         fill_lock_generation: AtomicU64::new(0),
+                        last_inactive_cleanup_unix_ms: AtomicU64::new(0),
                         stats: CacheZoneStats::default(),
                         change_notifier: change_notifier.clone(),
                     }),

--- a/crates/rginx-http/src/cache/mod.rs
+++ b/crates/rginx-http/src/cache/mod.rs
@@ -26,11 +26,11 @@ mod store;
 mod vary;
 
 use entry::{
-    CacheMetadata, build_cached_response, cache_paths, read_cache_metadata, read_cached_response,
-    unix_time_ms,
+    CacheMetadata, build_cached_response, cache_paths_for_zone, read_cache_metadata,
+    read_cached_response, unix_time_ms,
 };
 #[cfg(test)]
-use entry::{cache_key_hash, cache_metadata, cache_variant_key, write_cache_entry};
+use entry::{cache_key_hash, cache_metadata, cache_paths, cache_variant_key, write_cache_entry};
 use load::load_index_from_disk;
 use policy::{header_value, request_requires_revalidation};
 #[cfg(test)]
@@ -146,6 +146,7 @@ struct CacheZoneRuntime {
     io_lock: AsyncMutex<()>,
     fill_locks: Arc<Mutex<HashMap<String, CacheFillLockState>>>,
     fill_lock_generation: AtomicU64,
+    last_inactive_cleanup_unix_ms: AtomicU64,
     stats: CacheZoneStats,
     change_notifier: Option<CacheChangeNotifier>,
 }
@@ -154,6 +155,7 @@ struct CacheZoneRuntime {
 struct CacheIndex {
     entries: HashMap<String, CacheIndexEntry>,
     variants: HashMap<String, Vec<String>>,
+    admission_counts: HashMap<String, u64>,
     current_size_bytes: usize,
 }
 

--- a/crates/rginx-http/src/cache/policy.rs
+++ b/crates/rginx-http/src/cache/policy.rs
@@ -50,7 +50,7 @@ pub(super) fn response_is_storable_with_size(
     body_size: ResponseBodySize,
 ) -> bool {
     let requested_range = cacheable_range_request(&context.request, &context.policy);
-    if !status_is_cacheable(context, status) {
+    if !status_is_cacheable(context, status, requested_range.is_some()) {
         return false;
     }
     if requested_range.is_some() && status != StatusCode::PARTIAL_CONTENT {
@@ -197,10 +197,13 @@ pub(super) fn vary_headers(headers: &HeaderMap) -> Option<Vec<HeaderName>> {
     Some(names)
 }
 
-fn status_is_cacheable(context: &CacheStoreContext, status: StatusCode) -> bool {
+fn status_is_cacheable(
+    context: &CacheStoreContext,
+    status: StatusCode,
+    has_cacheable_request_range: bool,
+) -> bool {
     context.policy.statuses.contains(&status)
-        || (status == StatusCode::PARTIAL_CONTENT
-            && cacheable_range_request(&context.request, &context.policy).is_some())
+        || (status == StatusCode::PARTIAL_CONTENT && has_cacheable_request_range)
 }
 
 fn ignores_header(context: &CacheStoreContext, header: CacheIgnoreHeader) -> bool {

--- a/crates/rginx-http/src/cache/policy.rs
+++ b/crates/rginx-http/src/cache/policy.rs
@@ -1,16 +1,24 @@
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use http::StatusCode;
 use http::header::{
-    CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, EXPIRES, HeaderMap, HeaderName,
-    PRAGMA, SET_COOKIE, VARY,
+    CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, HeaderMap, HeaderName, SET_COOKIE, VARY,
 };
 use hyper::body::Body as _;
+use rginx_core::CacheIgnoreHeader;
 use rginx_core::CachePredicateRequestContext;
 
 use crate::handler::HttpResponse;
 
 use super::CacheStoreContext;
+use super::request::{cacheable_range_request, response_content_range_matches_request};
+
+mod directives;
+
+use directives::{
+    cache_control_contains, cache_control_duration, cache_control_max_age, expires_ttl,
+    pragma_contains, x_accel_expires_ttl,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct ResponseFreshness {
@@ -41,22 +49,34 @@ pub(super) fn response_is_storable_with_size(
     headers: &HeaderMap,
     body_size: ResponseBodySize,
 ) -> bool {
-    if !context.policy.statuses.contains(&status) {
+    let requested_range = cacheable_range_request(&context.request, &context.policy);
+    if !status_is_cacheable(context, status) {
         return false;
     }
-    if status == StatusCode::PARTIAL_CONTENT
-        || headers.contains_key(CONTENT_RANGE)
-        || headers.contains_key(SET_COOKIE)
-    {
+    if requested_range.is_some() && status != StatusCode::PARTIAL_CONTENT {
         return false;
     }
-    if !vary_is_supported(headers) {
+    if status == StatusCode::PARTIAL_CONTENT {
+        if requested_range.is_none()
+            || !response_content_range_matches_request(&context.request, &context.policy, headers)
+        {
+            return false;
+        }
+    } else if headers.contains_key(CONTENT_RANGE) {
+        return false;
+    }
+    if !ignores_header(context, CacheIgnoreHeader::SetCookie) && headers.contains_key(SET_COOKIE) {
+        return false;
+    }
+    if !vary_is_supported(context, headers) {
         return false;
     }
     if response_is_grpc(headers) {
         return false;
     }
-    if cache_control_contains(headers, &["no-store", "private"]) {
+    if !ignores_header(context, CacheIgnoreHeader::CacheControl)
+        && cache_control_contains(headers, &["no-store", "private"])
+    {
         return false;
     }
     if let Some(length) = parse_content_length(headers)
@@ -83,10 +103,15 @@ pub(super) fn response_freshness(
 ) -> ResponseFreshness {
     ResponseFreshness {
         ttl: response_ttl(context, status, headers),
-        stale_if_error: cache_control_duration(headers, "stale-if-error")
+        stale_if_error: (!ignores_header(context, CacheIgnoreHeader::CacheControl))
+            .then(|| cache_control_duration(headers, "stale-if-error"))
+            .flatten()
             .or(context.policy.stale_if_error),
-        stale_while_revalidate: cache_control_duration(headers, "stale-while-revalidate"),
-        must_revalidate: cache_control_contains(headers, &["no-cache", "must-revalidate"]),
+        stale_while_revalidate: (!ignores_header(context, CacheIgnoreHeader::CacheControl))
+            .then(|| cache_control_duration(headers, "stale-while-revalidate"))
+            .flatten(),
+        must_revalidate: !ignores_header(context, CacheIgnoreHeader::CacheControl)
+            && cache_control_contains(headers, &["no-cache", "must-revalidate"]),
     }
 }
 
@@ -127,9 +152,19 @@ pub(super) fn response_ttl(
     status: StatusCode,
     headers: &HeaderMap,
 ) -> Duration {
-    x_accel_expires_ttl(headers)
-        .or_else(|| cache_control_max_age(headers))
-        .or_else(|| expires_ttl(headers))
+    (!ignores_header(context, CacheIgnoreHeader::XAccelExpires))
+        .then(|| x_accel_expires_ttl(headers))
+        .flatten()
+        .or_else(|| {
+            (!ignores_header(context, CacheIgnoreHeader::CacheControl))
+                .then(|| cache_control_max_age(headers))
+                .flatten()
+        })
+        .or_else(|| {
+            (!ignores_header(context, CacheIgnoreHeader::Expires))
+                .then(|| expires_ttl(headers))
+                .flatten()
+        })
         .or_else(|| {
             context
                 .policy
@@ -140,86 +175,8 @@ pub(super) fn response_ttl(
         .unwrap_or(context.zone.config.default_ttl)
 }
 
-fn cache_control_max_age(headers: &HeaderMap) -> Option<Duration> {
-    let mut max_age = None;
-    for value in headers.get_all(CACHE_CONTROL) {
-        let Ok(value) = value.to_str() else {
-            continue;
-        };
-        for directive in value.split(',').map(str::trim) {
-            let Some((name, value)) = directive.split_once('=') else {
-                continue;
-            };
-            if name.trim().eq_ignore_ascii_case("s-maxage")
-                || name.trim().eq_ignore_ascii_case("max-age")
-            {
-                let Ok(seconds) = value.trim().trim_matches('"').parse::<u64>() else {
-                    continue;
-                };
-                let duration = Duration::from_secs(seconds);
-                if name.trim().eq_ignore_ascii_case("s-maxage") {
-                    return Some(duration);
-                }
-                if max_age.is_none() {
-                    max_age = Some(duration);
-                }
-            }
-        }
-    }
-    max_age
-}
-
-fn expires_ttl(headers: &HeaderMap) -> Option<Duration> {
-    let expires = headers.get(EXPIRES)?.to_str().ok()?;
-    let expires = httpdate::parse_http_date(expires).ok()?;
-    Some(expires.duration_since(SystemTime::now()).unwrap_or(Duration::ZERO))
-}
-
-fn cache_control_contains(headers: &HeaderMap, directives: &[&str]) -> bool {
-    headers.get_all(CACHE_CONTROL).iter().any(|value| {
-        value.to_str().ok().is_some_and(|value| {
-            value.split(',').any(|directive| {
-                let name = directive.split_once('=').map_or(directive, |(name, _)| name).trim();
-                directives.iter().any(|expected| name.eq_ignore_ascii_case(expected))
-            })
-        })
-    })
-}
-
-fn pragma_contains(headers: &HeaderMap, directive: &str) -> bool {
-    headers.get_all(PRAGMA).iter().any(|value| {
-        value.to_str().ok().is_some_and(|value| {
-            value.split(',').map(str::trim).any(|token| token.eq_ignore_ascii_case(directive))
-        })
-    })
-}
-
-pub(super) fn cache_control_duration(
-    headers: &HeaderMap,
-    directive_name: &str,
-) -> Option<Duration> {
-    for value in headers.get_all(CACHE_CONTROL) {
-        let Ok(value) = value.to_str() else {
-            continue;
-        };
-        for directive in value.split(',').map(str::trim) {
-            let Some((name, value)) = directive.split_once('=') else {
-                continue;
-            };
-            if !name.trim().eq_ignore_ascii_case(directive_name) {
-                continue;
-            }
-            let Ok(seconds) = value.trim().trim_matches('"').parse::<u64>() else {
-                continue;
-            };
-            return Some(Duration::from_secs(seconds));
-        }
-    }
-    None
-}
-
-pub(super) fn vary_is_supported(headers: &HeaderMap) -> bool {
-    vary_headers(headers).is_some()
+pub(super) fn vary_is_supported(context: &CacheStoreContext, headers: &HeaderMap) -> bool {
+    ignores_header(context, CacheIgnoreHeader::Vary) || vary_headers(headers).is_some()
 }
 
 pub(super) fn vary_headers(headers: &HeaderMap) -> Option<Vec<HeaderName>> {
@@ -240,24 +197,21 @@ pub(super) fn vary_headers(headers: &HeaderMap) -> Option<Vec<HeaderName>> {
     Some(names)
 }
 
+fn status_is_cacheable(context: &CacheStoreContext, status: StatusCode) -> bool {
+    context.policy.statuses.contains(&status)
+        || (status == StatusCode::PARTIAL_CONTENT
+            && cacheable_range_request(&context.request, &context.policy).is_some())
+}
+
+fn ignores_header(context: &CacheStoreContext, header: CacheIgnoreHeader) -> bool {
+    context.policy.ignore_headers.contains(&header)
+}
+
 fn parse_content_length(headers: &HeaderMap) -> Option<usize> {
     headers
         .get(CONTENT_LENGTH)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<usize>().ok())
-}
-
-fn x_accel_expires_ttl(headers: &HeaderMap) -> Option<Duration> {
-    let value = headers.get("x-accel-expires")?.to_str().ok()?.trim();
-    if value == "0" {
-        return Some(Duration::ZERO);
-    }
-    if let Some(value) = value.strip_prefix('@') {
-        let seconds = value.parse::<u64>().ok()?;
-        let expires_at = std::time::UNIX_EPOCH.checked_add(Duration::from_secs(seconds))?;
-        return Some(expires_at.duration_since(SystemTime::now()).unwrap_or(Duration::ZERO));
-    }
-    value.parse::<u64>().ok().map(Duration::from_secs)
 }
 
 impl ResponseBodySize {

--- a/crates/rginx-http/src/cache/policy/directives.rs
+++ b/crates/rginx-http/src/cache/policy/directives.rs
@@ -1,0 +1,94 @@
+use std::time::{Duration, SystemTime};
+
+use http::header::{CACHE_CONTROL, EXPIRES, HeaderMap, PRAGMA};
+
+pub(super) fn cache_control_max_age(headers: &HeaderMap) -> Option<Duration> {
+    let mut max_age = None;
+    for value in headers.get_all(CACHE_CONTROL) {
+        let Ok(value) = value.to_str() else {
+            continue;
+        };
+        for directive in value.split(',').map(str::trim) {
+            let Some((name, value)) = directive.split_once('=') else {
+                continue;
+            };
+            if name.trim().eq_ignore_ascii_case("s-maxage")
+                || name.trim().eq_ignore_ascii_case("max-age")
+            {
+                let Ok(seconds) = value.trim().trim_matches('"').parse::<u64>() else {
+                    continue;
+                };
+                let duration = Duration::from_secs(seconds);
+                if name.trim().eq_ignore_ascii_case("s-maxage") {
+                    return Some(duration);
+                }
+                if max_age.is_none() {
+                    max_age = Some(duration);
+                }
+            }
+        }
+    }
+    max_age
+}
+
+pub(super) fn expires_ttl(headers: &HeaderMap) -> Option<Duration> {
+    let expires = headers.get(EXPIRES)?.to_str().ok()?;
+    let expires = httpdate::parse_http_date(expires).ok()?;
+    Some(expires.duration_since(SystemTime::now()).unwrap_or(Duration::ZERO))
+}
+
+pub(super) fn cache_control_contains(headers: &HeaderMap, directives: &[&str]) -> bool {
+    headers.get_all(CACHE_CONTROL).iter().any(|value| {
+        value.to_str().ok().is_some_and(|value| {
+            value.split(',').any(|directive| {
+                let name = directive.split_once('=').map_or(directive, |(name, _)| name).trim();
+                directives.iter().any(|expected| name.eq_ignore_ascii_case(expected))
+            })
+        })
+    })
+}
+
+pub(super) fn pragma_contains(headers: &HeaderMap, directive: &str) -> bool {
+    headers.get_all(PRAGMA).iter().any(|value| {
+        value.to_str().ok().is_some_and(|value| {
+            value.split(',').map(str::trim).any(|token| token.eq_ignore_ascii_case(directive))
+        })
+    })
+}
+
+pub(super) fn cache_control_duration(
+    headers: &HeaderMap,
+    directive_name: &str,
+) -> Option<Duration> {
+    for value in headers.get_all(CACHE_CONTROL) {
+        let Ok(value) = value.to_str() else {
+            continue;
+        };
+        for directive in value.split(',').map(str::trim) {
+            let Some((name, value)) = directive.split_once('=') else {
+                continue;
+            };
+            if !name.trim().eq_ignore_ascii_case(directive_name) {
+                continue;
+            }
+            let Ok(seconds) = value.trim().trim_matches('"').parse::<u64>() else {
+                continue;
+            };
+            return Some(Duration::from_secs(seconds));
+        }
+    }
+    None
+}
+
+pub(super) fn x_accel_expires_ttl(headers: &HeaderMap) -> Option<Duration> {
+    let value = headers.get("x-accel-expires")?.to_str().ok()?.trim();
+    if value == "0" {
+        return Some(Duration::ZERO);
+    }
+    if let Some(value) = value.strip_prefix('@') {
+        let seconds = value.parse::<u64>().ok()?;
+        let expires_at = std::time::UNIX_EPOCH.checked_add(Duration::from_secs(seconds))?;
+        return Some(expires_at.duration_since(SystemTime::now()).unwrap_or(Duration::ZERO));
+    }
+    value.parse::<u64>().ok().map(Duration::from_secs)
+}

--- a/crates/rginx-http/src/cache/request.rs
+++ b/crates/rginx-http/src/cache/request.rs
@@ -1,9 +1,17 @@
-use http::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, RANGE};
+use http::header::{AUTHORIZATION, CONTENT_RANGE, CONTENT_TYPE, HeaderMap, RANGE};
 use http::{Method, Uri};
-use rginx_core::{CacheKeyRenderContext, CachePredicateRequestContext, RouteCachePolicy};
+use rginx_core::{
+    CacheKeyRenderContext, CachePredicateRequestContext, CacheRangeRequestPolicy, RouteCachePolicy,
+};
 
 use super::CacheRequest;
 use super::vary::normalized_accept_encoding;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CacheableRangeRequest {
+    pub(super) start: u64,
+    pub(super) end: u64,
+}
 
 pub(super) fn cache_request_bypass(request: &CacheRequest, policy: &RouteCachePolicy) -> bool {
     if !policy.methods.contains(&request.method) {
@@ -14,7 +22,11 @@ pub(super) fn cache_request_bypass(request: &CacheRequest, policy: &RouteCachePo
         return true;
     }
 
-    if request.headers.contains_key(AUTHORIZATION) || request.headers.contains_key(RANGE) {
+    if request.headers.contains_key(AUTHORIZATION) {
+        return true;
+    }
+
+    if request.headers.contains_key(RANGE) && cacheable_range_request(request, policy).is_none() {
         return true;
     }
 
@@ -60,5 +72,78 @@ pub(super) fn render_cache_key(
         rendered.push_str("|ae:");
         rendered.push_str(&accept_encoding);
     }
+    if let Some(range) = cacheable_range_request_from_parts(method, headers, policy) {
+        rendered.push_str("|range:");
+        rendered.push_str(&range.start.to_string());
+        rendered.push('-');
+        rendered.push_str(&range.end.to_string());
+    }
     rendered
+}
+
+pub(super) fn cacheable_range_request(
+    request: &CacheRequest,
+    policy: &RouteCachePolicy,
+) -> Option<CacheableRangeRequest> {
+    cacheable_range_request_from_parts(&request.method, &request.headers, policy)
+}
+
+pub(super) fn response_content_range_matches_request(
+    request: &CacheRequest,
+    policy: &RouteCachePolicy,
+    headers: &HeaderMap,
+) -> bool {
+    let Some(expected) = cacheable_range_request(request, policy) else {
+        return false;
+    };
+    let Some(value) = headers.get(CONTENT_RANGE) else {
+        return false;
+    };
+    let Ok(value) = value.to_str() else {
+        return false;
+    };
+    let Some(value) = value.trim().strip_prefix("bytes ") else {
+        return false;
+    };
+    let Some((range, _total)) = value.split_once('/') else {
+        return false;
+    };
+    let Some((start, end)) = range.split_once('-') else {
+        return false;
+    };
+    let Ok(start) = start.trim().parse::<u64>() else {
+        return false;
+    };
+    let Ok(end) = end.trim().parse::<u64>() else {
+        return false;
+    };
+    start == expected.start && end == expected.end
+}
+
+fn cacheable_range_request_from_parts(
+    method: &Method,
+    headers: &HeaderMap,
+    policy: &RouteCachePolicy,
+) -> Option<CacheableRangeRequest> {
+    if policy.range_requests != CacheRangeRequestPolicy::Cache
+        || !matches!(*method, Method::GET | Method::HEAD)
+    {
+        return None;
+    }
+    let value = headers.get(RANGE)?.to_str().ok()?;
+    parse_single_bounded_byte_range(value)
+}
+
+fn parse_single_bounded_byte_range(value: &str) -> Option<CacheableRangeRequest> {
+    let value = value.trim().strip_prefix("bytes=")?.trim();
+    if value.contains(',') {
+        return None;
+    }
+    let (start, end) = value.split_once('-')?;
+    if start.trim().is_empty() || end.trim().is_empty() {
+        return None;
+    }
+    let start = start.trim().parse::<u64>().ok()?;
+    let end = end.trim().parse::<u64>().ok()?;
+    (start <= end).then_some(CacheableRangeRequest { start, end })
 }

--- a/crates/rginx-http/src/cache/request.rs
+++ b/crates/rginx-http/src/cache/request.rs
@@ -130,7 +130,11 @@ fn cacheable_range_request_from_parts(
     {
         return None;
     }
-    let value = headers.get(RANGE)?.to_str().ok()?;
+    let mut values = headers.get_all(RANGE).iter();
+    let value = values.next()?.to_str().ok()?;
+    if values.next().is_some() {
+        return None;
+    }
     parse_single_bounded_byte_range(value)
 }
 

--- a/crates/rginx-http/src/cache/runtime.rs
+++ b/crates/rginx-http/src/cache/runtime.rs
@@ -94,7 +94,7 @@ impl CacheStoreContext {
         };
         let response = {
             let _io_guard = self.zone.io_lock.lock().await;
-            let paths = cache_paths(&self.zone.config.path, &entry.hash);
+            let paths = cache_paths_for_zone(self.zone.config.as_ref(), &entry.hash);
             build_cached_response(&paths.body, metadata, self.read_cached_body).await
         };
         match response {

--- a/crates/rginx-http/src/cache/runtime/support.rs
+++ b/crates/rginx-http/src/cache/runtime/support.rs
@@ -13,7 +13,7 @@ pub(in crate::cache) async fn remove_cache_files_if_unindexed(
     if lock_index(&zone.index).entries.contains_key(key) {
         return;
     }
-    let paths = cache_paths(&zone.config.path, hash);
+    let paths = cache_paths_for_zone(zone.config.as_ref(), hash);
     let _ = fs::remove_file(paths.metadata).await;
     let _ = fs::remove_file(paths.body).await;
 }

--- a/crates/rginx-http/src/cache/store.rs
+++ b/crates/rginx-http/src/cache/store.rs
@@ -86,12 +86,7 @@ pub(super) async fn store_response(
 
     let vary = cache_vary_values(&context, &context.request, &parts.headers);
     let final_key = cache_variant_key(&context.base_key, &vary);
-    if !record_cache_admission_attempt(
-        context.zone.as_ref(),
-        &final_key,
-        context.policy.min_uses,
-        context.cached_entry.is_some(),
-    ) {
+    if !record_cache_admission_attempt(context.zone.as_ref(), &final_key, context.policy.min_uses) {
         return Ok(Response::from_parts(parts, full_body(collected)));
     }
     let metadata = cache_metadata(

--- a/crates/rginx-http/src/cache/store.rs
+++ b/crates/rginx-http/src/cache/store.rs
@@ -8,8 +8,8 @@ use tokio::fs;
 use crate::handler::{HttpResponse, full_body};
 
 use super::entry::{
-    CacheMetadataInput, build_cached_response, cache_key_hash, cache_metadata, cache_paths,
-    cache_variant_key, unix_time_ms, write_cache_entry, write_cache_metadata,
+    CacheMetadataInput, build_cached_response, cache_key_hash, cache_metadata,
+    cache_paths_for_zone, cache_variant_key, unix_time_ms, write_cache_entry, write_cache_metadata,
 };
 use super::policy::{
     ResponseBodySize, response_freshness, response_is_storable, response_is_storable_with_size,
@@ -29,7 +29,7 @@ use helpers::{
 pub(in crate::cache) use helpers::{purge_scope, purge_selector_matches};
 pub(super) use maintenance::{
     cleanup_inactive_entries_in_zone, eviction_candidates, lock_index, purge_zone_entries,
-    remove_index_entry,
+    record_cache_admission_attempt, remove_index_entry,
 };
 
 pub(crate) struct CacheStoreError {
@@ -84,8 +84,16 @@ pub(super) async fn store_response(
         return Ok(Response::from_parts(parts, full_body(collected)));
     }
 
-    let vary = cache_vary_values(&context.request, &parts.headers);
+    let vary = cache_vary_values(&context, &context.request, &parts.headers);
     let final_key = cache_variant_key(&context.base_key, &vary);
+    if !record_cache_admission_attempt(
+        context.zone.as_ref(),
+        &final_key,
+        context.policy.min_uses,
+        context.cached_entry.is_some(),
+    ) {
+        return Ok(Response::from_parts(parts, full_body(collected)));
+    }
     let metadata = cache_metadata(
         final_key.clone(),
         parts.status,
@@ -98,7 +106,7 @@ pub(super) async fn store_response(
         .filter(|_| context.key == final_key)
         .map(|entry| entry.hash.clone())
         .unwrap_or_else(|| cache_key_hash(&final_key));
-    let paths = cache_paths(&context.zone.config.path, &hash);
+    let paths = cache_paths_for_zone(context.zone.config.as_ref(), &hash);
     let _io_guard = context.zone.io_lock.lock().await;
 
     if let Err(error) = write_cache_entry(&paths, &metadata, &collected).await {
@@ -163,7 +171,7 @@ pub(super) async fn refresh_not_modified_response(
     let merged_headers = merge_not_modified_headers(&cached_headers, response.headers());
     let now = unix_time_ms(SystemTime::now());
     let cached_status = StatusCode::from_u16(cached_metadata.status).unwrap_or(StatusCode::OK);
-    let paths = cache_paths(&context.zone.config.path, &cached_entry.hash);
+    let paths = cache_paths_for_zone(context.zone.config.as_ref(), &cached_entry.hash);
     if response_no_cache(&context, cached_status) {
         let response_metadata = cache_metadata(
             cached_metadata.key.clone(),
@@ -191,7 +199,7 @@ pub(super) async fn refresh_not_modified_response(
     }
 
     let freshness = response_freshness(&context, cached_status, &merged_headers);
-    let vary = cache_vary_values(&context.request, &merged_headers);
+    let vary = cache_vary_values(&context, &context.request, &merged_headers);
     let final_key = cache_variant_key(&context.base_key, &vary);
     let metadata = cache_metadata(
         final_key.clone(),

--- a/crates/rginx-http/src/cache/store/helpers.rs
+++ b/crates/rginx-http/src/cache/store/helpers.rs
@@ -1,4 +1,5 @@
 use http::header::{CONTENT_LENGTH, HeaderMap};
+use rginx_core::CacheIgnoreHeader;
 
 use super::super::policy::{ResponseFreshness, vary_headers};
 use super::super::vary::normalized_request_header_values;
@@ -29,9 +30,13 @@ pub(super) fn cache_metadata_input(
 }
 
 pub(super) fn cache_vary_values(
+    context: &crate::cache::CacheStoreContext,
     request: &crate::cache::CacheRequest,
     headers: &HeaderMap,
 ) -> Vec<CachedVaryHeaderValue> {
+    if context.policy.ignore_headers.contains(&CacheIgnoreHeader::Vary) {
+        return Vec::new();
+    }
     let mut vary = vary_headers(headers)
         .unwrap_or_default()
         .into_iter()

--- a/crates/rginx-http/src/cache/store/maintenance.rs
+++ b/crates/rginx-http/src/cache/store/maintenance.rs
@@ -4,39 +4,80 @@ use crate::cache::vary::sorted_vary_dimension_names;
 use std::collections::HashMap;
 
 pub(in crate::cache) async fn cleanup_inactive_entries_in_zone(zone: &Arc<CacheZoneRuntime>) {
-    let inactive_ms = duration_to_ms(zone.config.inactive);
     let now = unix_time_ms(SystemTime::now());
-    let removed = {
-        let mut index = lock_index(&zone.index);
-        let keys_to_remove = index
-            .entries
-            .iter()
-            .filter_map(|(key, entry)| {
-                (now.saturating_sub(entry.last_access_unix_ms) > inactive_ms).then_some(key.clone())
-            })
-            .collect::<Vec<_>>();
-        let mut removed = Vec::new();
-        for key in keys_to_remove {
-            if let Some(entry) = index.entries.remove(&key) {
-                index.current_size_bytes =
-                    index.current_size_bytes.saturating_sub(entry.body_size_bytes);
-                remove_variant_key(&mut index.variants, &entry.base_key, &key);
-                removed.push(entry);
-            }
-        }
-        removed
-    };
-    if removed.is_empty() {
+    let interval_ms = duration_to_ms(zone.config.inactive_cleanup_interval);
+    let last_cleanup =
+        zone.last_inactive_cleanup_unix_ms.load(std::sync::atomic::Ordering::Relaxed);
+    if last_cleanup != 0 && now.saturating_sub(last_cleanup) < interval_ms {
         return;
     }
-    zone.record_inactive_cleanup(removed.len());
-    let _io_guard = zone.io_lock.lock().await;
-    for entry in &removed {
-        let paths = cache_paths(&zone.config.path, &entry.hash);
-        let _ = fs::remove_file(paths.metadata).await;
-        let _ = fs::remove_file(paths.body).await;
+    zone.last_inactive_cleanup_unix_ms.store(now, std::sync::atomic::Ordering::Relaxed);
+
+    let inactive_ms = duration_to_ms(zone.config.inactive);
+    let batch_size = zone.config.manager_batch_entries.max(1);
+    let mut total_removed = 0usize;
+    let mut changed = false;
+
+    loop {
+        let removed = {
+            let mut index = lock_index(&zone.index);
+            let mut keys_to_remove = index
+                .entries
+                .iter()
+                .filter_map(|(key, entry)| {
+                    (now.saturating_sub(entry.last_access_unix_ms) > inactive_ms)
+                        .then_some((key.clone(), entry.last_access_unix_ms))
+                })
+                .collect::<Vec<_>>();
+            keys_to_remove.sort_by_key(|(_, last_access)| *last_access);
+            let keys_to_remove =
+                keys_to_remove.into_iter().take(batch_size).map(|(key, _)| key).collect::<Vec<_>>();
+            let mut removed = Vec::new();
+            for key in keys_to_remove {
+                if let Some(entry) = index.entries.remove(&key) {
+                    index.current_size_bytes =
+                        index.current_size_bytes.saturating_sub(entry.body_size_bytes);
+                    index.admission_counts.remove(&key);
+                    remove_variant_key(&mut index.variants, &entry.base_key, &key);
+                    removed.push(entry);
+                }
+            }
+            removed
+        };
+        if removed.is_empty() {
+            break;
+        }
+        changed = true;
+        total_removed += removed.len();
+        let io_guard = zone.io_lock.lock().await;
+        for entry in &removed {
+            let paths = cache_paths_for_zone(zone.config.as_ref(), &entry.hash);
+            let _ = fs::remove_file(paths.metadata).await;
+            let _ = fs::remove_file(paths.body).await;
+        }
+        drop(io_guard);
+        if removed.len() < batch_size {
+            break;
+        }
+        let has_more_inactive = {
+            let index = lock_index(&zone.index);
+            index
+                .entries
+                .values()
+                .any(|entry| now.saturating_sub(entry.last_access_unix_ms) > inactive_ms)
+        };
+        if !has_more_inactive {
+            break;
+        }
+        if !zone.config.manager_sleep.is_zero() {
+            tokio::time::sleep(zone.config.manager_sleep).await;
+        }
     }
-    zone.notify_changed();
+
+    if changed {
+        zone.record_inactive_cleanup(total_removed);
+        zone.notify_changed();
+    }
 }
 
 pub(in crate::cache) async fn purge_zone_entries(
@@ -56,6 +97,7 @@ pub(in crate::cache) async fn purge_zone_entries(
             if let Some(entry) = index.entries.remove(&key) {
                 index.current_size_bytes =
                     index.current_size_bytes.saturating_sub(entry.body_size_bytes);
+                index.admission_counts.remove(&key);
                 remove_variant_key(&mut index.variants, &entry.base_key, &key);
                 removed.push(entry);
             }
@@ -67,7 +109,7 @@ pub(in crate::cache) async fn purge_zone_entries(
         zone.record_purge(removed.len());
         let _io_guard = zone.io_lock.lock().await;
         for entry in &removed {
-            let paths = cache_paths(&zone.config.path, &entry.hash);
+            let paths = cache_paths_for_zone(zone.config.as_ref(), &entry.hash);
             let _ = fs::remove_file(paths.metadata).await;
             let _ = fs::remove_file(paths.body).await;
         }
@@ -96,6 +138,7 @@ pub(in crate::cache) async fn update_index_after_store(
         {
             index.current_size_bytes =
                 index.current_size_bytes.saturating_sub(removed.body_size_bytes);
+            index.admission_counts.remove(&replaced_key);
             remove_variant_key(&mut index.variants, &removed.base_key, &replaced_key);
             if removed.hash != entry.hash {
                 removed_hashes.push(removed.hash);
@@ -106,6 +149,7 @@ pub(in crate::cache) async fn update_index_after_store(
             if let Some(removed) = index.entries.remove(&incompatible_key) {
                 index.current_size_bytes =
                     index.current_size_bytes.saturating_sub(removed.body_size_bytes);
+                index.admission_counts.remove(&incompatible_key);
                 remove_variant_key(&mut index.variants, &removed.base_key, &incompatible_key);
                 if removed.hash != entry.hash {
                     removed_hashes.push(removed.hash);
@@ -116,16 +160,19 @@ pub(in crate::cache) async fn update_index_after_store(
         if let Some(existing) = index.entries.insert(key.clone(), entry.clone()) {
             index.current_size_bytes =
                 index.current_size_bytes.saturating_sub(existing.body_size_bytes);
+            index.admission_counts.remove(&key);
             remove_variant_key(&mut index.variants, &existing.base_key, &key);
             if existing.hash != entry.hash {
                 removed_hashes.push(existing.hash);
             }
         }
+        index.admission_counts.remove(&key);
         add_variant_key(&mut index.variants, entry.base_key.clone(), key);
         index.current_size_bytes = index.current_size_bytes.saturating_add(entry.body_size_bytes);
         for (evicted_key, evicted_entry) in
             eviction_candidates(&mut index, zone.config.max_size_bytes)
         {
+            index.admission_counts.remove(&evicted_key);
             remove_variant_key(&mut index.variants, &evicted_entry.base_key, &evicted_key);
             if evicted_entry.hash != entry.hash {
                 removed_hashes.push(evicted_entry.hash);
@@ -139,7 +186,7 @@ pub(in crate::cache) async fn update_index_after_store(
         zone.record_evictions(eviction_count);
     }
     for hash in removed_hashes {
-        let paths = cache_paths(&zone.config.path, &hash);
+        let paths = cache_paths_for_zone(zone.config.as_ref(), &hash);
         let _ = fs::remove_file(paths.metadata).await;
         let _ = fs::remove_file(paths.body).await;
     }
@@ -169,6 +216,7 @@ pub(in crate::cache) fn eviction_candidates(
         if index.entries.remove(&key).is_some() {
             index.current_size_bytes =
                 index.current_size_bytes.saturating_sub(entry.body_size_bytes);
+            index.admission_counts.remove(&key);
             evicted.push((key, entry));
         }
     }
@@ -181,6 +229,7 @@ pub(in crate::cache) fn remove_index_entry(zone: &CacheZoneRuntime, key: &str) {
         index.current_size_bytes = index.current_size_bytes.saturating_sub(entry.body_size_bytes);
         remove_variant_key(&mut index.variants, &entry.base_key, key);
     }
+    index.admission_counts.remove(key);
     zone.notify_changed();
 }
 
@@ -188,6 +237,29 @@ pub(in crate::cache) fn lock_index(
     mutex: &Mutex<CacheIndex>,
 ) -> std::sync::MutexGuard<'_, CacheIndex> {
     mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+pub(in crate::cache) fn record_cache_admission_attempt(
+    zone: &CacheZoneRuntime,
+    key: &str,
+    min_uses: u64,
+    cached_entry_exists: bool,
+) -> bool {
+    if cached_entry_exists || min_uses <= 1 {
+        let mut index = lock_index(&zone.index);
+        index.admission_counts.remove(key);
+        return true;
+    }
+
+    let mut index = lock_index(&zone.index);
+    let uses = index.admission_counts.entry(key.to_string()).or_insert(0);
+    *uses = uses.saturating_add(1);
+    if *uses >= min_uses {
+        index.admission_counts.remove(key);
+        true
+    } else {
+        false
+    }
 }
 
 fn add_variant_key(variants: &mut HashMap<String, Vec<String>>, base_key: String, key: String) {

--- a/crates/rginx-http/src/cache/store/maintenance.rs
+++ b/crates/rginx-http/src/cache/store/maintenance.rs
@@ -15,61 +15,53 @@ pub(in crate::cache) async fn cleanup_inactive_entries_in_zone(zone: &Arc<CacheZ
 
     let inactive_ms = duration_to_ms(zone.config.inactive);
     let batch_size = zone.config.manager_batch_entries.max(1);
+    let inactive_keys = {
+        let index = lock_index(&zone.index);
+        let mut keys = index
+            .entries
+            .iter()
+            .filter_map(|(key, entry)| {
+                (now.saturating_sub(entry.last_access_unix_ms) > inactive_ms)
+                    .then_some((key.clone(), entry.last_access_unix_ms))
+            })
+            .collect::<Vec<_>>();
+        keys.sort_by_key(|(_, last_access)| *last_access);
+        keys.into_iter().map(|(key, _)| key).collect::<Vec<_>>()
+    };
+    if inactive_keys.is_empty() {
+        return;
+    }
+
     let mut total_removed = 0usize;
     let mut changed = false;
-
-    loop {
+    let mut batches = inactive_keys.chunks(batch_size).peekable();
+    while let Some(batch) = batches.next() {
         let removed = {
             let mut index = lock_index(&zone.index);
-            let mut keys_to_remove = index
-                .entries
-                .iter()
-                .filter_map(|(key, entry)| {
-                    (now.saturating_sub(entry.last_access_unix_ms) > inactive_ms)
-                        .then_some((key.clone(), entry.last_access_unix_ms))
-                })
-                .collect::<Vec<_>>();
-            keys_to_remove.sort_by_key(|(_, last_access)| *last_access);
-            let keys_to_remove =
-                keys_to_remove.into_iter().take(batch_size).map(|(key, _)| key).collect::<Vec<_>>();
             let mut removed = Vec::new();
-            for key in keys_to_remove {
-                if let Some(entry) = index.entries.remove(&key) {
+            for key in batch {
+                if let Some(entry) = index.entries.remove(key) {
                     index.current_size_bytes =
                         index.current_size_bytes.saturating_sub(entry.body_size_bytes);
-                    index.admission_counts.remove(&key);
-                    remove_variant_key(&mut index.variants, &entry.base_key, &key);
+                    index.admission_counts.remove(key);
+                    remove_variant_key(&mut index.variants, &entry.base_key, key);
                     removed.push(entry);
                 }
             }
             removed
         };
-        if removed.is_empty() {
-            break;
+        if !removed.is_empty() {
+            changed = true;
+            total_removed += removed.len();
+            let io_guard = zone.io_lock.lock().await;
+            for entry in &removed {
+                let paths = cache_paths_for_zone(zone.config.as_ref(), &entry.hash);
+                let _ = fs::remove_file(paths.metadata).await;
+                let _ = fs::remove_file(paths.body).await;
+            }
+            drop(io_guard);
         }
-        changed = true;
-        total_removed += removed.len();
-        let io_guard = zone.io_lock.lock().await;
-        for entry in &removed {
-            let paths = cache_paths_for_zone(zone.config.as_ref(), &entry.hash);
-            let _ = fs::remove_file(paths.metadata).await;
-            let _ = fs::remove_file(paths.body).await;
-        }
-        drop(io_guard);
-        if removed.len() < batch_size {
-            break;
-        }
-        let has_more_inactive = {
-            let index = lock_index(&zone.index);
-            index
-                .entries
-                .values()
-                .any(|entry| now.saturating_sub(entry.last_access_unix_ms) > inactive_ms)
-        };
-        if !has_more_inactive {
-            break;
-        }
-        if !zone.config.manager_sleep.is_zero() {
+        if batches.peek().is_some() && !zone.config.manager_sleep.is_zero() {
             tokio::time::sleep(zone.config.manager_sleep).await;
         }
     }
@@ -160,7 +152,6 @@ pub(in crate::cache) async fn update_index_after_store(
         if let Some(existing) = index.entries.insert(key.clone(), entry.clone()) {
             index.current_size_bytes =
                 index.current_size_bytes.saturating_sub(existing.body_size_bytes);
-            index.admission_counts.remove(&key);
             remove_variant_key(&mut index.variants, &existing.base_key, &key);
             if existing.hash != entry.hash {
                 removed_hashes.push(existing.hash);
@@ -243,15 +234,13 @@ pub(in crate::cache) fn record_cache_admission_attempt(
     zone: &CacheZoneRuntime,
     key: &str,
     min_uses: u64,
-    cached_entry_exists: bool,
 ) -> bool {
-    if cached_entry_exists || min_uses <= 1 {
-        let mut index = lock_index(&zone.index);
+    let mut index = lock_index(&zone.index);
+    if min_uses <= 1 || index.entries.contains_key(key) {
         index.admission_counts.remove(key);
         return true;
     }
 
-    let mut index = lock_index(&zone.index);
     let uses = index.admission_counts.entry(key.to_string()).or_insert(0);
     *uses = uses.saturating_add(1);
     if *uses >= min_uses {

--- a/crates/rginx-http/src/cache/tests/lookup/keys.rs
+++ b/crates/rginx-http/src/cache/tests/lookup/keys.rs
@@ -230,3 +230,34 @@ fn cache_key_includes_range_when_enabled() {
         "https:example.com:/video.mp4|range:0-99"
     );
 }
+
+#[test]
+fn multiple_range_headers_bypass_cache_when_range_caching_is_enabled() {
+    let policy = RouteCachePolicy {
+        zone: "default".to_string(),
+        methods: vec![Method::GET],
+        statuses: vec![StatusCode::OK],
+        ttl_by_status: Vec::new(),
+        key: rginx_core::CacheKeyTemplate::parse("{uri}").expect("key should parse"),
+        cache_bypass: None,
+        no_cache: None,
+        stale_if_error: None,
+        use_stale: Vec::new(),
+        background_update: false,
+        lock_timeout: Duration::from_secs(5),
+        lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Cache,
+    };
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/video.mp4")
+        .header(http::header::RANGE, "bytes=0-99")
+        .header(http::header::RANGE, "bytes=100-199")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    let request = CacheRequest::from_request(&request);
+
+    assert!(cache_request_bypass(&request, &policy));
+}

--- a/crates/rginx-http/src/cache/tests/lookup/keys.rs
+++ b/crates/rginx-http/src/cache/tests/lookup/keys.rs
@@ -17,6 +17,9 @@ fn cache_key_template_renders_request_parts() {
         background_update: false,
         lock_timeout: Duration::from_secs(5),
         lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
     };
     let request = Request::builder()
         .method(Method::GET)
@@ -47,6 +50,9 @@ fn cache_key_includes_all_accept_encoding_header_values() {
         background_update: false,
         lock_timeout: Duration::from_secs(5),
         lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
     };
     let request = Request::builder()
         .method(Method::GET)
@@ -81,6 +87,9 @@ fn cache_key_template_renders_header_query_and_cookie_variables() {
         background_update: false,
         lock_timeout: Duration::from_secs(5),
         lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
     };
     let request = Request::builder()
         .method(Method::GET)
@@ -111,6 +120,9 @@ fn authorization_request_bypasses_cache() {
         background_update: false,
         lock_timeout: Duration::from_secs(5),
         lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
     };
     let request = Request::builder()
         .method(Method::GET)
@@ -140,6 +152,9 @@ fn configured_header_bypasses_cache() {
         background_update: false,
         lock_timeout: Duration::from_secs(5),
         lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
     };
     let request = Request::builder()
         .method(Method::GET)
@@ -150,4 +165,68 @@ fn configured_header_bypasses_cache() {
     let request = CacheRequest::from_request(&request);
 
     assert!(cache_request_bypass(&request, &policy));
+}
+
+#[test]
+fn range_request_bypasses_cache_by_default() {
+    let policy = RouteCachePolicy {
+        zone: "default".to_string(),
+        methods: vec![Method::GET],
+        statuses: vec![StatusCode::OK],
+        ttl_by_status: Vec::new(),
+        key: rginx_core::CacheKeyTemplate::parse("{uri}").expect("key should parse"),
+        cache_bypass: None,
+        no_cache: None,
+        stale_if_error: None,
+        use_stale: Vec::new(),
+        background_update: false,
+        lock_timeout: Duration::from_secs(5),
+        lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
+    };
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/video.mp4")
+        .header(http::header::RANGE, "bytes=0-99")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    let request = CacheRequest::from_request(&request);
+
+    assert!(cache_request_bypass(&request, &policy));
+}
+
+#[test]
+fn cache_key_includes_range_when_enabled() {
+    let policy = RouteCachePolicy {
+        zone: "default".to_string(),
+        methods: vec![Method::GET],
+        statuses: vec![StatusCode::OK],
+        ttl_by_status: Vec::new(),
+        key: rginx_core::CacheKeyTemplate::parse("{scheme}:{host}:{uri}")
+            .expect("key should parse"),
+        cache_bypass: None,
+        no_cache: None,
+        stale_if_error: None,
+        use_stale: Vec::new(),
+        background_update: false,
+        lock_timeout: Duration::from_secs(5),
+        lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Cache,
+    };
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/video.mp4")
+        .header("host", "example.com")
+        .header(http::header::RANGE, "bytes=0-99")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+
+    assert_eq!(
+        render_cache_key(request.method(), request.uri(), request.headers(), "https", &policy),
+        "https:example.com:/video.mp4|range:0-99"
+    );
 }

--- a/crates/rginx-http/src/cache/tests/mod.rs
+++ b/crates/rginx-http/src/cache/tests/mod.rs
@@ -14,6 +14,7 @@ mod lookup;
 mod notifications;
 mod policy;
 mod storage;
+mod storage_p1;
 mod storage_regressions;
 
 fn test_zone(path: PathBuf, max_entry_bytes: usize) -> Arc<CacheZoneRuntime> {
@@ -33,11 +34,18 @@ fn test_zone_with_notifier(
             inactive: Duration::from_secs(60),
             default_ttl: Duration::from_secs(60),
             max_entry_bytes,
+            path_levels: vec![2],
+            loader_batch_entries: 100,
+            loader_sleep: Duration::ZERO,
+            manager_batch_entries: 100,
+            manager_sleep: Duration::ZERO,
+            inactive_cleanup_interval: Duration::from_secs(60),
         }),
         index: Mutex::new(CacheIndex::default()),
         io_lock: AsyncMutex::new(()),
         fill_locks: Arc::new(Mutex::new(HashMap::new())),
         fill_lock_generation: AtomicU64::new(0),
+        last_inactive_cleanup_unix_ms: AtomicU64::new(0),
         stats: CacheZoneStats::default(),
         change_notifier,
     })
@@ -79,6 +87,9 @@ fn test_store_context(zone: Arc<CacheZoneRuntime>, key: &str) -> CacheStoreConte
             background_update: false,
             lock_timeout: Duration::from_secs(5),
             lock_age: Duration::from_secs(5),
+            min_uses: 1,
+            ignore_headers: Vec::new(),
+            range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
         },
         request: CacheRequest {
             method: Method::GET,
@@ -119,6 +130,9 @@ fn test_policy() -> RouteCachePolicy {
         background_update: false,
         lock_timeout: Duration::from_secs(5),
         lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
     }
 }
 

--- a/crates/rginx-http/src/cache/tests/storage_p1.rs
+++ b/crates/rginx-http/src/cache/tests/storage_p1.rs
@@ -1,0 +1,277 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
+
+use bytes::Bytes;
+use http::header::{CACHE_CONTROL, CONTENT_RANGE, SET_COOKIE};
+use http::{Method, Request, Response, StatusCode};
+use http_body_util::BodyExt;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::handler::full_body;
+
+use super::*;
+
+#[tokio::test]
+async fn cache_manager_requires_min_uses_before_storing() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let mut policy = test_policy();
+    policy.min_uses = 2;
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/min-uses")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+
+    let first_context =
+        match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+            CacheLookup::Miss(context) => *context,
+            _ => panic!("first request should miss"),
+        };
+    let first_response = Response::builder()
+        .status(StatusCode::OK)
+        .header(CACHE_CONTROL, "max-age=60")
+        .body(full_body("first"))
+        .expect("response should build");
+    let _ = manager.store_response(first_context, first_response).await;
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Miss(context) => {
+            let second_response = Response::builder()
+                .status(StatusCode::OK)
+                .header(CACHE_CONTROL, "max-age=60")
+                .body(full_body("second"))
+                .expect("response should build");
+            let _ = manager.store_response(*context, second_response).await;
+        }
+        _ => panic!("second request should still miss before admission threshold is met"),
+    }
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Hit(response) => {
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body.as_ref(), b"second");
+        }
+        _ => panic!("response should be cached after min_uses is reached"),
+    }
+}
+
+#[tokio::test]
+async fn cache_manager_can_ignore_cache_control_set_cookie_and_vary() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let mut policy = test_policy();
+    policy.ignore_headers = vec![
+        rginx_core::CacheIgnoreHeader::CacheControl,
+        rginx_core::CacheIgnoreHeader::SetCookie,
+        rginx_core::CacheIgnoreHeader::Vary,
+    ];
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/ignore-headers")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    let context = match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await
+    {
+        CacheLookup::Miss(context) => *context,
+        _ => panic!("request should miss before storing"),
+    };
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(CACHE_CONTROL, "no-store")
+        .header(SET_COOKIE, "sid=1")
+        .header("vary", "*")
+        .body(full_body("shared"))
+        .expect("response should build");
+    let _ = manager.store_response(context, response).await;
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Hit(response) => {
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body.as_ref(), b"shared");
+        }
+        _ => panic!("ignored cache headers should not block storage"),
+    }
+}
+
+#[tokio::test]
+async fn cache_manager_can_ignore_x_accel_expires() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let mut policy = test_policy();
+    policy.ignore_headers = vec![rginx_core::CacheIgnoreHeader::XAccelExpires];
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/ignore-x-accel")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    let context = match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await
+    {
+        CacheLookup::Miss(context) => *context,
+        _ => panic!("request should miss before storing"),
+    };
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header("x-accel-expires", "0")
+        .body(full_body("cached anyway"))
+        .expect("response should build");
+    let _ = manager.store_response(context, response).await;
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Hit(response) => {
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body.as_ref(), b"cached anyway");
+        }
+        _ => panic!("ignored x-accel-expires should fall back to default ttl"),
+    }
+}
+
+#[tokio::test]
+async fn cache_manager_caches_configured_single_range_response() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let mut policy = test_policy();
+    policy.range_requests = rginx_core::CacheRangeRequestPolicy::Cache;
+    let range_request = Request::builder()
+        .method(Method::GET)
+        .uri("/range")
+        .header("host", "example.com")
+        .header(http::header::RANGE, "bytes=0-3")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    let context =
+        match manager.lookup(CacheRequest::from_request(&range_request), "https", &policy).await {
+            CacheLookup::Miss(context) => *context,
+            _ => panic!("range request should miss before storing"),
+        };
+
+    let response = Response::builder()
+        .status(StatusCode::PARTIAL_CONTENT)
+        .header(CONTENT_RANGE, "bytes 0-3/10")
+        .header(CACHE_CONTROL, "max-age=60")
+        .body(full_body("data"))
+        .expect("response should build");
+    let _ = manager.store_response(context, response).await;
+
+    match manager.lookup(CacheRequest::from_request(&range_request), "https", &policy).await {
+        CacheLookup::Hit(response) => {
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body.as_ref(), b"data");
+        }
+        _ => panic!("same range request should hit cached 206 response"),
+    }
+
+    let full_request = Request::builder()
+        .method(Method::GET)
+        .uri("/range")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+    match manager.lookup(CacheRequest::from_request(&full_request), "https", &policy).await {
+        CacheLookup::Miss(_) => {}
+        _ => panic!("full request must not reuse range-specific cache entry"),
+    }
+}
+
+#[test]
+fn load_index_from_disk_supports_nested_path_levels() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let zone = CacheZone {
+        name: "default".to_string(),
+        path: temp.path().to_path_buf(),
+        max_size_bytes: Some(1024 * 1024),
+        inactive: Duration::from_secs(60),
+        default_ttl: Duration::from_secs(60),
+        max_entry_bytes: 1024,
+        path_levels: vec![1, 2],
+        loader_batch_entries: 100,
+        loader_sleep: Duration::ZERO,
+        manager_batch_entries: 100,
+        manager_sleep: Duration::ZERO,
+        inactive_cleanup_interval: Duration::from_secs(60),
+    };
+    let key = "https:example.com:/nested";
+    let hash = cache_key_hash(key);
+    let paths = cache_paths_for_zone(&zone, &hash);
+    let now = unix_time_ms(SystemTime::now());
+    std::fs::create_dir_all(&paths.dir).expect("cache dir should be created");
+    std::fs::write(
+        &paths.metadata,
+        serde_json::to_vec(&cache_metadata(
+            key.to_string(),
+            StatusCode::OK,
+            &http::HeaderMap::new(),
+            test_metadata_input(key, now.saturating_sub(2_000), now.saturating_add(60_000), 6),
+        ))
+        .expect("metadata should serialize"),
+    )
+    .expect("metadata should be written");
+    std::fs::write(&paths.body, b"cached").expect("body should be written");
+
+    let index = load_index_from_disk(&zone).expect("index should load");
+
+    assert!(index.entries.contains_key(key));
+    assert!(paths.metadata.exists());
+    assert!(paths.body.exists());
+}
+
+#[tokio::test]
+async fn cleanup_inactive_entries_honors_manager_batch_entries() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager_sleep = Duration::from_millis(20);
+    let zone = Arc::new(CacheZoneRuntime {
+        config: Arc::new(CacheZone {
+            name: "default".to_string(),
+            path: temp.path().to_path_buf(),
+            max_size_bytes: Some(1024 * 1024),
+            inactive: Duration::from_secs(1),
+            default_ttl: Duration::from_secs(60),
+            max_entry_bytes: 1024,
+            path_levels: vec![2],
+            loader_batch_entries: 100,
+            loader_sleep: Duration::ZERO,
+            manager_batch_entries: 1,
+            manager_sleep,
+            inactive_cleanup_interval: Duration::ZERO,
+        }),
+        index: Mutex::new(CacheIndex::default()),
+        io_lock: AsyncMutex::new(()),
+        fill_locks: Arc::new(Mutex::new(HashMap::new())),
+        fill_lock_generation: AtomicU64::new(0),
+        last_inactive_cleanup_unix_ms: AtomicU64::new(0),
+        stats: CacheZoneStats::default(),
+        change_notifier: None,
+    });
+    let now = unix_time_ms(SystemTime::now());
+
+    for (suffix, body) in [("one", b"one".as_slice()), ("two", b"two".as_slice())] {
+        let key = format!("https:example.com:/{suffix}");
+        let hash = cache_key_hash(&key);
+        let metadata = cache_metadata(
+            key.clone(),
+            StatusCode::OK,
+            &http::HeaderMap::new(),
+            test_metadata_input(&key, now.saturating_sub(5_000), now.saturating_sub(2_000), 3),
+        );
+        let paths = cache_paths_for_zone(zone.config.as_ref(), &hash);
+        write_cache_entry(&paths, &metadata, body).await.expect("entry should be written");
+        let mut index = lock_index(&zone.index);
+        index.entries.insert(
+            key.clone(),
+            test_index_entry(&key, hash, 3, now.saturating_sub(2_000), now.saturating_sub(5_000)),
+        );
+        index.current_size_bytes += 3;
+    }
+
+    let started = Instant::now();
+    cleanup_inactive_entries_in_zone(&zone).await;
+    assert!(lock_index(&zone.index).entries.is_empty());
+    assert!(started.elapsed() >= manager_sleep, "cleanup should pause between batches");
+}

--- a/crates/rginx-http/src/cache/tests/storage_p1.rs
+++ b/crates/rginx-http/src/cache/tests/storage_p1.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 
 use bytes::Bytes;
-use http::header::{CACHE_CONTROL, CONTENT_RANGE, SET_COOKIE};
+use http::header::{ACCEPT_LANGUAGE, CACHE_CONTROL, CONTENT_RANGE, SET_COOKIE};
 use http::{Method, Request, Response, StatusCode};
 use http_body_util::BodyExt;
 use tokio::sync::Mutex as AsyncMutex;
@@ -274,4 +274,58 @@ async fn cleanup_inactive_entries_honors_manager_batch_entries() {
     cleanup_inactive_entries_in_zone(&zone).await;
     assert!(lock_index(&zone.index).entries.is_empty());
     assert!(started.elapsed() >= manager_sleep, "cleanup should pause between batches");
+}
+
+#[tokio::test]
+async fn rebucketed_response_still_respects_min_uses_for_new_final_key() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let zone = manager.zones.get("default").expect("default zone should exist").clone();
+    let base_key = "https:example.com:/rebucket";
+    let hash = cache_key_hash(base_key);
+    let now = unix_time_ms(SystemTime::now());
+    let metadata = cache_metadata(
+        base_key.to_string(),
+        StatusCode::OK,
+        &http::HeaderMap::new(),
+        test_metadata_input(base_key, now.saturating_sub(5_000), now.saturating_sub(1_000), 6),
+    );
+    let paths = cache_paths_for_zone(zone.config.as_ref(), &hash);
+    write_cache_entry(&paths, &metadata, b"cached").await.expect("entry should be written");
+    let cached_entry =
+        test_index_entry(base_key, hash, 6, now.saturating_sub(1_000), now.saturating_sub(5_000));
+    {
+        let mut index = lock_index(&zone.index);
+        index.entries.insert(base_key.to_string(), cached_entry.clone());
+        index.current_size_bytes = 6;
+    }
+
+    let expected_final_key = cache_variant_key(
+        base_key,
+        &[CachedVaryHeaderValue { name: ACCEPT_LANGUAGE, value: Some("zh-CN".to_string()) }],
+    );
+
+    for attempt in 1..=2 {
+        let mut context = test_store_context(zone.clone(), base_key);
+        context.policy.min_uses = 2;
+        context.request.uri = http::Uri::from_static("/rebucket");
+        context.request.headers.insert(ACCEPT_LANGUAGE, "zh-CN".parse().unwrap());
+        context.cached_entry = Some(cached_entry.clone());
+        context.key = base_key.to_string();
+        context.base_key = base_key.to_string();
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .header(CACHE_CONTROL, "max-age=60")
+            .header("vary", "accept-language")
+            .body(full_body("rebucketed"))
+            .expect("response should build");
+        let _ = manager.store_response(context, response).await;
+
+        let has_final_key = lock_index(&zone.index).entries.contains_key(&expected_final_key);
+        assert_eq!(
+            has_final_key,
+            attempt == 2,
+            "rebucketed key should only be admitted after min_uses is reached"
+        );
+    }
 }

--- a/crates/rginx-http/src/proxy/tests/cache.rs
+++ b/crates/rginx-http/src/proxy/tests/cache.rs
@@ -15,6 +15,9 @@ fn cache_policy() -> rginx_core::RouteCachePolicy {
         background_update: false,
         lock_timeout: Duration::from_secs(5),
         lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
     }
 }
 
@@ -86,6 +89,12 @@ async fn forward_request_uses_route_cache_for_miss_then_hit() {
             inactive: Duration::from_secs(60),
             default_ttl: Duration::from_secs(60),
             max_entry_bytes: 1024,
+            path_levels: vec![2],
+            loader_batch_entries: 100,
+            loader_sleep: Duration::ZERO,
+            manager_batch_entries: 100,
+            manager_sleep: Duration::ZERO,
+            inactive_cleanup_interval: Duration::from_secs(60),
         }),
     );
     let state = crate::state::SharedState::from_config(snapshot).expect("state should build");
@@ -144,6 +153,12 @@ async fn forward_request_marks_authorization_request_as_cache_bypass() {
             inactive: Duration::from_secs(60),
             default_ttl: Duration::from_secs(60),
             max_entry_bytes: 1024,
+            path_levels: vec![2],
+            loader_batch_entries: 100,
+            loader_sleep: Duration::ZERO,
+            manager_batch_entries: 100,
+            manager_sleep: Duration::ZERO,
+            inactive_cleanup_interval: Duration::from_secs(60),
         }),
     );
     let state = crate::state::SharedState::from_config(snapshot).expect("state should build");

--- a/crates/rginx-http/src/state/tests/snapshots.rs
+++ b/crates/rginx-http/src/state/tests/snapshots.rs
@@ -137,24 +137,7 @@ async fn cache_snapshot_and_delta_report_zone_changes() {
     let since_version = shared.current_snapshot_version();
 
     let active = shared.snapshot().await;
-    let policy = rginx_core::RouteCachePolicy {
-        zone: "default".to_string(),
-        methods: vec![Method::GET, Method::HEAD],
-        statuses: vec![StatusCode::OK],
-        ttl_by_status: Vec::new(),
-        key: rginx_core::CacheKeyTemplate::parse("{scheme}:{host}:{uri}")
-            .expect("cache key should parse"),
-        cache_bypass: None,
-        no_cache: None,
-        stale_if_error: None,
-        use_stale: Vec::new(),
-        background_update: false,
-        lock_timeout: Duration::from_secs(5),
-        lock_age: Duration::from_secs(5),
-        min_uses: 1,
-        ignore_headers: Vec::new(),
-        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
-    };
+    let policy = default_route_cache_policy();
     let request = Request::builder()
         .method(Method::GET)
         .uri("/cached")

--- a/crates/rginx-http/src/state/tests/snapshots.rs
+++ b/crates/rginx-http/src/state/tests/snapshots.rs
@@ -151,6 +151,9 @@ async fn cache_snapshot_and_delta_report_zone_changes() {
         background_update: false,
         lock_timeout: Duration::from_secs(5),
         lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
     };
     let request = Request::builder()
         .method(Method::GET)

--- a/crates/rginx-http/src/state/tests/status.rs
+++ b/crates/rginx-http/src/state/tests/status.rs
@@ -290,6 +290,9 @@ async fn status_snapshot_reports_cache_zone_stats() {
         background_update: false,
         lock_timeout: Duration::from_secs(5),
         lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
     };
     let request = Request::builder()
         .method(Method::GET)

--- a/crates/rginx-http/src/state/tests/status.rs
+++ b/crates/rginx-http/src/state/tests/status.rs
@@ -276,24 +276,7 @@ async fn status_snapshot_reports_cache_zone_stats() {
     .expect("shared state should build");
 
     let active = shared.snapshot().await;
-    let policy = rginx_core::RouteCachePolicy {
-        zone: "default".to_string(),
-        methods: vec![Method::GET, Method::HEAD],
-        statuses: vec![StatusCode::OK],
-        ttl_by_status: Vec::new(),
-        key: rginx_core::CacheKeyTemplate::parse("{scheme}:{host}:{uri}")
-            .expect("cache key should parse"),
-        cache_bypass: None,
-        no_cache: None,
-        stale_if_error: None,
-        use_stale: Vec::new(),
-        background_update: false,
-        lock_timeout: Duration::from_secs(5),
-        lock_age: Duration::from_secs(5),
-        min_uses: 1,
-        ignore_headers: Vec::new(),
-        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
-    };
+    let policy = default_route_cache_policy();
     let request = Request::builder()
         .method(Method::GET)
         .uri("/status-cache")

--- a/crates/rginx-http/src/state/tests/support.rs
+++ b/crates/rginx-http/src/state/tests/support.rs
@@ -149,6 +149,12 @@ pub(crate) fn snapshot_with_cache_zone(listen: &str, path: PathBuf) -> ConfigSna
             inactive: Duration::from_secs(60),
             default_ttl: Duration::from_secs(60),
             max_entry_bytes: 1024,
+            path_levels: vec![2],
+            loader_batch_entries: 100,
+            loader_sleep: Duration::ZERO,
+            manager_batch_entries: 100,
+            manager_sleep: Duration::ZERO,
+            inactive_cleanup_interval: Duration::from_secs(60),
         }),
     );
     snapshot

--- a/crates/rginx-http/src/state/tests/support.rs
+++ b/crates/rginx-http/src/state/tests/support.rs
@@ -159,3 +159,24 @@ pub(crate) fn snapshot_with_cache_zone(listen: &str, path: PathBuf) -> ConfigSna
     );
     snapshot
 }
+
+pub(crate) fn default_route_cache_policy() -> rginx_core::RouteCachePolicy {
+    rginx_core::RouteCachePolicy {
+        zone: "default".to_string(),
+        methods: vec![http::Method::GET, http::Method::HEAD],
+        statuses: vec![StatusCode::OK],
+        ttl_by_status: Vec::new(),
+        key: rginx_core::CacheKeyTemplate::parse("{scheme}:{host}:{uri}")
+            .expect("cache key should parse"),
+        cache_bypass: None,
+        no_cache: None,
+        stale_if_error: None,
+        use_stale: Vec::new(),
+        background_update: false,
+        lock_timeout: Duration::from_secs(5),
+        lock_age: Duration::from_secs(5),
+        min_uses: 1,
+        ignore_headers: Vec::new(),
+        range_requests: rginx_core::CacheRangeRequestPolicy::Bypass,
+    }
+}

--- a/crates/rginx-runtime/src/cache.rs
+++ b/crates/rginx-runtime/src/cache.rs
@@ -4,10 +4,10 @@ use rginx_http::SharedState;
 use tokio::sync::watch;
 use tokio::time::MissedTickBehavior;
 
-const CACHE_INACTIVE_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+const CACHE_INACTIVE_CLEANUP_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 pub async fn run(state: SharedState, mut shutdown: watch::Receiver<bool>) {
-    let mut interval = tokio::time::interval(CACHE_INACTIVE_CLEANUP_INTERVAL);
+    let mut interval = tokio::time::interval(CACHE_INACTIVE_CLEANUP_POLL_INTERVAL);
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
     interval.tick().await;
 


### PR DESCRIPTION
## Summary
- add P1 cache config/runtime support for min-uses admission, ignore-header overrides, exact bounded single-range caching, and cache loader/manager/path tunables
- extend cache tests and fixtures, and split helper modules so the modularization gate stays green
- update CACHE_SUPPORT_PLAN.md to mark P1 complete and document the delivered range-caching boundary

## Testing
- cargo fmt --all
- cargo test -q -p rginx-config --lib
- cargo test -q -p rginx-http --lib
- cargo test -q --workspace
- ./scripts/run-clippy-gate.sh
- python3 ./scripts/run-modularization-gate.py