### PR TITLE
Add ACME phase 0-1 config model and validation

### DIFF
--- a/ACME_SUPPORT_PLAN.md
+++ b/ACME_SUPPORT_PLAN.md
@@ -1,0 +1,356 @@
+# rginx ACME 证书签发阶段计划
+
+## 当前状态
+
+- 截至 `2026-04-30`，`rginx` 还没有内置类似 `certbot` 的 ACME 自动签发工具。
+- 当前 TLS 模型仍然是“从现有 PEM 文件加载证书和私钥”，并在运行时支持下游 TLS、SNI、OCSP、mTLS、ALPN、热重载和优雅重启。
+- 当前运行时已经具备几个可复用的基础能力：
+  - TLS acceptor 构建与证书重载
+  - listener 生命周期管理
+  - admin/status/snapshot 观测面
+  - 后台任务生命周期
+  - OCSP 定时刷新
+
+这意味着 `rginx` 更适合把 ACME 作为独立运行时子系统接入，而不是把证书管理控制权反向交给 TLS 接入层。
+
+## 选型结论
+
+首选 `instant-acme`。
+
+原因：
+
+- `instant-acme` 是更底层的 ACME 协议客户端，适合嵌入现有 runtime。
+- `rginx` 已经自己掌管 TLS 证书装载、SNI、listener 生命周期、reload 和 HTTP/3；这里不需要一个“替我们接管 TLS incoming”的框架式方案。
+- `instant-acme` 更容易做成：
+  - 申请证书
+  - 续期证书
+  - 原子写回现有 `cert_path` / `key_path`
+  - 成功后刷新当前 listener 的 TLS 运行态
+
+不选 `rustls-acme` 作为主路径的原因：
+
+- `rustls-acme` 的强项是把 ACME 和 rustls serving 直接绑在一起。
+- 对简单 HTTPS 服务它很省事，但对 `rginx` 这种已经有完整 TLS/runtime orchestration 的项目，会和现有 listener/TLS/HTTP3 结构发生重叠。
+- 即使用其 low-level API，也仍然会把实现重心拉向“围绕 resolver/acceptor 接管握手”，而不是“围绕现有 runtime 子系统做编排”。
+
+其他备选：
+
+- `tokio-rustls-acme`：仍然更偏自动化 TLS serving 封装，不适合作为本项目的主集成路线。
+- `acme-lib`：生态和接口风格都不如 `instant-acme` 贴合当前项目。
+
+## V1 目标边界
+
+第一版只解决最值得先落地的路径：
+
+- 单机部署
+- 自动签发和自动续期
+- `HTTP-01`
+- 精确域名
+- 证书仍然落盘为 PEM
+- 续期成功后尽量直接刷新 TLS 运行态，而不是强制全量 reload
+
+第一版明确不做：
+
+- wildcard 证书
+- `DNS-01`
+- `TLS-ALPN-01`
+- 多节点共享 ACME 状态
+- 自动接管任意 DNS provider
+- 首版就承诺 HTTP/1.1、HTTP/2、HTTP/3 三条协议路径都无 reload 热生效
+
+## 当前代码接点
+
+计划基于以下已有结构展开：
+
+- `crates/rginx-http/src/tls/acceptor.rs`
+  - 负责从现有 `cert_path` / `key_path` 构建 TLS acceptor 与 HTTP/3 rustls config。
+- `crates/rginx-http/src/state/lifecycle/reload.rs`
+  - 已有 `refresh_tls_acceptors_from_current_config()`，适合承接“证书文件变更后刷新 TCP TLS acceptor”。
+- `crates/rginx-runtime/src/bootstrap/mod.rs`
+  - 已有 admin/cache/health/ocsp 后台任务挂载点，适合接入 ACME runtime task。
+- `crates/rginx-runtime/src/ocsp/scheduler.rs`
+  - 当前 OCSP 刷新流程可作为 ACME 任务结构和状态记录的参考。
+- `crates/rginx-http/src/handler/dispatch/mod.rs`
+  - 适合在常规 route 选择前短路处理 `/.well-known/acme-challenge/*`。
+- `crates/rginx-http/src/server/http3/endpoint.rs`
+  - HTTP/3 endpoint 当前在绑定时固化证书配置，后续需要单独处理其证书刷新路径。
+
+## 分阶段实施计划
+
+### 阶段 0：锁定首版边界
+
+目标：
+
+- 明确第一版只做 `instant-acme + HTTP-01 + 单机 + PEM 落盘`。
+- 明确首版只支持 vhost 级托管证书，不直接从 listener 级默认证书起步。
+
+主要设计：
+
+- 不把 ACME V1 做成“自动替换所有 TLS 配置来源”的大重构。
+- 首版优先支持 `servers[].tls` 的 ACME 托管模式。
+- 继续保留现有静态证书路径模式，ACME 只是新增来源，不替代静态 PEM。
+
+验收标准：
+
+- 计划文档、配置边界和实现范围一致。
+- 不把 wildcard、DNS provider、HTTP/3 热刷新一起塞进首个里程碑。
+
+### 阶段 1：补配置模型、校验和编译结果
+
+目标：
+
+- 为 ACME 增加最小但清晰的配置面。
+
+建议配置方向：
+
+- 在顶层 `Config` 增加 `acme` 全局配置。
+- 在 `VirtualHostTlsConfig` 增加 `acme` 子块。
+- 继续保留 `cert_path` / `key_path`，由 ACME 负责写入这些路径。
+
+建议全局字段：
+
+- `directory_url`
+- `contacts`
+- `state_dir`
+- `renew_before_days`
+- `poll_interval_secs`
+
+建议 vhost 级字段：
+
+- `domains`
+- `challenge = Http01`
+
+主要改动范围：
+
+- `crates/rginx-config/src/model.rs`
+- `crates/rginx-config/src/model/tls.rs`
+- `crates/rginx-config/src/validate/`
+- `crates/rginx-config/src/compile/`
+- `crates/rginx-core/src/config/`
+
+验收标准：
+
+- 配置可 parse、validate、compile。
+- 生成统一的 `ManagedCertificateSpec` 或等价编译产物，供 runtime 遍历。
+- 能拒绝明显不合法的组合：
+  - wildcard + `HTTP-01`
+  - `additional_certificates` + ACME
+  - 未声明可写证书路径
+  - 没有 HTTP listener 却启用 `HTTP-01`
+
+### 阶段 2：落地 ACME 核心模块
+
+目标：
+
+- 先把 `instant-acme` 协议流程封装成可测试的内部模块。
+
+建议模块布局：
+
+- `crates/rginx-runtime/src/acme/mod.rs`
+- `crates/rginx-runtime/src/acme/types.rs`
+- `crates/rginx-runtime/src/acme/account.rs`
+- `crates/rginx-runtime/src/acme/order.rs`
+- `crates/rginx-runtime/src/acme/storage.rs`
+- `crates/rginx-runtime/src/acme/tests.rs`
+
+职责：
+
+- 账户创建与恢复
+- 新订单创建
+- challenge 选择
+- challenge ready 提交
+- order ready 轮询
+- finalize / poll_certificate
+- 原子写证书和私钥
+
+持久化策略：
+
+- ACME account credentials 单独持久化到 `state_dir`
+- 证书和私钥写回 `cert_path` / `key_path`
+- 写文件必须原子替换，避免运行时读到半写状态
+
+验收标准：
+
+- 可以对单个 `ManagedCertificateSpec` 跑完整下单流程。
+- 账户恢复和重复续期可复用已持久化 credentials。
+- 文件写入具备 crash-safe 的最小原子性。
+
+### 阶段 3：先解决首签冷启动
+
+目标：
+
+- 解决“证书文件还不存在时，主 TLS listener 无法直接启动”的问题。
+
+现状约束：
+
+- 当前 TLS acceptor 构建依赖现有 PEM。
+- 当前 HTTP/3 endpoint 绑定也依赖现有证书。
+
+首版策略：
+
+- 先增加一次性签发入口，例如 `rginx acme issue --once`。
+- 该入口只临时服务 `/.well-known/acme-challenge/*` 所需的 HTTP 明文验证流量。
+- 签发完成后把 PEM 写到配置路径，再正常启动 `rginx`。
+
+原因：
+
+- 这条路径最小化对现有 listener/bootstrap 的侵入。
+- 可以先把“证书签下来”这件事独立做成可验收能力，再接自动续期。
+
+验收标准：
+
+- 在空证书目录场景下，可以通过一次性命令完成初始签发。
+- 正常启动路径仍然维持现有 TLS 架构，不要求首轮即支持 certless HTTPS 冷启动。
+
+### 阶段 4：把自动续期接入 runtime 后台任务
+
+目标：
+
+- 让 ACME 像现有 OCSP 一样成为长期运行的后台任务。
+
+建议接点：
+
+- 在 `crates/rginx-runtime/src/bootstrap/mod.rs` 新增 `acme_task`
+- 任务签名风格对齐当前 `ocsp::run(state.http.clone(), shutdown_tx.subscribe())`
+
+任务职责：
+
+- 订阅 config revision 变化
+- 定期扫描托管证书 spec
+- 判断是否需要申请/续期：
+  - 证书缺失
+  - SAN 不匹配
+  - 临近过期
+- 限制并发
+- 做错误退避
+
+验收标准：
+
+- 启动后可后台扫描托管证书。
+- config reload 后能重新 reconcile 证书任务集合。
+- 失败不会破坏已有可用证书文件。
+
+### 阶段 5：接入 HTTP-01 challenge 响应与 TCP TLS 热刷新
+
+目标：
+
+- 让正常运行中的 `rginx` 可以完成 `HTTP-01` 验证，并在续期成功后刷新 TCP TLS acceptor。
+
+实现方向：
+
+- 在 `crates/rginx-http/src/handler/dispatch/mod.rs` 最前面短路：
+  - `/.well-known/acme-challenge/*`
+- challenge token 存放在共享运行时状态中
+- ACME task 在 `set_ready()` 前注册 token，在完成后清理
+
+运行时刷新：
+
+- 成功写入新 PEM 后调用
+  `refresh_tls_acceptors_from_current_config()`
+- 对 TCP TLS listener，这样可以做到不触发全量 reload 的证书切换
+
+配套注意点：
+
+- challenge 路径必须绕过普通 route、鉴权、限流和 HTTP 到 HTTPS 重定向
+- 只允许返回当前 challenge token 对应内容
+
+验收标准：
+
+- `HTTP-01` 验证请求可由正式运行中的 `rginx` 返回正确响应。
+- 新证书落盘后，HTTP/1.1 和 HTTP/2 下游握手可以切到新证书。
+- 不要求此阶段同步解决 HTTP/3 证书热刷新。
+
+### 阶段 6：补 HTTP/3、OCSP 和协议差异收口
+
+目标：
+
+- 把“证书续期成功”从 TCP-only 收口到完整 TLS 运行时语义。
+
+当前关键约束：
+
+- TCP listener 的 TLS acceptor 已有独立刷新接口。
+- HTTP/3 endpoint 当前在绑定时固化 `quinn::ServerConfig`，不能直接复用 TCP acceptor 刷新路径。
+
+实现方向：
+
+- 短期策略二选一：
+  - 限制 ACME 托管 listener 暂不启用 `http3`
+  - 或者补一条 HTTP/3 endpoint 的 server config 更新路径
+- ACME 成功后补一次 OCSP refresh，避免新证书刚切换时 staple 缺失
+
+验收标准：
+
+- 文档和实现对 HTTP/3 行为保持一致，不制造“TCP 已热刷新但 HTTP/3 仍旧证书”的隐藏语义。
+- 新证书切换后，OCSP 状态能够重新建立。
+
+### 阶段 7：补状态观测、CLI 和硬化
+
+目标：
+
+- 让 ACME 子系统具备可观测性和运维可诊断性。
+
+建议状态字段：
+
+- `scope`
+- `domains`
+- `managed`
+- `last_success_unix_ms`
+- `next_renewal_unix_ms`
+- `refreshes_total`
+- `failures_total`
+- `last_error`
+- `challenge_type`
+- `directory_url`
+
+建议暴露面：
+
+- `status`
+- `snapshot`
+- `check`
+- 未来可选的 `rginx acme status`
+
+还需补的硬化项：
+
+- challenge 并发控制
+- 目录锁或文件锁
+- ACME 服务端退避与限速
+- 更严格的证书路径权限检查
+- staging / production directory 明确区分
+
+验收标准：
+
+- 运维可以从现有状态面看见 ACME 健康度。
+- 失败时能定位到证书 scope、最近错误和重试状态。
+- staging 验证流程和 production 上线流程可以分开执行。
+
+## 建议 PR 切分
+
+建议按 4 轮拆分，避免单次改动过大：
+
+1. `schema + validate + compile + doc`
+2. `acme issue --once`
+3. `runtime renewer + http-01 responder + tcp tls refresh`
+4. `http3 + ocsp + status + hardening`
+
+## V1 完成定义
+
+当以下条件全部满足时，可认为 ACME V1 完成：
+
+- `rginx` 具备内置 ACME 证书签发能力
+- 单机 `HTTP-01` 初始签发可用
+- 单机 `HTTP-01` 自动续期可用
+- 新证书可写回现有 `cert_path` / `key_path`
+- TCP TLS listener 可在不做全量 reload 的情况下切换到新证书
+- ACME 状态可通过现有运维面查看
+- 文档明确说明 HTTP/3 的当前行为和限制
+
+## 后续扩展方向
+
+V1 之后再考虑：
+
+- `DNS-01`
+- wildcard 证书
+- 多账户/多 directory
+- 多节点共享 ACME 状态
+- 真正的 certless HTTPS 冷启动
+- HTTP/3 证书热刷新彻底收口

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ scripts/run-fuzz-coverage.sh --target certificate_inspect
 ## 文档
 
 - [docs/README.md](docs/README.md) 汇总当前生效的仓库治理文档
