### PR TITLE
Add cache benchmarks, stress tests, and fault injection

### DIFF
--- a/crates/rginx-app/tests/reload/cache.rs
+++ b/crates/rginx-app/tests/reload/cache.rs
@@ -2,7 +2,8 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use super::*;
 
@@ -43,6 +44,95 @@ fn reload_preserves_cache_entries_when_zone_path_is_reused() {
     )
     .expect("third request should succeed");
     assert_eq!(response_header_value(&third, "x-cache").as_deref(), Some("HIT"));
+    assert_eq!(upstream_hits.load(Ordering::Relaxed), 1);
+
+    server.shutdown_and_wait(Duration::from_secs(5));
+}
+
+#[test]
+#[ignore = "cache stress suite; run via scripts/run-cache-stress.sh"]
+fn reload_keeps_hot_cache_hits_available_under_concurrent_traffic() {
+    let _guard = test_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let listen_addr = reserve_loopback_addr();
+    let (upstream_addr, upstream_hits) = spawn_counting_response_server("reload cache stress\n");
+    let mut server = TestServer::spawn_with_setup("rginx-reload-cache-stress", |temp_dir| {
+        cached_proxy_config(listen_addr, upstream_addr, &temp_dir.join("cache"), 3)
+    });
+
+    server.wait_for_http_ready(listen_addr, Duration::from_secs(5));
+
+    let request =
+        format!("GET /api/demo HTTP/1.1\r\nHost: {listen_addr}\r\nConnection: close\r\n\r\n");
+    let first = send_raw_request(listen_addr, &request).expect("warm miss should succeed");
+    assert_eq!(response_header_value(&first, "x-cache").as_deref(), Some("MISS"));
+
+    let second = send_raw_request(listen_addr, &request).expect("warm hit should succeed");
+    assert_eq!(response_header_value(&second, "x-cache").as_deref(), Some("HIT"));
+    assert_eq!(upstream_hits.load(Ordering::Relaxed), 1);
+
+    let failures = Arc::new(Mutex::new(Vec::new()));
+    let stop = Arc::new(AtomicBool::new(false));
+    let workers = (0..4)
+        .map(|worker_id| {
+            let request = request.clone();
+            let failures = failures.clone();
+            let stop = stop.clone();
+            std::thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    match send_raw_request(listen_addr, &request) {
+                        Ok(response) => {
+                            let status = response
+                                .lines()
+                                .next()
+                                .and_then(|line| line.split_whitespace().nth(1))
+                                .unwrap_or("<missing>");
+                            let x_cache = response_header_value(&response, "x-cache");
+                            if status != "200" || x_cache.as_deref() != Some("HIT") {
+                                failures
+                                    .lock()
+                                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                                    .push(format!(
+                                        "worker {worker_id} observed status={status} x-cache={x_cache:?}"
+                                    ));
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            failures
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                                .push(format!("worker {worker_id} request failed: {error}"));
+                            break;
+                        }
+                    }
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let cache_dir = server.temp_dir().join("cache");
+    for (revision, timeout_secs) in [4_u64, 5, 6, 7].into_iter().enumerate() {
+        server.write_config(cached_proxy_config(
+            listen_addr,
+            upstream_addr,
+            &cache_dir,
+            timeout_secs,
+        ));
+        server.send_signal(libc::SIGHUP);
+        server.wait_for_status_output(
+            |output| output.contains(&format!("revision={}", revision + 1)),
+            Duration::from_secs(5),
+        );
+        std::thread::sleep(Duration::from_millis(150));
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    for worker in workers {
+        worker.join().expect("cache stress worker should join cleanly");
+    }
+
+    let failures = failures.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(failures.is_empty(), "concurrent reload cache traffic should stay hot: {failures:?}");
     assert_eq!(upstream_hits.load(Ordering::Relaxed), 1);
 
     server.shutdown_and_wait(Duration::from_secs(5));

--- a/crates/rginx-http/src/cache/tests/lookup/recovery.rs
+++ b/crates/rginx-http/src/cache/tests/lookup/recovery.rs
@@ -196,6 +196,59 @@ async fn cache_manager_serves_head_hit_without_reading_body_file() {
     }
 }
 
+#[tokio::test]
+async fn cache_manager_treats_missing_body_file_as_miss_and_cleans_index() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = test_manager(temp.path().to_path_buf(), 1024);
+    let policy = test_policy();
+    let key = "https:example.com:/missing-body";
+    let hash = cache_key_hash(key);
+    let paths = cache_paths(temp.path(), &hash);
+    let now = unix_time_ms(SystemTime::now());
+    let metadata = cache_metadata(
+        key.to_string(),
+        StatusCode::OK,
+        &http::HeaderMap::new(),
+        test_metadata_input(key, now.saturating_sub(2_000), now.saturating_add(60_000), 6),
+    );
+    write_cache_entry(&paths, &metadata, b"cached").await.expect("entry should be written");
+
+    let zone = manager.zones.get("default").expect("zone should exist");
+    {
+        let mut index = lock_index(&zone.index);
+        index.insert_entry(
+            key.to_string(),
+            test_index_entry(key, hash, 6, now.saturating_add(60_000), now),
+        );
+        index.current_size_bytes = 6;
+    }
+
+    tokio::fs::remove_file(&paths.body).await.expect("body file should be removable");
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/missing-body")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+
+    match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Miss(_) => {}
+        CacheLookup::Hit(_) => panic!("missing body file must not be served"),
+        CacheLookup::Updating(_, _) => {
+            panic!("missing body file must not trigger background update")
+        }
+        CacheLookup::Bypass(status) => panic!("cacheable request should not bypass: {status:?}"),
+    }
+
+    let index = lock_index(&zone.index);
+    assert!(!index.entries.contains_key(key));
+    assert_eq!(index.current_size_bytes, 0);
+    drop(index);
+    assert!(!paths.metadata.exists());
+    assert!(!paths.body.exists());
+}
+
 #[test]
 fn should_refresh_from_not_modified_requires_cached_entry() {
     let temp = tempfile::tempdir().expect("cache temp dir should exist");

--- a/crates/rginx-http/src/cache/tests/mod.rs
+++ b/crates/rginx-http/src/cache/tests/mod.rs
@@ -18,6 +18,7 @@ mod storage_p1;
 mod storage_p2;
 mod storage_p3;
 mod storage_regressions;
+mod stress;
 
 fn test_zone(path: PathBuf, max_entry_bytes: usize) -> Arc<CacheZoneRuntime> {
     test_zone_with_notifier(path, max_entry_bytes, None)

--- a/crates/rginx-http/src/cache/tests/storage_p2.rs
+++ b/crates/rginx-http/src/cache/tests/storage_p2.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::Ordering;
 use std::time::SystemTime;
 
 use bytes::Bytes;
@@ -92,6 +93,62 @@ async fn shared_index_sync_shares_admission_counts_between_managers() {
         }
         _ => panic!("shared admission counts should allow the second manager to populate"),
     }
+}
+
+#[tokio::test]
+async fn shared_index_sync_keeps_local_hits_when_shared_metadata_db_is_corrupted() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager_a = test_manager(temp.path().to_path_buf(), 1024);
+    let manager_b = test_manager(temp.path().to_path_buf(), 1024);
+    let policy = test_policy();
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/shared-corrupt")
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("request should build");
+
+    let context =
+        match manager_a.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+            CacheLookup::Miss(context) => *context,
+            _ => panic!("first manager should miss before storing"),
+        };
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(CACHE_CONTROL, "max-age=60")
+        .body(full_body("shared"))
+        .expect("response should build");
+    let _ = manager_a.store_response(context, response).await;
+
+    match manager_b.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Hit(response) => {
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body.as_ref(), b"shared");
+        }
+        _ => panic!("second manager should sync the shared cache entry before corruption"),
+    }
+
+    let zone = manager_b.zones.get("default").expect("zone should exist");
+    let shared_generation = zone.shared_index_generation.load(Ordering::Relaxed);
+    let shared_path = zone
+        .shared_index_store
+        .as_ref()
+        .expect("shared metadata store should exist")
+        .path()
+        .to_path_buf();
+    std::fs::write(&shared_path, b"corrupt sqlite bytes")
+        .expect("shared metadata db should be corrupted on disk");
+
+    match manager_b.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+        CacheLookup::Hit(response) => {
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body.as_ref(), b"shared");
+        }
+        _ => panic!("corrupt shared metadata must not evict an already-synced local hit"),
+    }
+
+    assert_eq!(zone.shared_index_generation.load(Ordering::Relaxed), shared_generation);
+    assert!(lock_index(&zone.index).entries.contains_key("https:example.com:/shared-corrupt"));
 }
 
 #[tokio::test]