+- [ACME_SUPPORT_PLAN.md](ACME_SUPPORT_PLAN.md) 记录 `instant-acme` 接入、HTTP-01、续期和运行时刷新阶段计划
 - [docs/CACHE_ARCHITECTURE_GAPS.md](docs/CACHE_ARCHITECTURE_GAPS.md) 记录缓存当前长期架构差距与演进方向
 - [docs/NEZHA_DASHBOARD.md](docs/NEZHA_DASHBOARD.md) 提供 Nezha Dashboard 反向代理完整示例
 - [fuzz/README.md](fuzz/README.md) 说明 fuzz target、seed、smoke 和 coverage 流程

--- a/crates/rginx-config/src/compile/acme.rs
+++ b/crates/rginx-config/src/compile/acme.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+use std::time::Duration;
+
+use rginx_core::{AcmeChallengeType, AcmeSettings, ManagedCertificateSpec, VirtualHostTls};
+
+use crate::model::{AcmeChallengeConfig, AcmeConfig, VirtualHostAcmeConfig};
+
+const DEFAULT_ACME_RENEW_BEFORE_DAYS: u64 = 30;
+const DEFAULT_ACME_POLL_INTERVAL_SECS: u64 = 3600;
+
+pub(super) fn compile_global_acme(
+    acme: Option<AcmeConfig>,
+    base_dir: &Path,
+) -> Option<AcmeSettings> {
+    let acme = acme?;
+    let directory_url = acme.directory_url.trim().to_string();
+    let contacts = acme.contacts.into_iter().map(|contact| contact.trim().to_string()).collect();
+    let state_dir = super::resolve_path(base_dir, acme.state_dir);
+    let renew_before = Duration::from_secs(
+        acme.renew_before_days.unwrap_or(DEFAULT_ACME_RENEW_BEFORE_DAYS) * 86_400,
+    );
+    let poll_interval =
+        Duration::from_secs(acme.poll_interval_secs.unwrap_or(DEFAULT_ACME_POLL_INTERVAL_SECS));
+
+    Some(AcmeSettings { directory_url, contacts, state_dir, renew_before, poll_interval })
+}
+
+pub(super) fn compile_managed_certificate_spec(
+    scope: String,
+    tls: &VirtualHostTls,
+    acme: Option<VirtualHostAcmeConfig>,
+) -> Option<ManagedCertificateSpec> {
+    let acme = acme?;
+    let domains = acme
+        .domains
+        .into_iter()
+        .map(|domain| domain.trim().to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    let challenge = match acme.challenge.unwrap_or(AcmeChallengeConfig::Http01) {
+        AcmeChallengeConfig::Http01 => AcmeChallengeType::Http01,
+    };
+
+    Some(ManagedCertificateSpec {
+        scope,
+        domains,
+        cert_path: tls.cert_path.clone(),
+        key_path: tls.key_path.clone(),
+        challenge,
+    })
+}

--- a/crates/rginx-config/src/compile/mod.rs
+++ b/crates/rginx-config/src/compile/mod.rs
@@ -5,6 +5,7 @@ use rginx_core::{ConfigSnapshot, Result, VirtualHost};
 
 use crate::validate::validate;
 
+mod acme;
 mod cache;
 mod path;
 mod route;
@@ -46,6 +47,7 @@ pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<Conf
 
     let Config {
         runtime,
+        acme: raw_acme,
         listeners: raw_listeners,
         cache_zones: raw_cache_zones,
         server,
@@ -54,6 +56,7 @@ pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<Conf
         servers: raw_servers,
     } = raw;
     let runtime = runtime::compile_runtime_settings(runtime)?;
+    let acme = acme::compile_global_acme(raw_acme, base_dir);
     let cache_zones = cache::compile_cache_zones(raw_cache_zones, base_dir)?;
     let any_vhost_tls = raw_servers.iter().any(|vhost| vhost.tls.is_some());
     let any_vhost_listen = raw_servers.iter().any(|vhost| !vhost.listen.is_empty());
@@ -78,6 +81,7 @@ pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<Conf
         tls: None,
     };
 
+    let mut managed_certificates = Vec::new();
     let compiled_vhosts = raw_servers
         .into_iter()
         .enumerate()
@@ -93,10 +97,22 @@ pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<Conf
     let mut vhosts = Vec::with_capacity(compiled_vhosts.len());
     for compiled in compiled_vhosts {
         upstreams.extend(compiled.upstreams);
+        if let Some(spec) = compiled.managed_certificate {
+            managed_certificates.push(spec);
+        }
         vhosts.push(compiled.vhost);
     }
 
-    Ok(ConfigSnapshot { runtime, listeners, default_vhost, vhosts, cache_zones, upstreams })
+    Ok(ConfigSnapshot {
+        runtime,
+        acme,
+        managed_certificates,
+        listeners,
+        default_vhost,
+        vhosts,
+        cache_zones,
+        upstreams,
+    })
 }
 #[cfg(test)]
 mod tests;

--- a/crates/rginx-config/src/compile/server/tls.rs
+++ b/crates/rginx-config/src/compile/server/tls.rs
@@ -80,6 +80,7 @@ pub(super) fn compile_virtual_host_tls(
         additional_certificates,
         ocsp_staple_path,
         ocsp,
+        acme: _,
     }) = tls
     else {
         return Ok(None);

--- a/crates/rginx-config/src/compile/tests.rs
+++ b/crates/rginx-config/src/compile/tests.rs
@@ -53,6 +53,7 @@ fn test_location(matcher: MatcherConfig, handler: HandlerConfig) -> LocationConf
     }
 }
 
+mod acme;
 mod cache;
 mod cache_p1;
 mod cache_p2;