--- a/crates/rginx-http/src/cache/tests/stress.rs
+++ b/crates/rginx-http/src/cache/tests/stress.rs
@@ -1,0 +1,156 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use http::header::CACHE_CONTROL;
+use http::{Method, Request, Response, StatusCode};
+use http_body_util::BodyExt;
+use tokio::task::JoinSet;
+
+use crate::handler::full_body;
+
+use super::*;
+
+const STRESS_KEY_COUNT: usize = 256;
+const STRESS_HIT_ROUNDS: usize = 4;
+const LARGE_BODY_BYTES: usize = 256 * 1024;
+const LARGE_BODY_CONCURRENCY: usize = 48;
+const LARGE_BODY_ROUNDS: usize = 6;
+
+fn stress_request(path: &str) -> Request<crate::handler::HttpBody> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .header("host", "example.com")
+        .body(full_body(Bytes::new()))
+        .expect("stress request should build")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "cache stress suite; run via scripts/run-cache-stress.sh"]
+async fn cache_manager_handles_large_keysets_under_parallel_fill_and_hit_load() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager = Arc::new(test_manager(temp.path().to_path_buf(), 1024 * 1024));
+    let policy = Arc::new(test_policy());
+    let body = Bytes::from_static(b"stress-ok");
+
+    let mut fill_tasks = JoinSet::new();
+    for key_index in 0..STRESS_KEY_COUNT {
+        let manager = manager.clone();
+        let policy = policy.clone();
+        let body = body.clone();
+        fill_tasks.spawn(async move {
+            let path = format!("/stress-fill/{key_index}");
+            let request = stress_request(&path);
+            let context = match manager
+                .lookup(CacheRequest::from_request(&request), "https", &policy)
+                .await
+            {
+                CacheLookup::Miss(context) => *context,
+                CacheLookup::Hit(_) => panic!("unique stress fill key should miss"),
+                CacheLookup::Updating(_, _) => {
+                    panic!("unique stress fill key should not update")
+                }
+                CacheLookup::Bypass(status) => {
+                    panic!("stress fill request should not bypass: {status:?}")
+                }
+            };
+            let response = Response::builder()
+                .status(StatusCode::OK)
+                .header(CACHE_CONTROL, "max-age=60")
+                .body(full_body(body))
+                .expect("stress fill response should build");
+            let stored = manager.store_response(context, response).await;
+            assert_eq!(stored.headers().get(CACHE_STATUS_HEADER).unwrap(), "MISS");
+        });
+    }
+    while let Some(result) = fill_tasks.join_next().await {
+        result.expect("stress fill task should complete");
+    }
+
+    let zone = manager.zones.get("default").expect("zone should exist");
+    assert_eq!(lock_index(&zone.index).entries.len(), STRESS_KEY_COUNT);
+
+    for round in 0..STRESS_HIT_ROUNDS {
+        let mut hit_tasks = JoinSet::new();
+        for key_index in 0..STRESS_KEY_COUNT {
+            let manager = manager.clone();
+            let policy = policy.clone();
+            let body = body.clone();
+            hit_tasks.spawn(async move {
+                let path = format!("/stress-fill/{key_index}");
+                let request = stress_request(&path);
+                match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+                    CacheLookup::Hit(response) => {
+                        assert_eq!(response.headers().get(CACHE_STATUS_HEADER).unwrap(), "HIT");
+                        let hit_body = response.into_body().collect().await.unwrap().to_bytes();
+                        assert_eq!(hit_body.as_ref(), body.as_ref());
+                    }
+                    CacheLookup::Miss(_) => panic!("stress hit round {round} unexpectedly missed"),
+                    CacheLookup::Updating(_, _) => {
+                        panic!("stress hit round {round} unexpectedly updated")
+                    }
+                    CacheLookup::Bypass(status) => {
+                        panic!("stress hit round {round} bypassed cache: {status:?}")
+                    }
+                }
+            });
+        }
+        while let Some(result) = hit_tasks.join_next().await {
+            result.expect("stress hit task should complete");
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "cache stress suite; run via scripts/run-cache-stress.sh"]
+async fn cache_manager_serves_large_cached_body_under_sustained_parallel_hits() {
+    let temp = tempfile::tempdir().expect("cache temp dir should exist");
+    let manager =
+        Arc::new(test_manager(temp.path().to_path_buf(), LARGE_BODY_BYTES.saturating_mul(2)));
+    let policy = Arc::new(test_policy());
+    let body = Bytes::from(vec![b'x'; LARGE_BODY_BYTES]);
+    let request = stress_request("/large-body");
+
+    let context = match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await
+    {
+        CacheLookup::Miss(context) => *context,
+        CacheLookup::Hit(_) => panic!("large body fill should miss"),
+        CacheLookup::Updating(_, _) => panic!("large body fill should not update"),
+        CacheLookup::Bypass(status) => panic!("large body fill should not bypass: {status:?}"),
+    };
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(CACHE_CONTROL, "max-age=60")
+        .body(full_body(body.clone()))
+        .expect("large body response should build");
+    let _ = manager.store_response(context, response).await;
+
+    for _round in 0..LARGE_BODY_ROUNDS {
+        let mut hit_tasks = JoinSet::new();
+        for _ in 0..LARGE_BODY_CONCURRENCY {
+            let manager = manager.clone();
+            let policy = policy.clone();
+            let expected_len = LARGE_BODY_BYTES;
+            hit_tasks.spawn(async move {
+                let request = stress_request("/large-body");
+                match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
+                    CacheLookup::Hit(response) => {
+                        assert_eq!(response.headers().get(CACHE_STATUS_HEADER).unwrap(), "HIT");
+                        let hit_body = response.into_body().collect().await.unwrap().to_bytes();
+                        assert_eq!(hit_body.len(), expected_len);
+                    }
+                    CacheLookup::Miss(_) => panic!("large cached body unexpectedly missed"),
+                    CacheLookup::Updating(_, _) => {
+                        panic!("large cached body unexpectedly updated")
+                    }
+                    CacheLookup::Bypass(status) => {
+                        panic!("large cached body bypassed cache: {status:?}")
+                    }
+                }
+            });
+        }
+        while let Some(result) = hit_tasks.join_next().await {
+            result.expect("large body hit task should complete");
+        }
+    }
+}