--- a/crates/rginx-config/src/compile/tests/acme.rs
+++ b/crates/rginx-config/src/compile/tests/acme.rs
@@ -1,0 +1,196 @@
+use super::*;
+
+fn listener(name: &str, listen: &str, tls: Option<ServerTlsConfig>) -> ListenerConfig {
+    ListenerConfig {
+        name: name.to_string(),
+        server_header: None,
+        proxy_protocol: None,
+        default_certificate: None,
+        listen: listen.to_string(),
+        trusted_proxies: Vec::new(),
+        client_ip_header: None,
+        keep_alive: Some(true),
+        max_headers: None,
+        max_request_body_bytes: None,
+        max_connections: None,
+        header_read_timeout_secs: None,
+        request_body_read_timeout_secs: None,
+        response_write_timeout_secs: None,
+        access_log_format: None,
+        tls,
+        http3: None,
+    }
+}
+
+fn server_tls(cert_path: &str, key_path: &str) -> ServerTlsConfig {
+    ServerTlsConfig {
+        cert_path: cert_path.to_string(),
+        key_path: key_path.to_string(),
+        additional_certificates: None,
+        versions: None,
+        cipher_suites: None,
+        key_exchange_groups: None,
+        alpn_protocols: None,
+        ocsp_staple_path: None,
+        ocsp: None,
+        session_resumption: None,
+        session_tickets: None,
+        session_cache_size: None,
+        session_ticket_count: None,
+        client_auth: None,
+    }
+}
+
+fn managed_vhost(
+    server_names: Vec<&str>,
+    domains: Vec<&str>,
+    cert_path: &str,
+    key_path: &str,
+) -> VirtualHostConfig {
+    VirtualHostConfig {
+        listen: Vec::new(),
+        server_names: server_names.into_iter().map(str::to_string).collect(),
+        upstreams: Vec::new(),
+        locations: vec![test_location(
+            MatcherConfig::Exact("/".to_string()),
+            HandlerConfig::Return {
+                status: 200,
+                location: String::new(),
+                body: Some("managed\n".to_string()),
+            },
+        )],
+        tls: Some(crate::model::VirtualHostTlsConfig {
+            acme: Some(crate::model::VirtualHostAcmeConfig {
+                domains: domains.into_iter().map(str::to_string).collect(),
+                challenge: None,
+            }),
+            cert_path: cert_path.to_string(),
+            key_path: key_path.to_string(),
+            additional_certificates: None,
+            ocsp_staple_path: None,
+            ocsp: None,
+        }),
+        http3: None,
+    }
+}
+
+fn managed_acme_config(
+    directory_url: &str,
+    state_dir: &str,
+    renew_before_days: Option<u64>,
+    poll_interval_secs: Option<u64>,
+    server_names: Vec<&str>,
+    domains: Vec<&str>,
+) -> Config {
+    let cert_path = "managed.crt";
+    let key_path = "managed.key";
+
+    Config {
+        acme: Some(crate::model::AcmeConfig {
+            directory_url: directory_url.to_string(),
+            contacts: vec![
+                " mailto:ops@example.com ".to_string(),
+                "mailto:security@example.com".to_string(),
+            ],
+            state_dir: state_dir.to_string(),
+            renew_before_days,
+            poll_interval_secs,
+        }),
+        cache_zones: Vec::new(),
+        runtime: RuntimeConfig {
+            shutdown_timeout_secs: 10,
+            worker_threads: None,
+            accept_workers: None,
+        },
+        listeners: vec![
+            listener("http", "127.0.0.1:80", None),
+            listener("https", "127.0.0.1:443", Some(server_tls(cert_path, key_path))),
+        ],
+        server: ServerConfig {
+            listen: None,
+            server_header: None,
+            proxy_protocol: None,
+            default_certificate: None,
+            server_names: Vec::new(),
+            trusted_proxies: Vec::new(),
+            client_ip_header: None,
+            keep_alive: None,
+            max_headers: None,
+            max_request_body_bytes: None,
+            max_connections: None,
+            header_read_timeout_secs: None,
+            request_body_read_timeout_secs: None,
+            response_write_timeout_secs: None,
+            access_log_format: None,
+            tls: None,
+            http3: None,
+        },
+        upstreams: Vec::new(),
+        locations: Vec::new(),
+        servers: vec![managed_vhost(server_names, domains, cert_path, key_path)],
+    }
+}
+
+#[test]
+fn compile_resolves_global_acme_settings_relative_to_base() {
+    let base_dir = temp_base_dir("rginx-acme-global-");
+    fs::write(base_dir.path().join("managed.crt"), b"placeholder")
+        .expect("managed cert should be written");
+    fs::write(base_dir.path().join("managed.key"), b"placeholder")
+        .expect("managed key should be written");
+
+    let config = managed_acme_config(
+        " https://acme-staging-v02.api.letsencrypt.org/directory ",
+        "state/acme",
+        Some(21),
+        Some(600),
+        vec!["api.example.com"],
+        vec!["api.example.com"],
+    );
+
+    let snapshot =
+        compile_with_base(config, base_dir.path()).expect("managed ACME config should compile");
+    let acme = snapshot.acme.expect("compiled snapshot should include ACME settings");
+
+    assert_eq!(acme.directory_url, "https://acme-staging-v02.api.letsencrypt.org/directory");
+    assert_eq!(
+        acme.contacts,
+        vec!["mailto:ops@example.com".to_string(), "mailto:security@example.com".to_string(),]
+    );
+    assert_eq!(acme.state_dir, base_dir.path().join("state/acme"));
+    assert_eq!(acme.renew_before, Duration::from_secs(21 * 86_400));
+    assert_eq!(acme.poll_interval, Duration::from_secs(600));
+}
+
+#[test]
+fn compile_emits_managed_certificate_specs_for_acme_vhosts() {
+    let base_dir = temp_base_dir("rginx-acme-managed-spec-");
+    fs::write(base_dir.path().join("managed.crt"), b"placeholder")
+        .expect("managed cert should be written");
+    fs::write(base_dir.path().join("managed.key"), b"placeholder")
+        .expect("managed key should be written");
+
+    let config = managed_acme_config(
+        "https://acme-staging-v02.api.letsencrypt.org/directory",
+        "state/acme",
+        None,
+        None,
+        vec!["API.EXAMPLE.COM", "www.example.com"],
+        vec![" api.example.com ", "WWW.EXAMPLE.COM"],
+    );
+
+    let snapshot =
+        compile_with_base(config, base_dir.path()).expect("managed ACME config should compile");
+
+    let acme = snapshot.acme.as_ref().expect("compiled snapshot should include ACME settings");
+    assert_eq!(acme.renew_before, Duration::from_secs(30 * 86_400));
+    assert_eq!(acme.poll_interval, Duration::from_secs(3600));
+
+    assert_eq!(snapshot.managed_certificates.len(), 1);
+    let spec = &snapshot.managed_certificates[0];
+    assert_eq!(spec.scope, "servers[0]");
+    assert_eq!(spec.domains, vec!["api.example.com".to_string(), "www.example.com".to_string()]);
+    assert_eq!(spec.cert_path, base_dir.path().join("managed.crt"));
+    assert_eq!(spec.key_path, base_dir.path().join("managed.key"));
+    assert_eq!(spec.challenge, rginx_core::AcmeChallengeType::Http01);
+}