--- a/crates/rginx-http/src/cache/tests/stress.rs
+++ b/crates/rginx-http/src/cache/tests/stress.rs
@@ -25,6 +25,18 @@ fn stress_request(path: &str) -> Request<crate::handler::HttpBody> {
         .expect("stress request should build")
 }
 
+async fn response_body_len(response: crate::handler::HttpResponse) -> usize {
+    let mut body = response.into_body();
+    let mut len = 0usize;
+    while let Some(frame) = body.frame().await {
+        let frame = frame.expect("response body frame should be readable");
+        if let Some(data) = frame.data_ref() {
+            len = len.saturating_add(data.len());
+        }
+    }
+    len
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "cache stress suite; run via scripts/run-cache-stress.sh"]
 async fn cache_manager_handles_large_keysets_under_parallel_fill_and_hit_load() {
@@ -136,8 +148,7 @@ async fn cache_manager_serves_large_cached_body_under_sustained_parallel_hits() 
                 match manager.lookup(CacheRequest::from_request(&request), "https", &policy).await {
                     CacheLookup::Hit(response) => {
                         assert_eq!(response.headers().get(CACHE_STATUS_HEADER).unwrap(), "HIT");
-                        let hit_body = response.into_body().collect().await.unwrap().to_bytes();
-                        assert_eq!(hit_body.len(), expected_len);
+                        assert_eq!(response_body_len(response).await, expected_len);
                     }
                     CacheLookup::Miss(_) => panic!("large cached body unexpectedly missed"),
                     CacheLookup::Updating(_, _) => {

--- a/docs/CACHE_ARCHITECTURE_GAPS.md
+++ b/docs/CACHE_ARCHITECTURE_GAPS.md
@@ -46,6 +46,24 @@
   - range cache 对条件化 range 请求的安全边界更明确
   - route 级 stale 控制面覆盖了更多现网常见降级状态
 
+### 已完成：建立第一轮缓存专项 benchmark、压力测试与故障注入体系
+
+该项已于 2026-04-29 完成第一轮落地。
+
+- 当前实现：
+  - 新增 `scripts/run-cache-benchmark.py`，对真实 `rginx` 进程和真实 upstream 路径执行 `fill` / `hit` / `revalidate` / `slice-hit` 专项 benchmark
+  - 新增 `scripts/run-cache-stress.sh`，驱动大 key 数、 大对象持续命中、reload 并发下热点缓存保持的专项 stress / soak 用例
+  - 新增缓存故障注入回归，覆盖 body 文件缺失清理、shared index SQLite 损坏降级、本地索引保活等失败路径
+- 运行入口：
+  - `python3 scripts/run-cache-benchmark.py`
+  - `./scripts/run-cache-stress.sh --iterations 3`
+  - `cargo test -p rginx-http --lib shared_index_sync_keeps_local_hits_when_shared_metadata_db_is_corrupted`
+  - `cargo test -p rginx-http --lib cache_manager_treats_missing_body_file_as_miss_and_cleans_index`
+- 收敛效果：
+  - cache 主路径第一次具备了可重复执行的专项性能基线
+  - 高并发、大 key 数、大对象、reload 并发不再只靠零散功能测试间接覆盖
+  - shared index 损坏和文件缺失这类缓存失败模式现在有了稳定的回归入口
+
 ## 长期差距
 
 ### 1. 将缓存写入路径从“全量收集后落盘”升级为流式写入路径

--- a/scripts/run-cache-benchmark.py
+++ b/scripts/run-cache-benchmark.py
@@ -5,7 +5,6 @@ import argparse
 import concurrent.futures
 import http.client
 import http.server
-import os
 import socket
 import socketserver
 import statistics
@@ -31,6 +30,7 @@ READY_ROUTE_CONFIG = """        LocationConfig(
 """
 
 REVALIDATE_ETAG = '"cache-bench-etag"'
+STARTUP_RETRY_LIMIT = 8
 
 
 @dataclass(frozen=True)
@@ -155,16 +155,30 @@ def parse_single_range(header_value: str, payload_len: int) -> tuple[int, int] |
     if "," in raw_range or "-" not in raw_range:
         return None
     raw_start, raw_end = raw_range.split("-", 1)
-    if not raw_start or not raw_end:
+    raw_start = raw_start.strip()
+    raw_end = raw_end.strip()
+    if not raw_start and not raw_end:
         return None
     try:
-        start = int(raw_start)
-        end = int(raw_end)
+        if raw_start:
+            start = int(raw_start)
+            if start < 0 or start >= payload_len:
+                return None
+            if raw_end:
+                end = int(raw_end)
+                if end < start:
+                    return None
+            else:
+                end = payload_len - 1
+            return start, min(end, payload_len - 1)
+
+        suffix_len = int(raw_end)
     except ValueError:
         return None
-    if start < 0 or end < start or start >= payload_len:
+    if suffix_len <= 0:
         return None
-    return start, min(end, payload_len - 1)
+    suffix_len = min(suffix_len, payload_len)
+    return payload_len - suffix_len, payload_len - 1
 
 
 def reserve_loopback_port() -> int:
@@ -192,6 +206,7 @@ def write_proxy_config(
     listen_port: int,
     upstream_port: int,
     cache_dir: Path,
+    cache_max_size_bytes: int,
     max_entry_bytes: int,
     slice_size_bytes: int,
 ) -> None:
@@ -203,7 +218,7 @@ def write_proxy_config(
         CacheZoneConfig(
             name: "default",
             path: "{cache_dir.as_posix()}",
-            max_size_bytes: Some({max_entry_bytes * 16}),
+            max_size_bytes: Some({cache_max_size_bytes}),
             inactive_secs: Some(600),
             default_ttl_secs: Some(60),
             max_entry_bytes: Some({max_entry_bytes}),
@@ -284,12 +299,34 @@ def write_proxy_config(
     path.write_text(config, encoding="utf-8")
 
 
-def wait_for_ready(port: int, timeout: float, process: subprocess.Popen[str]) -> None:
+def read_process_log(log_path: Path) -> str:
+    if not log_path.exists():
+        return ""
+    return log_path.read_text(encoding="utf-8", errors="replace")
+
+
+def should_retry_startup(log_output: str) -> bool:
+    lowered = log_output.lower()
+    return (
+        "address already in use" in lowered
+        or "os error 98" in lowered
+        or "addrinuse" in lowered
+    )
+
+
+def wait_for_ready(
+    port: int,
+    timeout: float,
+    process: subprocess.Popen[str],
+    log_path: Path,
+) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            output = process.stdout.read() if process.stdout else ""
-            raise RuntimeError(f"rginx exited before becoming ready:\n{output}")
+            output = read_process_log(log_path)
+            raise RuntimeError(
+                f"rginx exited before becoming ready on 127.0.0.1:{port}:\n{output}"
+            )
         try:
             conn = http.client.HTTPConnection("127.0.0.1", port, timeout=0.5)
             conn.request("GET", "/-/ready", headers={"Host": f"127.0.0.1:{port}"})
@@ -303,6 +340,65 @@ def wait_for_ready(port: int, timeout: float, process: subprocess.Popen[str]) ->
         else:
             time.sleep(0.1)
     raise TimeoutError(f"timed out waiting for rginx to listen on 127.0.0.1:{port}")
+
+
+def estimate_cache_max_size_bytes(
+    max_entry_bytes: int,
+    fill_keys: int,
+    hit_keys: int,
+) -> int:
+    expected_cached_entries = fill_keys + hit_keys + 2
+    return max_entry_bytes * max(expected_cached_entries * 4, 128)
+
+
+def start_rginx(
+    root: Path,
+    binary: Path,
+    config_path: Path,
+    log_path: Path,
+    origin_port: int,
+    cache_dir: Path,
+    cache_max_size_bytes: int,
+    max_entry_bytes: int,
+    slice_size_bytes: int,
+    ready_timeout: float,
+) -> tuple[subprocess.Popen[str], int]:
+    last_error: Exception | None = None
+    for attempt in range(1, STARTUP_RETRY_LIMIT + 1):
+        listen_port = reserve_loopback_port()
+        write_proxy_config(
+            config_path,
+            listen_port,
+            origin_port,
+            cache_dir,
+            cache_max_size_bytes,
+            max_entry_bytes,
+            slice_size_bytes,
+        )
+        with log_path.open("w", encoding="utf-8") as log_file:
+            process = subprocess.Popen(
+                [str(binary), "--config", str(config_path)],
+                cwd=root,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        try:
+            wait_for_ready(listen_port, ready_timeout, process, log_path)
+            return process, listen_port
+        except RuntimeError as error:
+            last_error = error
+            output = read_process_log(log_path)
+            terminate_process(process)
+            if attempt < STARTUP_RETRY_LIMIT and should_retry_startup(output):
+                continue
+            raise
+        except Exception as error:
+            last_error = error
+            terminate_process(process)
+            raise
+    assert last_error is not None
+    raise last_error
 
 
 def run_request(port: int, bench_request: BenchRequest, timeout: float) -> float:
@@ -511,29 +607,28 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="rginx-cache-bench-") as temp_dir:
         temp_root = Path(temp_dir)
         config_path = temp_root / "rginx.ron"
+        log_path = temp_root / "rginx.log"
         cache_dir = temp_root / "cache"
         cache_dir.mkdir(parents=True, exist_ok=True)
-        listen_port = reserve_loopback_port()
         max_entry_bytes = max(args.body_bytes, args.slice_payload_bytes) + 4096
-        write_proxy_config(
+        cache_max_size_bytes = estimate_cache_max_size_bytes(
+            max_entry_bytes,
+            args.fill_keys,
+            args.hit_keys,
+        )
+        process, listen_port = start_rginx(
+            root,
+            binary,
             config_path,
-            listen_port,
+            log_path,
             origin_port,
             cache_dir,
+            cache_max_size_bytes,
             max_entry_bytes,
             args.slice_size_bytes,
-        )
-
-        process = subprocess.Popen(
-            [str(binary), "--config", str(config_path)],
-            cwd=root,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+            args.ready_timeout,
         )
         try:
-            wait_for_ready(listen_port, args.ready_timeout, process)
-
             rows: list[ScenarioRow] = []
 
             before_fill = origin_state.count("fill")

--- a/scripts/run-cache-benchmark.py
+++ b/scripts/run-cache-benchmark.py
@@ -83,7 +83,7 @@ class OriginState:
 class OriginHandler(http.server.BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
-    def log_message(self, format: str, *args: object) -> None:
+    def log_message(self, _format: str, *_args: object) -> None:
         return
 
     def do_GET(self) -> None:  # noqa: N802
@@ -430,13 +430,19 @@ def run_request(port: int, bench_request: BenchRequest, timeout: float) -> float
     return time.perf_counter() - started
 
 
-def benchmark(port: int, requests: list[BenchRequest], concurrency: int, timeout: float) -> tuple[float, float, float, float]:
+def benchmark(
+    port: int,
+    requests: list[BenchRequest],
+    concurrency: int,
+    timeout: float,
+) -> tuple[float, float, float, float]:
     started = time.perf_counter()
     durations: list[float] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as executor:
         futures = [executor.submit(run_request, port, request, timeout) for request in requests]
-        for future in concurrent.futures.as_completed(futures):
-            durations.append(future.result())
+        durations.extend(
+            future.result() for future in concurrent.futures.as_completed(futures)
+        )
     elapsed = time.perf_counter() - started
     avg_ms = statistics.mean(durations) * 1000 if durations else 0.0
     req_per_sec = len(requests) / elapsed if elapsed else 0.0
@@ -705,18 +711,18 @@ def main() -> int:
             before_slice = origin_state.count("slice")
             run_warmup(listen_port, slice_warmup(), args.timeout)
             warmed_slice = origin_state.count("slice") - before_slice
-            slice = slice_requests(args.requests)
+            slice_hit_requests = slice_requests(args.requests)
             elapsed, req_per_sec, avg_ms, p95_ms = benchmark(
                 listen_port,
-                slice,
-                min(args.concurrency, len(slice)),
+                slice_hit_requests,
+                min(args.concurrency, len(slice_hit_requests)),
                 args.timeout,
             )
             rows.append(
                 ScenarioRow(
                     name="slice_hit",
-                    requests=len(slice),
-                    concurrency=min(args.concurrency, len(slice)),
+                    requests=len(slice_hit_requests),
+                    concurrency=min(args.concurrency, len(slice_hit_requests)),
                     expected_cache="HIT",
                     upstream_requests=origin_state.count("slice") - before_slice,
                     elapsed_s=elapsed,

--- a/scripts/run-cache-benchmark.py
+++ b/scripts/run-cache-benchmark.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import http.client
+import http.server
+import os
+import socket
+import socketserver
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+READY_ROUTE_CONFIG = """        LocationConfig(
+            matcher: Exact("/-/ready"),
+            handler: Return(
+                status: 200,
+                location: "",
+                body: Some("ready\\n"),
+            ),
+        ),
+"""
+
+REVALIDATE_ETAG = '"cache-bench-etag"'
+
+
+@dataclass(frozen=True)
+class BenchRequest:
+    path: str
+    expected_status: int
+    expected_cache: str
+    expected_length: int
+    headers: dict[str, str]
+
+
+@dataclass(frozen=True)
+class ScenarioRow:
+    name: str
+    requests: int
+    concurrency: int
+    expected_cache: str
+    upstream_requests: int
+    elapsed_s: float
+    req_per_sec: float
+    avg_ms: float
+    p95_ms: float
+
+
+class ThreadingHttpServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+class OriginState:
+    def __init__(self, body_bytes: int, slice_payload_bytes: int) -> None:
+        self.lock = threading.Lock()
+        self.counts = Counter()
+        self.body = (b"x" * body_bytes) or b"x"
+        payload = bytearray()
+        alphabet = b"abcdefghijklmnopqrstuvwxyz"
+        while len(payload) < slice_payload_bytes:
+            payload.extend(alphabet)
+        self.slice_payload = bytes(payload[:slice_payload_bytes])
+
+    def bump(self, key: str) -> None:
+        with self.lock:
+            self.counts[key] += 1
+
+    def count(self, key: str) -> int:
+        with self.lock:
+            return self.counts[key]
+
+
+class OriginHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlsplit(self.path).path or self.path.split("?", 1)[0]
+        state: OriginState = self.server.state  # type: ignore[attr-defined]
+        if path.startswith("/fill/"):
+            state.bump("fill")
+            self.respond(200, state.body, {"Cache-Control": "max-age=60"})
+            return
+        if path.startswith("/hit/"):
+            state.bump("hit")
+            self.respond(200, state.body, {"Cache-Control": "max-age=60"})
+            return
+        if path == "/revalidate":
+            state.bump("revalidate")
+            headers = {
+                "Cache-Control": "max-age=60, no-cache",
+                "ETag": REVALIDATE_ETAG,
+            }
+            if self.headers.get("If-None-Match") == REVALIDATE_ETAG:
+                self.respond(304, b"", headers)
+            else:
+                self.respond(200, state.body, headers)
+            return
+        if path == "/slice":
+            state.bump("slice")
+            self.respond_range(state.slice_payload)
+            return
+        self.respond(404, b"not found\n", {"Cache-Control": "no-store"})
+
+    def respond_range(self, payload: bytes) -> None:
+        range_header = self.headers.get("Range")
+        if not range_header:
+            self.respond(200, payload, {"Cache-Control": "max-age=60"})
+            return
+
+        parsed = parse_single_range(range_header, len(payload))
+        if parsed is None:
+            self.respond(416, b"", {"Content-Range": f"bytes */{len(payload)}"})
+            return
+
+        start, end = parsed
+        body = payload[start : end + 1]
+        self.respond(
+            206,
+            body,
+            {
+                "Cache-Control": "max-age=60",
+                "Content-Range": f"bytes {start}-{end}/{len(payload)}",
+            },
+        )
+
+    def respond(self, status: int, body: bytes, headers: dict[str, str]) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        for name, value in headers.items():
+            self.send_header(name, value)
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+
+def parse_single_range(header_value: str, payload_len: int) -> tuple[int, int] | None:
+    value = header_value.strip()
+    if not value.startswith("bytes="):
+        return None
+    raw_range = value[len("bytes=") :].strip()
+    if "," in raw_range or "-" not in raw_range:
+        return None
+    raw_start, raw_end = raw_range.split("-", 1)
+    if not raw_start or not raw_end:
+        return None
+    try:
+        start = int(raw_start)
+        end = int(raw_end)
+    except ValueError:
+        return None
+    if start < 0 or end < start or start >= payload_len:
+        return None
+    return start, min(end, payload_len - 1)
+
+
+def reserve_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def ensure_rginx_binary(root: Path, explicit: str | None, rebuild: bool) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+
+    binary = root / "target" / "release" / "rginx"
+    if rebuild or not binary.exists():
+        subprocess.run(
+            ["cargo", "build", "--release", "--locked", "-p", "rginx"],
+            cwd=root,
+            check=True,
+        )
+    return binary
+
+
+def write_proxy_config(
+    path: Path,
+    listen_port: int,
+    upstream_port: int,
+    cache_dir: Path,
+    max_entry_bytes: int,
+    slice_size_bytes: int,
+) -> None:
+    config = f"""Config(
+    runtime: RuntimeConfig(
+        shutdown_timeout_secs: 2,
+    ),
+    cache_zones: [
+        CacheZoneConfig(
+            name: "default",
+            path: "{cache_dir.as_posix()}",
+            max_size_bytes: Some({max_entry_bytes * 16}),
+            inactive_secs: Some(600),
+            default_ttl_secs: Some(60),
+            max_entry_bytes: Some({max_entry_bytes}),
+        ),
+    ],
+    server: ServerConfig(
+        listen: "127.0.0.1:{listen_port}",
+    ),
+    upstreams: [
+        UpstreamConfig(
+            name: "backend",
+            peers: [
+                UpstreamPeerConfig(
+                    url: "http://127.0.0.1:{upstream_port}",
+                ),
+            ],
+            request_timeout_secs: Some(5),
+        ),
+    ],
+    locations: [
+{READY_ROUTE_CONFIG}        LocationConfig(
+            matcher: Prefix("/fill"),
+            handler: Proxy(
+                upstream: "backend",
+            ),
+            cache: Some(CacheRouteConfig(
+                zone: "default",
+                methods: Some(["GET", "HEAD"]),
+                statuses: Some([200]),
+                key: Some("{{scheme}}:{{host}}:{{uri}}"),
+                stale_if_error_secs: Some(60),
+            )),
+        ),
+        LocationConfig(
+            matcher: Prefix("/hit"),
+            handler: Proxy(
+                upstream: "backend",
+            ),
+            cache: Some(CacheRouteConfig(
+                zone: "default",
+                methods: Some(["GET", "HEAD"]),
+                statuses: Some([200]),
+                key: Some("{{scheme}}:{{host}}:{{uri}}"),
+                stale_if_error_secs: Some(60),
+            )),
+        ),
+        LocationConfig(
+            matcher: Exact("/revalidate"),
+            handler: Proxy(
+                upstream: "backend",
+            ),
+            cache: Some(CacheRouteConfig(
+                zone: "default",
+                methods: Some(["GET", "HEAD"]),
+                statuses: Some([200]),
+                key: Some("{{scheme}}:{{host}}:{{uri}}"),
+                stale_if_error_secs: Some(60),
+            )),
+        ),
+        LocationConfig(
+            matcher: Exact("/slice"),
+            handler: Proxy(
+                upstream: "backend",
+            ),
+            cache: Some(CacheRouteConfig(
+                zone: "default",
+                methods: Some(["GET", "HEAD"]),
+                statuses: Some([206]),
+                key: Some("{{scheme}}:{{host}}:{{uri}}"),
+                stale_if_error_secs: Some(60),
+                range_requests: Some(Cache),
+                slice_size_bytes: Some({slice_size_bytes}),
+            )),
+        ),
+    ],
+)
+"""
+    path.write_text(config, encoding="utf-8")
+
+
+def wait_for_ready(port: int, timeout: float, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            output = process.stdout.read() if process.stdout else ""
+            raise RuntimeError(f"rginx exited before becoming ready:\n{output}")
+        try:
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=0.5)
+            conn.request("GET", "/-/ready", headers={"Host": f"127.0.0.1:{port}"})
+            response = conn.getresponse()
+            response.read()
+            conn.close()
+            if response.status == 200:
+                return
+        except OSError:
+            time.sleep(0.1)
+        else:
+            time.sleep(0.1)
+    raise TimeoutError(f"timed out waiting for rginx to listen on 127.0.0.1:{port}")
+
+
+def run_request(port: int, bench_request: BenchRequest, timeout: float) -> float:
+    started = time.perf_counter()
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=timeout)
+    headers = {"Host": f"127.0.0.1:{port}", "Connection": "close", **bench_request.headers}
+    conn.request("GET", bench_request.path, headers=headers)
+    response = conn.getresponse()
+    body = response.read()
+    x_cache = response.getheader("x-cache")
+    conn.close()
+
+    if response.status != bench_request.expected_status:
+        raise RuntimeError(
+            f"{bench_request.path} returned {response.status}, "
+            f"expected {bench_request.expected_status}"
+        )
+    if x_cache != bench_request.expected_cache:
+        raise RuntimeError(
+            f"{bench_request.path} returned x-cache={x_cache!r}, "
+            f"expected {bench_request.expected_cache!r}"
+        )
+    if len(body) != bench_request.expected_length:
+        raise RuntimeError(
+            f"{bench_request.path} returned body length {len(body)}, "
+            f"expected {bench_request.expected_length}"
+        )
+
+    return time.perf_counter() - started
+
+
+def benchmark(port: int, requests: list[BenchRequest], concurrency: int, timeout: float) -> tuple[float, float, float, float]:
+    started = time.perf_counter()
+    durations: list[float] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = [executor.submit(run_request, port, request, timeout) for request in requests]
+        for future in concurrent.futures.as_completed(futures):
+            durations.append(future.result())
+    elapsed = time.perf_counter() - started
+    avg_ms = statistics.mean(durations) * 1000 if durations else 0.0
+    req_per_sec = len(requests) / elapsed if elapsed else 0.0
+    p95_ms = percentile_ms(durations, 0.95)
+    return elapsed, req_per_sec, avg_ms, p95_ms
+
+
+def percentile_ms(durations: list[float], percentile: float) -> float:
+    if not durations:
+        return 0.0
+    ordered = sorted(durations)
+    index = max(0, min(len(ordered) - 1, int(round((len(ordered) - 1) * percentile))))
+    return ordered[index] * 1000
+
+
+def fill_requests(count: int, body_bytes: int) -> list[BenchRequest]:
+    return [
+        BenchRequest(
+            path=f"/fill/{request_id}",
+            expected_status=200,
+            expected_cache="MISS",
+            expected_length=body_bytes,
+            headers={},
+        )
+        for request_id in range(count)
+    ]
+
+
+def hit_warmup(key_count: int, body_bytes: int) -> list[BenchRequest]:
+    return [
+        BenchRequest(
+            path=f"/hit/{key_id}",
+            expected_status=200,
+            expected_cache="MISS",
+            expected_length=body_bytes,
+            headers={},
+        )
+        for key_id in range(key_count)
+    ]
+
+
+def hit_requests(requests: int, key_count: int, body_bytes: int) -> list[BenchRequest]:
+    return [
+        BenchRequest(
+            path=f"/hit/{request_id % key_count}",
+            expected_status=200,
+            expected_cache="HIT",
+            expected_length=body_bytes,
+            headers={},
+        )
+        for request_id in range(requests)
+    ]
+
+
+def revalidate_warmup(body_bytes: int) -> list[BenchRequest]:
+    return [
+        BenchRequest(
+            path="/revalidate",
+            expected_status=200,
+            expected_cache="MISS",
+            expected_length=body_bytes,
+            headers={},
+        )
+    ]
+
+
+def revalidate_requests(requests: int, body_bytes: int) -> list[BenchRequest]:
+    return [
+        BenchRequest(
+            path="/revalidate",
+            expected_status=200,
+            expected_cache="REVALIDATED",
+            expected_length=body_bytes,
+            headers={},
+        )
+        for _ in range(requests)
+    ]
+
+
+def slice_warmup() -> list[BenchRequest]:
+    return [
+        BenchRequest(
+            path="/slice",
+            expected_status=206,
+            expected_cache="MISS",
+            expected_length=3,
+            headers={"Range": "bytes=2-4"},
+        )
+    ]
+
+
+def slice_requests(requests: int) -> list[BenchRequest]:
+    return [
+        BenchRequest(
+            path="/slice",
+            expected_status=206,
+            expected_cache="HIT",
+            expected_length=2,
+            headers={"Range": "bytes=5-6"},
+        )
+        for _ in range(requests)
+    ]
+
+
+def run_warmup(port: int, requests: list[BenchRequest], timeout: float) -> None:
+    for request in requests:
+        run_request(port, request, timeout)
+
+
+def print_table(rows: list[ScenarioRow]) -> None:
+    print(
+        "| scenario | requests | concurrency | expected_cache | upstream_requests | elapsed_s | req_per_sec | avg_ms | p95_ms |"
+    )
+    print("| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |")
+    for row in rows:
+        print(
+            f"| {row.name} | {row.requests} | {row.concurrency} | {row.expected_cache} | "
+            f"{row.upstream_requests} | {row.elapsed_s:.3f} | {row.req_per_sec:.2f} | "
+            f"{row.avg_ms:.2f} | {row.p95_ms:.2f} |"
+        )
+
+
+def terminate_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run cache-specific benchmark scenarios against a real rginx process."
+    )
+    parser.add_argument("--binary", help="Path to an existing rginx binary")
+    parser.add_argument("--rebuild", action="store_true", help="Force cargo build --release -p rginx")
+    parser.add_argument("--requests", type=int, default=400)
+    parser.add_argument("--fill-keys", type=int, default=256)
+    parser.add_argument("--hit-keys", type=int, default=64)
+    parser.add_argument("--concurrency", type=int, default=32)
+    parser.add_argument("--body-bytes", type=int, default=64 * 1024)
+    parser.add_argument("--slice-size-bytes", type=int, default=8192)
+    parser.add_argument("--slice-payload-bytes", type=int, default=32 * 1024)
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--ready-timeout", type=float, default=30.0)
+    args = parser.parse_args()
+
+    if args.requests < 1 or args.fill_keys < 1 or args.hit_keys < 1 or args.concurrency < 1:
+        parser.error("--requests, --fill-keys, --hit-keys, and --concurrency must be >= 1")
+    if args.body_bytes < 1 or args.slice_size_bytes < 1 or args.slice_payload_bytes < 8:
+        parser.error("--body-bytes, --slice-size-bytes, and --slice-payload-bytes must be positive")
+
+    root = Path(__file__).resolve().parent.parent
+    binary = ensure_rginx_binary(root, args.binary, args.rebuild)
+    if not binary.exists():
+        raise FileNotFoundError(f"rginx binary does not exist: {binary}")
+
+    origin_state = OriginState(args.body_bytes, args.slice_payload_bytes)
+    origin_server = ThreadingHttpServer(("127.0.0.1", 0), OriginHandler)
+    origin_server.state = origin_state  # type: ignore[attr-defined]
+    origin_port = int(origin_server.server_address[1])
+    origin_thread = threading.Thread(target=origin_server.serve_forever, daemon=True)
+    origin_thread.start()
+
+    with tempfile.TemporaryDirectory(prefix="rginx-cache-bench-") as temp_dir:
+        temp_root = Path(temp_dir)
+        config_path = temp_root / "rginx.ron"
+        cache_dir = temp_root / "cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        listen_port = reserve_loopback_port()
+        max_entry_bytes = max(args.body_bytes, args.slice_payload_bytes) + 4096
+        write_proxy_config(
+            config_path,
+            listen_port,
+            origin_port,
+            cache_dir,
+            max_entry_bytes,
+            args.slice_size_bytes,
+        )
+
+        process = subprocess.Popen(
+            [str(binary), "--config", str(config_path)],
+            cwd=root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            wait_for_ready(listen_port, args.ready_timeout, process)
+
+            rows: list[ScenarioRow] = []
+
+            before_fill = origin_state.count("fill")
+            fill = fill_requests(args.fill_keys, args.body_bytes)
+            elapsed, req_per_sec, avg_ms, p95_ms = benchmark(
+                listen_port,
+                fill,
+                min(args.concurrency, len(fill)),
+                args.timeout,
+            )
+            rows.append(
+                ScenarioRow(
+                    name="fill",
+                    requests=len(fill),
+                    concurrency=min(args.concurrency, len(fill)),
+                    expected_cache="MISS",
+                    upstream_requests=origin_state.count("fill") - before_fill,
+                    elapsed_s=elapsed,
+                    req_per_sec=req_per_sec,
+                    avg_ms=avg_ms,
+                    p95_ms=p95_ms,
+                )
+            )
+
+            before_hit = origin_state.count("hit")
+            run_warmup(listen_port, hit_warmup(args.hit_keys, args.body_bytes), args.timeout)
+            warmed_hit = origin_state.count("hit") - before_hit
+            hit = hit_requests(args.requests, args.hit_keys, args.body_bytes)
+            elapsed, req_per_sec, avg_ms, p95_ms = benchmark(
+                listen_port,
+                hit,
+                min(args.concurrency, len(hit)),
+                args.timeout,
+            )
+            rows.append(
+                ScenarioRow(
+                    name="hit",
+                    requests=len(hit),
+                    concurrency=min(args.concurrency, len(hit)),
+                    expected_cache="HIT",
+                    upstream_requests=origin_state.count("hit") - before_hit,
+                    elapsed_s=elapsed,
+                    req_per_sec=req_per_sec,
+                    avg_ms=avg_ms,
+                    p95_ms=p95_ms,
+                )
+            )
+            if origin_state.count("hit") - before_hit != warmed_hit:
+                raise RuntimeError("hit benchmark unexpectedly forwarded requests upstream")
+
+            before_revalidate = origin_state.count("revalidate")
+            run_warmup(listen_port, revalidate_warmup(args.body_bytes), args.timeout)
+            revalidate = revalidate_requests(args.requests, args.body_bytes)
+            elapsed, req_per_sec, avg_ms, p95_ms = benchmark(
+                listen_port,
+                revalidate,
+                min(args.concurrency, len(revalidate)),
+                args.timeout,
+            )
+            rows.append(
+                ScenarioRow(
+                    name="revalidate",
+                    requests=len(revalidate),
+                    concurrency=min(args.concurrency, len(revalidate)),
+                    expected_cache="REVALIDATED",
+                    upstream_requests=origin_state.count("revalidate") - before_revalidate,
+                    elapsed_s=elapsed,
+                    req_per_sec=req_per_sec,
+                    avg_ms=avg_ms,
+                    p95_ms=p95_ms,
+                )
+            )
+
+            before_slice = origin_state.count("slice")
+            run_warmup(listen_port, slice_warmup(), args.timeout)
+            warmed_slice = origin_state.count("slice") - before_slice
+            slice = slice_requests(args.requests)
+            elapsed, req_per_sec, avg_ms, p95_ms = benchmark(
+                listen_port,
+                slice,
+                min(args.concurrency, len(slice)),
+                args.timeout,
+            )
+            rows.append(
+                ScenarioRow(
+                    name="slice_hit",
+                    requests=len(slice),
+                    concurrency=min(args.concurrency, len(slice)),
+                    expected_cache="HIT",
+                    upstream_requests=origin_state.count("slice") - before_slice,
+                    elapsed_s=elapsed,
+                    req_per_sec=req_per_sec,
+                    avg_ms=avg_ms,
+                    p95_ms=p95_ms,
+                )
+            )
+            if origin_state.count("slice") - before_slice != warmed_slice:
+                raise RuntimeError("slice-hit benchmark unexpectedly forwarded requests upstream")
+
+            print_table(rows)
+            return 0
+        finally:
+            terminate_process(process)
+            origin_server.shutdown()
+            origin_server.server_close()
+            origin_thread.join(timeout=5)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/run-cache-benchmark.py
+++ b/scripts/run-cache-benchmark.py
@@ -662,6 +662,9 @@ def main() -> int:
             before_hit = origin_state.count("hit")
             run_warmup(listen_port, hit_warmup(args.hit_keys, args.body_bytes), args.timeout)
             warmed_hit = origin_state.count("hit") - before_hit
+            if warmed_hit != args.hit_keys:
+                raise RuntimeError("hit warmup did not populate every cache key")
+            before_hit_benchmark = origin_state.count("hit")
             hit = hit_requests(args.requests, args.hit_keys, args.body_bytes)
             elapsed, req_per_sec, avg_ms, p95_ms = benchmark(
                 listen_port,
@@ -675,18 +678,21 @@ def main() -> int:
                     requests=len(hit),
                     concurrency=min(args.concurrency, len(hit)),
                     expected_cache="HIT",
-                    upstream_requests=origin_state.count("hit") - before_hit,
+                    upstream_requests=origin_state.count("hit") - before_hit_benchmark,
                     elapsed_s=elapsed,
                     req_per_sec=req_per_sec,
                     avg_ms=avg_ms,
                     p95_ms=p95_ms,
                 )
             )
-            if origin_state.count("hit") - before_hit != warmed_hit:
+            if origin_state.count("hit") - before_hit_benchmark != 0:
                 raise RuntimeError("hit benchmark unexpectedly forwarded requests upstream")
 
             before_revalidate = origin_state.count("revalidate")
             run_warmup(listen_port, revalidate_warmup(args.body_bytes), args.timeout)
+            if origin_state.count("revalidate") - before_revalidate != 1:
+                raise RuntimeError("revalidate warmup did not seed the cached response")
+            before_revalidate_benchmark = origin_state.count("revalidate")
             revalidate = revalidate_requests(args.requests, args.body_bytes)
             elapsed, req_per_sec, avg_ms, p95_ms = benchmark(
                 listen_port,
@@ -700,7 +706,8 @@ def main() -> int:
                     requests=len(revalidate),
                     concurrency=min(args.concurrency, len(revalidate)),
                     expected_cache="REVALIDATED",
-                    upstream_requests=origin_state.count("revalidate") - before_revalidate,
+                    upstream_requests=origin_state.count("revalidate")
+                    - before_revalidate_benchmark,
                     elapsed_s=elapsed,
                     req_per_sec=req_per_sec,
                     avg_ms=avg_ms,
@@ -711,6 +718,9 @@ def main() -> int:
             before_slice = origin_state.count("slice")
             run_warmup(listen_port, slice_warmup(), args.timeout)
             warmed_slice = origin_state.count("slice") - before_slice
+            if warmed_slice != 1:
+                raise RuntimeError("slice warmup did not seed the cached range entry")
+            before_slice_benchmark = origin_state.count("slice")
             slice_hit_requests = slice_requests(args.requests)
             elapsed, req_per_sec, avg_ms, p95_ms = benchmark(
                 listen_port,
@@ -724,14 +734,14 @@ def main() -> int:
                     requests=len(slice_hit_requests),
                     concurrency=min(args.concurrency, len(slice_hit_requests)),
                     expected_cache="HIT",
-                    upstream_requests=origin_state.count("slice") - before_slice,
+                    upstream_requests=origin_state.count("slice") - before_slice_benchmark,
                     elapsed_s=elapsed,
                     req_per_sec=req_per_sec,
                     avg_ms=avg_ms,
                     p95_ms=p95_ms,
                 )
             )
-            if origin_state.count("slice") - before_slice != warmed_slice:
+            if origin_state.count("slice") - before_slice_benchmark != 0:
                 raise RuntimeError("slice-hit benchmark unexpectedly forwarded requests upstream")
 
             print_table(rows)

--- a/scripts/run-cache-stress.sh
+++ b/scripts/run-cache-stress.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-$0}"
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+ITERATIONS=1
+RELEASE=0
+
+usage() {
+    cat <<'EOF'
+Usage: run-cache-stress.sh [options]
+
+Options:
+  --iterations <n>
+      重复执行整套 cache stress 矩阵的次数，默认 1
+  --release
+      使用 cargo test --release
+  -h, --help
+      显示帮助
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --iterations)
+            [[ $# -ge 2 ]] || { echo "--iterations requires a value" >&2; exit 1; }
+            ITERATIONS="$2"
+            shift 2
+            ;;
+        --release)
+            RELEASE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+[[ "${ITERATIONS}" =~ ^[0-9]+$ ]] || { echo "--iterations must be a positive integer" >&2; exit 1; }
+[[ "${ITERATIONS}" -ge 1 ]] || { echo "--iterations must be >= 1" >&2; exit 1; }
+
+cd "${ROOT_DIR}"
+
+if [[ "${RELEASE}" -eq 1 ]]; then
+    cargo_args=(cargo test --release --locked)
+else
+    cargo_args=(cargo test --locked)
+fi
+
+matrix=(
+    "rginx-http|cache_manager_handles_large_keysets_under_parallel_fill_and_hit_load|crate-local large-key and parallel hit/fill stress"
+    "rginx-http|cache_manager_serves_large_cached_body_under_sustained_parallel_hits|crate-local large-object sustained hit stress"
+    "rginx|reload_keeps_hot_cache_hits_available_under_concurrent_traffic|real-process reload plus hot-cache concurrency stress"
+)
+
+for iteration in $(seq 1 "${ITERATIONS}"); do
+    printf '[cache-stress] iteration %s/%s\n' "${iteration}" "${ITERATIONS}"
+    for entry in "${matrix[@]}"; do
+        crate_name="${entry%%|*}"
+        remainder="${entry#*|}"
+        test_name="${remainder%%|*}"
+        label="${remainder#*|}"
+        printf '[cache-stress] running %-60s %s\n' "${test_name}" "${label}"
+        if [[ "${crate_name}" == "rginx" ]]; then
+            "${cargo_args[@]}" -p rginx --test reload "${test_name}" -- --ignored --nocapture --test-threads=1
+        else
+            "${cargo_args[@]}" -p "${crate_name}" --lib "${test_name}" -- --ignored --nocapture --test-threads=1
+        fi
+    done
+done
+
+printf '[cache-stress] completed %s iteration(s)\n' "${ITERATIONS}"


### PR DESCRIPTION
## Summary
- add a cache-specific benchmark harness for fill, hit, revalidate, and slice-hit paths
- add cache stress coverage for large keysets, large cached objects, and reload concurrency
- add fault-injection regressions for missing cache body files and corrupted shared index metadata
- update CACHE_ARCHITECTURE_GAPS to mark item 4 as first-pass completed with run commands

## Testing
- cargo test -p rginx-http --lib --locked -- --test-threads=1
- cargo test -p rginx --test reload --locked -- --test-threads=1
- ./scripts/run-cache-stress.sh
- python3 ./scripts/run-cache-benchmark.py --binary ./target/debug/rginx --requests 24 --fill-keys 8 --hit-keys 4 --concurrency 4 --body-bytes 4096 --slice-payload-bytes 16384 --ready-timeout 15
- ./scripts/run-clippy-gate.sh
- python3 ./scripts/run-modularization-gate.py