--- a/crates/rginx-config/src/compile/tests/cache.rs
+++ b/crates/rginx-config/src/compile/tests/cache.rs
@@ -4,6 +4,7 @@ use super::*;
 fn compile_attaches_cache_zones_and_route_policy() {
     let base_dir = temp_base_dir("rginx-cache-compile");
     let mut config = Config {
+        acme: None,
         cache_zones: vec![CacheZoneConfig {
             name: "default".to_string(),
             path: "cache/default".to_string(),
@@ -194,6 +195,7 @@ fn compile_attaches_cache_zones_and_route_policy() {
 fn compile_cache_policy_supports_p0_controls() {
     let base_dir = temp_base_dir("rginx-cache-compile-p0");
     let config = Config {
+        acme: None,
         cache_zones: vec![CacheZoneConfig {
             name: "default".to_string(),
             path: "cache/default".to_string(),

--- a/crates/rginx-config/src/compile/tests/cache_p1.rs
+++ b/crates/rginx-config/src/compile/tests/cache_p1.rs
@@ -4,6 +4,7 @@ use super::*;
 fn compile_cache_policy_supports_p1_controls() {
     let base_dir = temp_base_dir("rginx-cache-compile-p1");
     let config = Config {
+        acme: None,
         cache_zones: vec![CacheZoneConfig {
             name: "default".to_string(),
             path: "cache/default".to_string(),

--- a/crates/rginx-config/src/compile/tests/cache_p2.rs
+++ b/crates/rginx-config/src/compile/tests/cache_p2.rs
@@ -4,6 +4,7 @@ use super::*;
 fn compile_cache_policy_supports_disabling_p2_defaults() {
     let base_dir = temp_base_dir("rginx-cache-compile-p2-disable");
     let config = Config {
+        acme: None,
         cache_zones: vec![CacheZoneConfig {
             name: "default".to_string(),
             path: "cache/default".to_string(),

--- a/crates/rginx-config/src/compile/tests/cache_p3.rs
+++ b/crates/rginx-config/src/compile/tests/cache_p3.rs
@@ -4,6 +4,7 @@ use super::*;
 fn compile_cache_policy_supports_p3_slice_controls() {
     let base_dir = temp_base_dir("rginx-cache-compile-p3");
     let config = Config {
+        acme: None,
         cache_zones: vec![CacheZoneConfig {
             name: "default".to_string(),
             path: "cache/default".to_string(),

--- a/crates/rginx-config/src/compile/tests/http3.rs
+++ b/crates/rginx-config/src/compile/tests/http3.rs
@@ -9,6 +9,7 @@ fn compile_http3_listener_defaults_to_tcp_listen_addr_and_default_alt_svc_policy
     fs::write(&key_path, "placeholder key").expect("key file should be written");
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -114,6 +115,7 @@ fn compile_http3_applies_transport_settings_and_resolves_host_key_path() {
     fs::write(&key_path, b"placeholder").expect("server key should be written");
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 2,

--- a/crates/rginx-config/src/compile/tests/listeners.rs
+++ b/crates/rginx-config/src/compile/tests/listeners.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_supports_explicit_multi_listener_configs() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/route.rs
+++ b/crates/rginx-config/src/compile/tests/route.rs
@@ -5,6 +5,7 @@ mod regex;
 #[test]
 fn compile_attaches_route_access_control() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -67,6 +68,7 @@ fn compile_attaches_route_access_control() {
 #[test]
 fn compile_attaches_route_rate_limit() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -131,6 +133,7 @@ fn compile_attaches_route_rate_limit() {
 #[test]
 fn compile_applies_route_transport_policy_defaults_and_overrides() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -230,6 +233,7 @@ fn compile_applies_route_transport_policy_defaults_and_overrides() {
 #[test]
 fn compile_generates_distinct_route_and_vhost_ids() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -295,6 +299,7 @@ fn compile_generates_distinct_route_and_vhost_ids() {
 #[test]
 fn compile_prioritizes_grpc_constrained_routes_with_same_path_matcher() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/route/regex.rs
+++ b/crates/rginx-config/src/compile/tests/route/regex.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_attaches_regex_matcher_and_dynamic_proxy_headers() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -119,6 +120,7 @@ fn compile_attaches_regex_matcher_and_dynamic_proxy_headers() {
 #[test]
 fn compile_preserves_declaration_order_for_overlapping_regex_routes() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/server_settings.rs
+++ b/crates/rginx-config/src/compile/tests/server_settings.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_applies_custom_server_header() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -48,6 +49,7 @@ fn compile_applies_custom_server_header() {
 #[test]
 fn compile_normalizes_trusted_proxy_ips_and_cidrs() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -115,6 +117,7 @@ fn compile_normalizes_trusted_proxy_ips_and_cidrs() {
 #[test]
 fn compile_attaches_server_hardening_settings() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -198,6 +201,7 @@ fn compile_attaches_server_hardening_settings() {
 #[test]
 fn compile_rejects_invalid_server_access_log_format() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/server_tls.rs
+++ b/crates/rginx-config/src/compile/tests/server_tls.rs
@@ -9,6 +9,7 @@ fn compile_resolves_server_tls_paths_relative_to_config_base() {
     fs::write(&key_path, b"placeholder").expect("temp key file should be written");
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -94,6 +95,7 @@ fn compile_preserves_server_tls_policy_fields() {
     fs::write(&key_path, b"placeholder").expect("temp key file should be written");
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -185,6 +187,7 @@ fn compile_preserves_server_tls_ocsp_policy_fields() {
     fs::write(&ocsp_path, b"").expect("temp ocsp file should be written");
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/upstream_defaults.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_defaults.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_accepts_https_upstreams() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -116,6 +117,7 @@ fn compile_accepts_https_upstreams() {
 #[test]
 fn compile_defaults_grpc_health_check_path_when_service_is_set() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/upstream_fallbacks.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_fallbacks.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_accepts_backup_peers() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -125,6 +126,7 @@ fn compile_accepts_backup_peers() {
 #[test]
 fn compile_uses_legacy_request_timeout_fallbacks_and_disables_pool_idle_timeout() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -234,6 +236,7 @@ fn compile_uses_legacy_request_timeout_fallbacks_and_disables_pool_idle_timeout(
 #[test]
 fn compile_uses_default_pool_idle_timeout() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/upstream_server_name.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_server_name.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_normalizes_server_name_override() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -103,6 +104,7 @@ fn compile_normalizes_server_name_override() {
 #[test]
 fn compile_preserves_upstream_server_name_toggle() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -209,6 +211,7 @@ fn compile_preserves_upstream_server_name_toggle() {
 #[test]
 fn compile_rejects_invalid_server_name_override() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/upstream_tls.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_tls.rs
@@ -7,6 +7,7 @@ fn compile_resolves_custom_ca_relative_to_config_base() {
     fs::write(&ca_path, b"placeholder").expect("temp CA file should be written");
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -136,6 +137,7 @@ fn compile_resolves_custom_ca_relative_to_config_base() {
 #[test]
 fn compile_accepts_https_http3_upstreams() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -242,6 +244,7 @@ fn compile_resolves_upstream_mtls_identity_and_tls_versions_relative_to_config_b
     fs::write(&client_key_path, b"placeholder").expect("temp client key file should be written");
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/upstream_transport.rs
+++ b/crates/rginx-config/src/compile/tests/upstream_transport.rs
@@ -3,6 +3,7 @@ use super::*;
 #[test]
 fn compile_applies_granular_upstream_transport_settings() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -98,6 +99,7 @@ fn compile_applies_granular_upstream_transport_settings() {
 #[test]
 fn compile_accepts_least_conn_load_balance() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -205,6 +207,7 @@ fn compile_accepts_least_conn_load_balance() {
 #[test]
 fn compile_applies_peer_weights() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/compile/tests/vhosts.rs
+++ b/crates/rginx-config/src/compile/tests/vhosts.rs
@@ -10,6 +10,7 @@ fn compile_generates_deduplicated_listeners_from_vhost_listen() {
     fs::write(base_dir.path().join("api.key"), b"placeholder").expect("key should be written");
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -30,6 +31,7 @@ fn compile_generates_deduplicated_listeners_from_vhost_listen() {
                 upstreams: Vec::new(),
                 locations: vec![return_location("api\n")],
                 tls: Some(crate::model::VirtualHostTlsConfig {
+                    acme: None,
                     cert_path: "api.crt".to_string(),
                     key_path: "api.key".to_string(),
                     additional_certificates: None,
@@ -76,6 +78,7 @@ fn compile_generates_deduplicated_listeners_from_vhost_listen() {
 #[test]
 fn compile_uses_vhost_local_upstream_before_global_upstream() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -131,6 +134,7 @@ fn compile_applies_server_tls_defaults_only_to_vhost_ssl_listeners() {
     server.tls = Some(server_tls("default.crt", "default.key"));
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -147,6 +151,7 @@ fn compile_applies_server_tls_defaults_only_to_vhost_ssl_listeners() {
             upstreams: Vec::new(),
             locations: vec![return_location("api\n")],
             tls: Some(crate::model::VirtualHostTlsConfig {
+                acme: None,
                 cert_path: "api.crt".to_string(),
                 key_path: "api.key".to_string(),
                 additional_certificates: None,
@@ -183,6 +188,7 @@ fn compile_uses_first_tls_vhost_as_implicit_default_certificate() {
     }
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -212,6 +218,7 @@ fn compile_uses_first_tls_vhost_as_implicit_default_certificate() {
 #[test]
 fn compile_preserves_ipv6_vhost_listener_ids() {
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -288,6 +295,7 @@ fn tls_vhost(server_name: &str, cert_path: &str, key_path: &str) -> VirtualHostC
         upstreams: Vec::new(),
         locations: vec![return_location("ok\n")],
         tls: Some(crate::model::VirtualHostTlsConfig {
+            acme: None,
             cert_path: cert_path.to_string(),
             key_path: key_path.to_string(),
             additional_certificates: None,

--- a/crates/rginx-config/src/compile/tests/vhosts/listener_conflicts.rs
+++ b/crates/rginx-config/src/compile/tests/vhosts/listener_conflicts.rs
@@ -44,6 +44,7 @@ fn compile_rejects_conflicting_shared_vhost_listener_flags() {
 
     for (servers, expected) in cases {
         let config = Config {
+            acme: None,
             cache_zones: Vec::new(),
             runtime: RuntimeConfig {
                 shutdown_timeout_secs: 10,
@@ -74,6 +75,7 @@ fn listen_vhost(
         upstreams: Vec::new(),
         locations: vec![return_location("ok\n")],
         tls: tls.then(|| crate::model::VirtualHostTlsConfig {
+            acme: None,
             cert_path: format!("{server_name}.crt"),
             key_path: format!("{server_name}.key"),
             additional_certificates: None,

--- a/crates/rginx-config/src/compile/tests/vhosts/nezha.rs
+++ b/crates/rginx-config/src/compile/tests/vhosts/nezha.rs
@@ -25,6 +25,7 @@ fn compile_supports_nezha_dashboard_native_vhost_shape() {
     dashboard_http.write_timeout_secs = Some(3600);
 
     let config = Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,
@@ -114,6 +115,7 @@ fn compile_supports_nezha_dashboard_native_vhost_shape() {
                 ),
             ],
             tls: Some(crate::model::VirtualHostTlsConfig {
+                acme: None,
                 cert_path: "dashboard.crt".to_string(),
                 key_path: "dashboard.key".to_string(),
                 additional_certificates: None,

--- a/crates/rginx-config/src/compile/vhost.rs
+++ b/crates/rginx-config/src/compile/vhost.rs
@@ -2,13 +2,14 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use rginx_core::{Result, Upstream, VirtualHost};
+use rginx_core::{ManagedCertificateSpec, Result, Upstream, VirtualHost};
 
 use crate::model::VirtualHostConfig;
 
 pub(super) struct CompiledVirtualHost {
     pub(super) vhost: VirtualHost,
     pub(super) upstreams: HashMap<String, Arc<Upstream>>,
+    pub(super) managed_certificate: Option<ManagedCertificateSpec>,
 }
 
 pub(super) fn compile_virtual_host(
@@ -25,6 +26,7 @@ pub(super) fn compile_virtual_host(
         tls,
         http3: _,
     } = config;
+    let acme = tls.as_ref().and_then(|tls| tls.acme.clone());
     let local_upstream_names = raw_upstreams
         .iter()
         .map(|upstream| {
@@ -48,9 +50,13 @@ pub(super) fn compile_virtual_host(
         &vhost_id,
     )?;
     let tls = super::server::compile_virtual_host_tls(tls, base_dir)?;
+    let managed_certificate = tls
+        .as_ref()
+        .and_then(|tls| super::acme::compile_managed_certificate_spec(vhost_id.clone(), tls, acme));
 
     Ok(CompiledVirtualHost {
         vhost: VirtualHost { id: vhost_id, server_names, routes, tls },
         upstreams: local_upstreams,
+        managed_certificate,
     })
 }

--- a/crates/rginx-config/src/model.rs
+++ b/crates/rginx-config/src/model.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 
+mod acme;
 mod cache;
 mod listener;
 mod route;
@@ -9,6 +10,7 @@ mod tls;
 mod upstream;
 mod vhost;
 
+pub use acme::{AcmeChallengeConfig, AcmeConfig, VirtualHostAcmeConfig};
 pub use cache::{
     CacheIgnoreHeaderConfig, CachePredicateConfig, CacheRangeRequestPolicyConfig, CacheRouteConfig,
     CacheStatusTtlConfig, CacheUseStaleConditionConfig, CacheZoneConfig,
@@ -34,6 +36,8 @@ pub use vhost::VirtualHostConfig;
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub runtime: RuntimeConfig,
+    #[serde(default)]
+    pub acme: Option<AcmeConfig>,
     #[serde(default)]
     pub listeners: Vec<ListenerConfig>,
     #[serde(default)]

--- a/crates/rginx-config/src/model/acme.rs
+++ b/crates/rginx-config/src/model/acme.rs
@@ -1,0 +1,26 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AcmeConfig {
+    pub directory_url: String,
+    #[serde(default)]
+    pub contacts: Vec<String>,
+    pub state_dir: String,
+    #[serde(default)]
+    pub renew_before_days: Option<u64>,
+    #[serde(default)]
+    pub poll_interval_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VirtualHostAcmeConfig {
+    #[serde(default)]
+    pub domains: Vec<String>,
+    #[serde(default)]
+    pub challenge: Option<AcmeChallengeConfig>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Hash)]
+pub enum AcmeChallengeConfig {
+    Http01,
+}

--- a/crates/rginx-config/src/model/tls.rs
+++ b/crates/rginx-config/src/model/tls.rs
@@ -1,3 +1,4 @@
+use super::VirtualHostAcmeConfig;
 use serde::{Deserialize, Deserializer, de};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -37,6 +38,7 @@ pub struct VirtualHostTlsConfig {
     pub additional_certificates: Option<Vec<ServerCertificateBundleConfig>>,
     pub ocsp_staple_path: Option<String>,
     pub ocsp: Option<OcspConfig>,
+    pub acme: Option<VirtualHostAcmeConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -132,6 +134,8 @@ impl<'de> Deserialize<'de> for VirtualHostTlsConfig {
                 ocsp_staple_path: Option<String>,
                 #[serde(default)]
                 ocsp: Option<OcspConfig>,
+                #[serde(default)]
+                acme: Option<VirtualHostAcmeConfig>,
             },
             ServerTlsConfig {
                 cert_path: String,
@@ -160,6 +164,8 @@ impl<'de> Deserialize<'de> for VirtualHostTlsConfig {
                 session_ticket_count: Option<u64>,
                 #[serde(default)]
                 client_auth: Option<ServerClientAuthConfig>,
+                #[serde(default)]
+                acme: Option<VirtualHostAcmeConfig>,
             },
         }
 
@@ -170,7 +176,15 @@ impl<'de> Deserialize<'de> for VirtualHostTlsConfig {
                 additional_certificates,
                 ocsp_staple_path,
                 ocsp,
-            } => Ok(Self { cert_path, key_path, additional_certificates, ocsp_staple_path, ocsp }),
+                acme,
+            } => Ok(Self {
+                cert_path,
+                key_path,
+                additional_certificates,
+                ocsp_staple_path,
+                ocsp,
+                acme,
+            }),
             VirtualHostTlsConfigDe::ServerTlsConfig {
                 cert_path,
                 key_path,
@@ -186,6 +200,7 @@ impl<'de> Deserialize<'de> for VirtualHostTlsConfig {
                 session_cache_size,
                 session_ticket_count,
                 client_auth,
+                acme,
             } => {
                 if versions.is_some()
                     || cipher_suites.is_some()
@@ -196,13 +211,21 @@ impl<'de> Deserialize<'de> for VirtualHostTlsConfig {
                     || session_cache_size.is_some()
                     || session_ticket_count.is_some()
                     || client_auth.is_some()
+                    || acme.is_some()
                 {
                     return Err(de::Error::custom(
-                        "vhost TLS policy fields are not supported in legacy `ServerTlsConfig(...)`; use `VirtualHostTlsConfig(...)` for certificate overrides and keep versions, cipher_suites, key_exchange_groups, ALPN, session settings, session cache settings, and client_auth on server.tls or listeners[].tls",
+                        "vhost TLS policy fields are not supported in legacy `ServerTlsConfig(...)`; use `VirtualHostTlsConfig(...)` for certificate overrides, ACME-managed certificates, and keep versions, cipher_suites, key_exchange_groups, ALPN, session settings, session cache settings, and client_auth on server.tls or listeners[].tls",
                     ));
                 }
 
-                Ok(Self { cert_path, key_path, additional_certificates, ocsp_staple_path, ocsp })
+                Ok(Self {
+                    cert_path,
+                    key_path,
+                    additional_certificates,
+                    ocsp_staple_path,
+                    ocsp,
+                    acme: None,
+                })
             }
         }
     }

--- a/crates/rginx-config/src/validate.rs
+++ b/crates/rginx-config/src/validate.rs
@@ -4,6 +4,7 @@ use rginx_core::{Error, Result};
 
 use crate::model::{Config, LocationConfig, RouteBufferingPolicyConfig};
 
+mod acme;
 mod cache;
 mod route;
 mod runtime;
@@ -37,6 +38,7 @@ pub fn validate(config: &Config) -> Result<()> {
         config.server.tls.as_ref(),
         &cache_zone_names,
     )?;
+    acme::validate_acme(config)?;
     validate_request_buffering_limits(config)?;
 
     Ok(())

--- a/crates/rginx-config/src/validate/acme.rs
+++ b/crates/rginx-config/src/validate/acme.rs
@@ -139,6 +139,20 @@ fn normalize_unique_domains(
 }
 
 fn has_http01_listener(config: &Config) -> Result<bool> {
+    let any_vhost_listen = config.servers.iter().any(|vhost| !vhost.listen.is_empty());
+    if any_vhost_listen {
+        for (vhost_index, vhost) in config.servers.iter().enumerate() {
+            for (listen_index, listen) in vhost.listen.iter().enumerate() {
+                let owner = format!("servers[{vhost_index}].listen[{listen_index}]");
+                let parsed = crate::listen::parse_vhost_listen(&owner, listen)?;
+                if parsed.addr.port() == 80 && !parsed.ssl {
+                    return Ok(true);
+                }
+            }
+        }
+        return Ok(false);
+    }
+
     if !config.listeners.is_empty() {
         for (listener_index, listener) in config.listeners.iter().enumerate() {
             if listener.tls.is_some() {
@@ -157,19 +171,8 @@ fn has_http01_listener(config: &Config) -> Result<bool> {
         return Ok(false);
     }
 
-    let any_vhost_listen = config.servers.iter().any(|vhost| !vhost.listen.is_empty());
-    if any_vhost_listen {
-        for (vhost_index, vhost) in config.servers.iter().enumerate() {
-            for (listen_index, listen) in vhost.listen.iter().enumerate() {
-                let owner = format!("servers[{vhost_index}].listen[{listen_index}]");
-                let parsed = crate::listen::parse_vhost_listen(&owner, listen)?;
-                if parsed.addr.port() == 80 && !parsed.ssl {
-                    return Ok(true);
-                }
-            }
-        }
-        return Ok(false);
-    }
-
+    // In legacy server.listen mode, any managed vhost certificate turns the single generated
+    // listener into a TLS termination point for that bind, so it cannot satisfy HTTP-01's
+    // requirement for a plain HTTP listener on port 80.
     Ok(false)
 }

--- a/crates/rginx-config/src/validate/acme.rs
+++ b/crates/rginx-config/src/validate/acme.rs
@@ -140,14 +140,21 @@ fn normalize_unique_domains(
 
 fn has_http01_listener(config: &Config) -> Result<bool> {
     if !config.listeners.is_empty() {
-        return Ok(config.listeners.iter().any(|listener| {
-            listener.tls.is_none()
-                && listener
-                    .listen
-                    .parse::<std::net::SocketAddr>()
-                    .map(|addr| addr.port() == 80)
-                    .unwrap_or(false)
-        }));
+        for (listener_index, listener) in config.listeners.iter().enumerate() {
+            if listener.tls.is_some() {
+                continue;
+            }
+
+            let owner = format!("listeners[{listener_index}].listen");
+            let listen_addr = listener.listen.parse::<std::net::SocketAddr>().map_err(|error| {
+                Error::Config(format!("{owner} `{}` is invalid: {error}", listener.listen))
+            })?;
+            if listen_addr.port() == 80 {
+                return Ok(true);
+            }
+        }
+
+        return Ok(false);
     }
 
     let any_vhost_listen = config.servers.iter().any(|vhost| !vhost.listen.is_empty());

--- a/crates/rginx-config/src/validate/acme.rs
+++ b/crates/rginx-config/src/validate/acme.rs
@@ -1,0 +1,168 @@
+use std::collections::BTreeSet;
+
+use rginx_core::{Error, Result};
+
+use crate::model::{
+    AcmeConfig, Config, VirtualHostAcmeConfig, VirtualHostConfig, VirtualHostTlsConfig,
+};
+
+pub(super) fn validate_acme(config: &Config) -> Result<()> {
+    if let Some(acme) = config.acme.as_ref() {
+        validate_global_acme(acme)?;
+    }
+
+    let mut any_managed_vhost = false;
+    for (index, vhost) in config.servers.iter().enumerate() {
+        let Some(tls) = vhost.tls.as_ref() else {
+            continue;
+        };
+        let Some(acme) = tls.acme.as_ref() else {
+            continue;
+        };
+
+        any_managed_vhost = true;
+        validate_vhost_acme(&format!("servers[{index}]"), vhost, tls, acme, config.acme.as_ref())?;
+    }
+
+    if any_managed_vhost && !has_http01_listener(config)? {
+        return Err(Error::Config(
+            "ACME HTTP-01 requires at least one plain HTTP listener bound to port 80".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_global_acme(acme: &AcmeConfig) -> Result<()> {
+    if acme.directory_url.trim().is_empty() {
+        return Err(Error::Config("acme.directory_url must not be empty".to_string()));
+    }
+
+    if acme.state_dir.trim().is_empty() {
+        return Err(Error::Config("acme.state_dir must not be empty".to_string()));
+    }
+
+    for (index, contact) in acme.contacts.iter().enumerate() {
+        if contact.trim().is_empty() {
+            return Err(Error::Config(format!("acme.contacts[{index}] must not be empty")));
+        }
+    }
+
+    if acme.renew_before_days.is_some_and(|days| days == 0) {
+        return Err(Error::Config("acme.renew_before_days must be greater than 0".to_string()));
+    }
+
+    if acme.poll_interval_secs.is_some_and(|secs| secs == 0) {
+        return Err(Error::Config("acme.poll_interval_secs must be greater than 0".to_string()));
+    }
+
+    Ok(())
+}
+
+fn validate_vhost_acme(
+    owner_label: &str,
+    vhost: &VirtualHostConfig,
+    tls: &VirtualHostTlsConfig,
+    acme: &VirtualHostAcmeConfig,
+    global_acme: Option<&AcmeConfig>,
+) -> Result<()> {
+    if global_acme.is_none() {
+        return Err(Error::Config(format!(
+            "{owner_label} TLS ACME requires top-level acme configuration"
+        )));
+    }
+
+    if tls.additional_certificates.as_ref().is_some_and(|bundles| !bundles.is_empty()) {
+        return Err(Error::Config(format!(
+            "{owner_label} TLS ACME does not support additional_certificates in phase 1"
+        )));
+    }
+
+    if acme.domains.is_empty() {
+        return Err(Error::Config(format!("{owner_label} TLS ACME domains must not be empty")));
+    }
+
+    let normalized_server_names = normalize_unique_domains(
+        &vhost.server_names,
+        &format!("{owner_label} server_names"),
+        true,
+    )?;
+    let normalized_domains =
+        normalize_unique_domains(&acme.domains, &format!("{owner_label} TLS ACME domains"), true)?;
+
+    if normalized_domains != normalized_server_names {
+        return Err(Error::Config(format!(
+            "{owner_label} TLS ACME domains must match server_names exactly in phase 1"
+        )));
+    }
+
+    if acme
+        .challenge
+        .is_some_and(|challenge| !matches!(challenge, crate::model::AcmeChallengeConfig::Http01))
+    {
+        return Err(Error::Config(format!(
+            "{owner_label} TLS ACME only supports HTTP-01 in phase 1"
+        )));
+    }
+
+    Ok(())
+}
+
+fn normalize_unique_domains(
+    values: &[String],
+    owner_label: &str,
+    reject_wildcards: bool,
+) -> Result<BTreeSet<String>> {
+    let mut normalized = BTreeSet::new();
+
+    for (index, value) in values.iter().enumerate() {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(Error::Config(format!("{owner_label}[{index}] must not be empty")));
+        }
+
+        if reject_wildcards && value.contains('*') {
+            return Err(Error::Config(format!(
+                "{owner_label}[{index}] wildcard `{value}` is not supported by ACME phase 1"
+            )));
+        }
+
+        let lowered = value.to_ascii_lowercase();
+        if !normalized.insert(lowered) {
+            return Err(Error::Config(format!(
+                "{owner_label}[{index}] duplicates another ACME domain entry"
+            )));
+        }
+    }
+
+    Ok(normalized)
+}
+
+fn has_http01_listener(config: &Config) -> Result<bool> {
+    if !config.listeners.is_empty() {
+        return Ok(config.listeners.iter().any(|listener| {
+            listener.tls.is_none()
+                && listener
+                    .listen
+                    .parse::<std::net::SocketAddr>()
+                    .map(|addr| addr.port() == 80)
+                    .unwrap_or(false)
+        }));
+    }
+
+    let any_vhost_listen = config.servers.iter().any(|vhost| !vhost.listen.is_empty());
+    if any_vhost_listen {
+        for (vhost_index, vhost) in config.servers.iter().enumerate() {
+            for (listen_index, listen) in vhost.listen.iter().enumerate() {
+                let owner = format!("servers[{vhost_index}].listen[{listen_index}]");
+                let parsed = crate::listen::parse_vhost_listen(&owner, listen)?;
+                if parsed.addr.port() == 80 && !parsed.ssl {
+                    return Ok(true);
+                }
+            }
+        }
+        return Ok(false);
+    }
+
+    Ok(false)
+}

--- a/crates/rginx-config/src/validate/tests.rs
+++ b/crates/rginx-config/src/validate/tests.rs
@@ -9,6 +9,7 @@ use crate::model::{
 
 use super::{DEFAULT_GRPC_HEALTH_CHECK_PATH, validate};
 
+mod acme;
 mod cache;
 mod listeners;
 mod route;
@@ -24,6 +25,7 @@ mod vhosts;
 
 fn base_config() -> Config {
     Config {
+        acme: None,
         cache_zones: Vec::new(),
         runtime: RuntimeConfig {
             shutdown_timeout_secs: 10,

--- a/crates/rginx-config/src/validate/tests/acme.rs
+++ b/crates/rginx-config/src/validate/tests/acme.rs
@@ -144,6 +144,14 @@ fn validate_rejects_zero_global_acme_poll_interval_secs() {
 }
 
 #[test]
+fn validate_accepts_global_acme_without_contacts() {
+    let mut config = base_config();
+    config.acme = Some(crate::model::AcmeConfig { contacts: Vec::new(), ..valid_global_acme() });
+
+    validate(&config).expect("phase 1 should allow ACME accounts without explicit contacts");
+}
+
+#[test]
 fn validate_rejects_managed_vhost_without_global_acme() {
     let mut config = base_config();
     enable_acme_listeners(&mut config);
@@ -236,6 +244,23 @@ fn validate_rejects_managed_vhost_without_plain_http_80_listener() {
     config.servers = vec![managed_vhost(vec!["api.example.com"], vec!["api.example.com"])];
 
     let error = validate(&config).expect_err("HTTP-01 should require a plain HTTP :80 listener");
+    assert!(
+        error
+            .to_string()
+            .contains("ACME HTTP-01 requires at least one plain HTTP listener bound to port 80")
+    );
+}
+
+#[test]
+fn validate_rejects_managed_vhost_with_legacy_server_listen_only() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    config.server.listen = Some("127.0.0.1:80".to_string());
+    config.servers = vec![managed_vhost(vec!["api.example.com"], vec!["api.example.com"])];
+
+    let error = validate(&config).expect_err(
+        "legacy server.listen should not count as plain HTTP once vhost TLS is managed",
+    );
     assert!(
         error
             .to_string()

--- a/crates/rginx-config/src/validate/tests/acme.rs
+++ b/crates/rginx-config/src/validate/tests/acme.rs
@@ -1,0 +1,254 @@
+use super::*;
+
+fn explicit_listener(name: &str, listen: &str, tls: Option<ServerTlsConfig>) -> ListenerConfig {
+    ListenerConfig {
+        name: name.to_string(),
+        server_header: None,
+        proxy_protocol: None,
+        default_certificate: None,
+        listen: listen.to_string(),
+        trusted_proxies: Vec::new(),
+        client_ip_header: None,
+        keep_alive: Some(true),
+        max_headers: None,
+        max_request_body_bytes: None,
+        max_connections: None,
+        header_read_timeout_secs: None,
+        request_body_read_timeout_secs: None,
+        response_write_timeout_secs: None,
+        access_log_format: None,
+        tls,
+        http3: None,
+    }
+}
+
+fn valid_global_acme() -> crate::model::AcmeConfig {
+    crate::model::AcmeConfig {
+        directory_url: "https://acme-staging-v02.api.letsencrypt.org/directory".to_string(),
+        contacts: vec!["mailto:ops@example.com".to_string()],
+        state_dir: "var/acme".to_string(),
+        renew_before_days: None,
+        poll_interval_secs: None,
+    }
+}
+
+fn managed_vhost(server_names: Vec<&str>, domains: Vec<&str>) -> VirtualHostConfig {
+    let mut vhost = sample_vhost(server_names);
+    vhost.tls = Some(VirtualHostTlsConfig {
+        acme: Some(crate::model::VirtualHostAcmeConfig {
+            domains: domains.into_iter().map(str::to_string).collect(),
+            challenge: None,
+        }),
+        cert_path: "managed.crt".to_string(),
+        key_path: "managed.key".to_string(),
+        additional_certificates: None,
+        ocsp_staple_path: None,
+        ocsp: None,
+    });
+    vhost
+}
+
+fn enable_acme_listeners(config: &mut Config) {
+    config.server.listen = None;
+    config.listeners = vec![
+        explicit_listener("http", "127.0.0.1:80", None),
+        explicit_listener("https", "127.0.0.1:443", Some(valid_server_tls())),
+    ];
+}
+
+#[test]
+fn deserialize_rejects_legacy_vhost_server_tls_with_acme_field() {
+    let error = ron::from_str::<Config>(
+        r#"Config(
+    runtime: RuntimeConfig(
+        shutdown_timeout_secs: 10,
+    ),
+    server: ServerConfig(
+        listen: "127.0.0.1:8080",
+    ),
+    upstreams: [
+        UpstreamConfig(
+            name: "backend",
+            peers: [UpstreamPeerConfig(url: "http://127.0.0.1:9000")],
+        ),
+    ],
+    locations: [
+        LocationConfig(
+            matcher: Prefix("/"),
+            handler: Proxy(upstream: "backend"),
+        ),
+    ],
+    servers: [
+        VirtualHostConfig(
+            server_names: ["api.example.com"],
+            locations: [
+                LocationConfig(
+                    matcher: Exact("/"),
+                    handler: Return(status: 200, location: "", body: Some("ok\n")),
+                ),
+            ],
+            tls: Some(ServerTlsConfig(
+                cert_path: "managed.crt",
+                key_path: "managed.key",
+                acme: Some(VirtualHostAcmeConfig(
+                    domains: ["api.example.com"],
+                )),
+            )),
+        ),
+    ],
+)"#,
+    )
+    .expect_err("legacy vhost ServerTlsConfig with ACME should be rejected");
+
+    assert!(error.to_string().contains("vhost TLS policy fields are not supported"));
+}
+
+#[test]
+fn validate_rejects_empty_global_acme_directory_url() {
+    let mut config = base_config();
+    config.acme =
+        Some(crate::model::AcmeConfig { directory_url: "   ".to_string(), ..valid_global_acme() });
+
+    let error = validate(&config).expect_err("empty ACME directory_url should be rejected");
+    assert!(error.to_string().contains("acme.directory_url must not be empty"));
+}
+
+#[test]
+fn validate_rejects_empty_global_acme_state_dir() {
+    let mut config = base_config();
+    config.acme =
+        Some(crate::model::AcmeConfig { state_dir: " ".to_string(), ..valid_global_acme() });
+
+    let error = validate(&config).expect_err("empty ACME state_dir should be rejected");
+    assert!(error.to_string().contains("acme.state_dir must not be empty"));
+}
+
+#[test]
+fn validate_rejects_zero_global_acme_renew_before_days() {
+    let mut config = base_config();
+    config.acme =
+        Some(crate::model::AcmeConfig { renew_before_days: Some(0), ..valid_global_acme() });
+
+    let error = validate(&config).expect_err("zero ACME renew_before_days should be rejected");
+    assert!(error.to_string().contains("acme.renew_before_days must be greater than 0"));
+}
+
+#[test]
+fn validate_rejects_zero_global_acme_poll_interval_secs() {
+    let mut config = base_config();
+    config.acme =
+        Some(crate::model::AcmeConfig { poll_interval_secs: Some(0), ..valid_global_acme() });
+
+    let error = validate(&config).expect_err("zero ACME poll_interval_secs should be rejected");
+    assert!(error.to_string().contains("acme.poll_interval_secs must be greater than 0"));
+}
+
+#[test]
+fn validate_rejects_managed_vhost_without_global_acme() {
+    let mut config = base_config();
+    enable_acme_listeners(&mut config);
+    config.servers = vec![managed_vhost(vec!["api.example.com"], vec!["api.example.com"])];
+
+    let error = validate(&config).expect_err("managed vhost should require top-level ACME");
+    assert!(
+        error.to_string().contains("servers[0] TLS ACME requires top-level acme configuration")
+    );
+}
+
+#[test]
+fn validate_rejects_managed_vhost_with_empty_domains() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    enable_acme_listeners(&mut config);
+    config.servers = vec![managed_vhost(vec!["api.example.com"], Vec::new())];
+
+    let error = validate(&config).expect_err("managed vhost without domains should be rejected");
+    assert!(error.to_string().contains("servers[0] TLS ACME domains must not be empty"));
+}
+
+#[test]
+fn validate_rejects_managed_vhost_with_wildcard_domain() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    enable_acme_listeners(&mut config);
+    config.servers = vec![managed_vhost(vec!["api.example.com"], vec!["*.example.com"])];
+
+    let error = validate(&config).expect_err("wildcard ACME domains should be rejected");
+    assert!(error.to_string().contains("servers[0] TLS ACME domains[0] wildcard `*.example.com`"));
+}
+
+#[test]
+fn validate_rejects_managed_vhost_with_wildcard_server_name() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    enable_acme_listeners(&mut config);
+    config.servers = vec![managed_vhost(vec!["*.example.com"], vec!["*.example.com"])];
+
+    let error = validate(&config).expect_err("wildcard server_names should be rejected for ACME");
+    assert!(error.to_string().contains("servers[0] server_names[0] wildcard `*.example.com`"));
+}
+
+#[test]
+fn validate_rejects_managed_vhost_with_domain_server_name_mismatch() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    enable_acme_listeners(&mut config);
+    config.servers = vec![managed_vhost(vec!["api.example.com"], vec!["www.example.com"])];
+
+    let error =
+        validate(&config).expect_err("managed vhost domains should match server_names exactly");
+    assert!(
+        error
+            .to_string()
+            .contains("servers[0] TLS ACME domains must match server_names exactly in phase 1")
+    );
+}
+
+#[test]
+fn validate_rejects_managed_vhost_with_additional_certificates() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    enable_acme_listeners(&mut config);
+    let mut vhost = managed_vhost(vec!["api.example.com"], vec!["api.example.com"]);
+    vhost.tls.as_mut().expect("managed vhost should define tls").additional_certificates =
+        Some(vec![crate::model::ServerCertificateBundleConfig {
+            cert_path: "backup.crt".to_string(),
+            key_path: "backup.key".to_string(),
+            ocsp_staple_path: None,
+            ocsp: None,
+        }]);
+    config.servers = vec![vhost];
+
+    let error = validate(&config).expect_err("managed vhost should reject additional certificates");
+    assert!(
+        error
+            .to_string()
+            .contains("servers[0] TLS ACME does not support additional_certificates in phase 1")
+    );
+}
+
+#[test]
+fn validate_rejects_managed_vhost_without_plain_http_80_listener() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    config.server.listen = None;
+    config.listeners = vec![explicit_listener("https", "127.0.0.1:443", Some(valid_server_tls()))];
+    config.servers = vec![managed_vhost(vec!["api.example.com"], vec!["api.example.com"])];
+
+    let error = validate(&config).expect_err("HTTP-01 should require a plain HTTP :80 listener");
+    assert!(
+        error
+            .to_string()
+            .contains("ACME HTTP-01 requires at least one plain HTTP listener bound to port 80")
+    );
+}
+
+#[test]
+fn validate_accepts_phase1_managed_vhost_configuration() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    enable_acme_listeners(&mut config);
+    config.servers = vec![managed_vhost(vec!["api.example.com"], vec!["api.example.com"])];
+
+    validate(&config).expect("phase 1 managed vhost ACME config should validate");
+}

--- a/crates/rginx-config/src/validate/tests/vhosts.rs
+++ b/crates/rginx-config/src/validate/tests/vhosts.rs
@@ -59,6 +59,7 @@ fn validate_rejects_tls_vhost_without_server_name() {
     let mut config = base_config();
     let mut vhost = sample_vhost(Vec::new());
     vhost.tls = Some(VirtualHostTlsConfig {
+        acme: None,
         cert_path: "server.crt".to_string(),
         key_path: "server.key".to_string(),
         additional_certificates: None,
@@ -166,6 +167,7 @@ fn validate_rejects_vhost_tls_without_any_tls_listener() {
             streaming_response_idle_timeout_secs: None,
         }],
         tls: Some(VirtualHostTlsConfig {
+            acme: None,
             cert_path: "server.crt".to_string(),
             key_path: "server.key".to_string(),
             additional_certificates: None,
@@ -201,6 +203,7 @@ fn validate_accepts_server_tls_defaults_with_vhost_listen() {
     let mut vhost = sample_vhost(vec!["api.example.com"]);
     vhost.listen = vec!["127.0.0.1:8443 ssl http2".to_string()];
     vhost.tls = Some(VirtualHostTlsConfig {
+        acme: None,
         cert_path: "api.crt".to_string(),
         key_path: "api.key".to_string(),
         additional_certificates: None,
@@ -276,6 +279,7 @@ fn validate_rejects_inconsistent_http3_on_shared_vhost_listen() {
     let mut first = sample_vhost(vec!["api.example.com"]);
     first.listen = vec!["127.0.0.1:8443 ssl http2 http3".to_string()];
     first.tls = Some(VirtualHostTlsConfig {
+        acme: None,
         cert_path: "api.crt".to_string(),
         key_path: "api.key".to_string(),
         additional_certificates: None,
@@ -286,6 +290,7 @@ fn validate_rejects_inconsistent_http3_on_shared_vhost_listen() {
     let mut second = sample_vhost(vec!["www.example.com"]);
     second.listen = vec!["127.0.0.1:8443 ssl http2 http3".to_string()];
     second.tls = Some(VirtualHostTlsConfig {
+        acme: None,
         cert_path: "www.crt".to_string(),
         key_path: "www.key".to_string(),
         additional_certificates: None,
@@ -310,6 +315,7 @@ fn validate_rejects_vhost_http3_when_server_tls_policy_disables_tls13() {
     let mut vhost = sample_vhost(vec!["api.example.com"]);
     vhost.listen = vec!["127.0.0.1:8443 ssl http2 http3".to_string()];
     vhost.tls = Some(VirtualHostTlsConfig {
+        acme: None,
         cert_path: "api.crt".to_string(),
         key_path: "api.key".to_string(),
         additional_certificates: None,

--- a/crates/rginx-core/src/config.rs
+++ b/crates/rginx-core/src/config.rs
@@ -1,4 +1,5 @@
 mod access_log;
+mod acme;
 mod cache;
 mod listener;
 mod route;
@@ -10,6 +11,7 @@ mod upstream;
 mod virtual_host;
 
 pub use access_log::{AccessLogFormat, AccessLogValues};
+pub use acme::{AcmeChallengeType, AcmeSettings, ManagedCertificateSpec};
 pub use cache::{
     CacheIgnoreHeader, CacheKeyRenderContext, CacheKeyTemplate, CacheKeyTemplateError,
     CachePredicate, CachePredicateRequestContext, CacheRangeRequestPolicy, CacheStatusTtlRule,

--- a/crates/rginx-core/src/config/acme.rs
+++ b/crates/rginx-core/src/config/acme.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AcmeChallengeType {
+    Http01,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcmeSettings {
+    pub directory_url: String,
+    pub contacts: Vec<String>,
+    pub state_dir: PathBuf,
+    pub renew_before: Duration,
+    pub poll_interval: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedCertificateSpec {
+    pub scope: String,
+    pub domains: Vec<String>,
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+    pub challenge: AcmeChallengeType,
+}

--- a/crates/rginx-core/src/config/snapshot.rs
+++ b/crates/rginx-core/src/config/snapshot.rs
@@ -1,11 +1,16 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::{CacheZone, Listener, RuntimeSettings, Upstream, VirtualHost};
+use super::{
+    AcmeSettings, CacheZone, Listener, ManagedCertificateSpec, RuntimeSettings, Upstream,
+    VirtualHost,
+};
 
 #[derive(Debug, Clone)]
 pub struct ConfigSnapshot {
     pub runtime: RuntimeSettings,
+    pub acme: Option<AcmeSettings>,
+    pub managed_certificates: Vec<ManagedCertificateSpec>,
     pub listeners: Vec<Listener>,
     pub default_vhost: VirtualHost,
     pub vhosts: Vec<VirtualHost>,

--- a/crates/rginx-core/src/config/tests/core.rs
+++ b/crates/rginx-core/src/config/tests/core.rs
@@ -72,6 +72,8 @@ fn config_snapshot_counts_routes_across_all_vhosts() {
         tls: None,
     };
     let snapshot = ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
             worker_threads: None,

--- a/crates/rginx-core/src/lib.rs
+++ b/crates/rginx-core/src/lib.rs
@@ -5,18 +5,19 @@ pub mod service;
 pub mod types;
 
 pub use config::{
-    AccessLogFormat, AccessLogValues, ActiveHealthCheck, CacheIgnoreHeader, CacheKeyRenderContext,
-    CacheKeyTemplate, CacheKeyTemplateError, CachePredicate, CachePredicateRequestContext,
-    CacheRangeRequestPolicy, CacheStatusTtlRule, CacheUseStaleCondition, CacheZone, ClientIdentity,
-    ConfigSnapshot, DEFAULT_SERVER_HEADER, GrpcRouteMatch, Listener, ListenerApplicationProtocol,
-    ListenerHttp3, ListenerTransportBinding, ListenerTransportKind, OcspConfig, OcspNonceMode,
-    OcspResponderPolicy, ProxyHeaderRenderContext, ProxyHeaderTemplate, ProxyHeaderTemplateError,
-    ProxyHeaderValue, ProxyTarget, ReturnAction, Route, RouteAccessControl, RouteAction,
-    RouteBufferingPolicy, RouteCachePolicy, RouteCompressionPolicy, RouteMatcher, RouteRateLimit,
-    RouteRegexError, RouteRegexMatcher, RuntimeSettings, Server, ServerCertificateBundle,
-    ServerClientAuthMode, ServerClientAuthPolicy, ServerNameMatch, ServerTls, TlsCipherSuite,
-    TlsKeyExchangeGroup, TlsVersion, Upstream, UpstreamDnsPolicy, UpstreamLoadBalance,
-    UpstreamPeer, UpstreamProtocol, UpstreamSettings, UpstreamTls, VirtualHost, VirtualHostTls,
-    best_matching_server_name_pattern, default_server_header, match_server_name,
+    AccessLogFormat, AccessLogValues, AcmeChallengeType, AcmeSettings, ActiveHealthCheck,
+    CacheIgnoreHeader, CacheKeyRenderContext, CacheKeyTemplate, CacheKeyTemplateError,
+    CachePredicate, CachePredicateRequestContext, CacheRangeRequestPolicy, CacheStatusTtlRule,
+    CacheUseStaleCondition, CacheZone, ClientIdentity, ConfigSnapshot, DEFAULT_SERVER_HEADER,
+    GrpcRouteMatch, Listener, ListenerApplicationProtocol, ListenerHttp3, ListenerTransportBinding,
+    ListenerTransportKind, ManagedCertificateSpec, OcspConfig, OcspNonceMode, OcspResponderPolicy,
+    ProxyHeaderRenderContext, ProxyHeaderTemplate, ProxyHeaderTemplateError, ProxyHeaderValue,
+    ProxyTarget, ReturnAction, Route, RouteAccessControl, RouteAction, RouteBufferingPolicy,
+    RouteCachePolicy, RouteCompressionPolicy, RouteMatcher, RouteRateLimit, RouteRegexError,
+    RouteRegexMatcher, RuntimeSettings, Server, ServerCertificateBundle, ServerClientAuthMode,
+    ServerClientAuthPolicy, ServerNameMatch, ServerTls, TlsCipherSuite, TlsKeyExchangeGroup,
+    TlsVersion, Upstream, UpstreamDnsPolicy, UpstreamLoadBalance, UpstreamPeer, UpstreamProtocol,
+    UpstreamSettings, UpstreamTls, VirtualHost, VirtualHostTls, best_matching_server_name_pattern,
+    default_server_header, match_server_name,
 };
 pub use error::{Error, Result};

--- a/crates/rginx-http/src/handler/tests/support.rs
+++ b/crates/rginx-http/src/handler/tests/support.rs
@@ -30,6 +30,8 @@ pub(crate) fn test_config(default_vhost: VirtualHost, vhosts: Vec<VirtualHost>) 
         tls: None,
     };
     ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),

--- a/crates/rginx-http/src/proxy/clients/tests.rs
+++ b/crates/rginx-http/src/proxy/clients/tests.rs
@@ -104,6 +104,8 @@ async fn peer_health_snapshot_delegates_to_registry() {
         tls: None,
     };
     let snapshot = ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),

--- a/crates/rginx-http/src/proxy/health/registry/tests.rs
+++ b/crates/rginx-http/src/proxy/health/registry/tests.rs
@@ -122,6 +122,8 @@ fn snapshot_reports_passive_and_active_health_state() {
         tls: None,
     };
     let config = rginx_core::ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),

--- a/crates/rginx-http/src/proxy/tests/mod.rs
+++ b/crates/rginx-http/src/proxy/tests/mod.rs
@@ -203,6 +203,8 @@ fn snapshot_with_upstreams_map(
 ) -> rginx_core::ConfigSnapshot {
     let server = default_server();
     rginx_core::ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),

--- a/crates/rginx-http/src/state/tests/support.rs
+++ b/crates/rginx-http/src/state/tests/support.rs
@@ -18,6 +18,8 @@ pub(crate) fn snapshot(listen: &str) -> ConfigSnapshot {
         tls: None,
     };
     ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(10),

--- a/crates/rginx-http/src/state/tls_runtime/bindings/tests.rs
+++ b/crates/rginx-http/src/state/tls_runtime/bindings/tests.rs
@@ -98,6 +98,8 @@ fn certificates(scopes: &[&str]) -> Vec<TlsCertificateStatusSnapshot> {
 #[test]
 fn listener_certificate_is_default_when_no_explicit_default_is_configured() {
     let config = ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),
@@ -137,6 +139,8 @@ fn listener_certificate_is_default_when_no_explicit_default_is_configured() {
 #[test]
 fn single_named_vhost_certificate_becomes_implicit_default_without_listener_tls() {
     let config = ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),

--- a/crates/rginx-http/src/transition/tests.rs
+++ b/crates/rginx-http/src/transition/tests.rs
@@ -26,6 +26,8 @@ fn snapshot(listen: &str) -> ConfigSnapshot {
         tls: None,
     };
     ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(10),

--- a/crates/rginx-runtime/src/bootstrap/listeners/tests.rs
+++ b/crates/rginx-runtime/src/bootstrap/listeners/tests.rs
@@ -36,6 +36,8 @@ fn listener(id: &str, name: &str, listen_addr: SocketAddr) -> Listener {
 
 fn config_with_listeners(listeners: Vec<Listener>) -> ConfigSnapshot {
     ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: rginx_core::RuntimeSettings {
             shutdown_timeout: std::time::Duration::from_secs(1),

--- a/crates/rginx-runtime/src/bootstrap/shutdown/tests.rs
+++ b/crates/rginx-runtime/src/bootstrap/shutdown/tests.rs
@@ -16,6 +16,8 @@ use super::*;
 
 fn snapshot() -> ConfigSnapshot {
     ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),

--- a/crates/rginx-runtime/src/health/tests.rs
+++ b/crates/rginx-runtime/src/health/tests.rs
@@ -52,6 +52,8 @@ async fn collect_probe_targets_only_includes_enabled_upstreams() {
         tls: None,
     };
     let snapshot = ConfigSnapshot {
+        acme: None,
+        managed_certificates: Vec::new(),
         cache_zones: HashMap::new(),
         runtime: RuntimeSettings {
             shutdown_timeout: Duration::from_secs(1),


### PR DESCRIPTION
## Summary
- add phase 0-1 ACME config models and compiled snapshot outputs
- validate phase 1 ACME constraints for managed vhost certificates
- document the ACME rollout plan and add compile/validate coverage

## Testing
- cargo fmt --all --check
- python3 ./scripts/run-modularization-gate.py
- SKIP_MODULARIZATION_GATE=1 ./scripts/test-fast.sh
- ./scripts/run-clippy-gate.sh
- ./scripts/test-slow.sh
- ./scripts/run-tls-gate.sh