### PR TITLE
Add ACME issuance and renewal runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,7 @@ dependencies = [
  "hyper-util",
  "rustls",
  "rustls-native-certs",
+ "rustls-platform-verifier",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1187,6 +1188,32 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "instant-acme"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "httpdate",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "rcgen",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1866,6 +1893,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
+ "aws-lc-rs",
  "pem",
  "ring",
  "rustls-pki-types",
@@ -2039,10 +2067,12 @@ version = "0.1.4-rc.1"
 dependencies = [
  "bytes",
  "ctor",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "instant-acme",
  "libc",
  "quinn",
  "rginx-config",
@@ -2053,6 +2083,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2",
+ "tempfile",
  "tokio",
  "tracing",
 ]
@@ -2172,6 +2203,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2936,6 +2994,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,6 +3359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
+ "aws-lc-rs",
  "data-encoding",
  "der-parser",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ hickory-resolver = "0.26.0"
 hyper = { version = "1.9", features = ["client", "http1", "http2", "server"] }
 hyper-rustls = { version = "0.27.9", default-features = false, features = ["aws-lc-rs", "http1", "http2", "native-tokio", "tls12"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
+instant-acme = { version = "0.8.5", default-features = false, features = ["aws-lc-rs", "hyper-rustls", "rcgen"] }
 ipnet = "2.12"
 pin-project-lite = "0.2"
 proptest = "1"

--- a/crates/rginx-app/src/admin_cli/mod.rs
+++ b/crates/rginx-app/src/admin_cli/mod.rs
@@ -68,6 +68,6 @@ pub(crate) fn run_admin_command(config_path: &Path, command: &Command) -> anyhow
             upstreams::print_admin_upstreams(config_path, args)?;
             Ok(true)
         }
-        Command::Check => Ok(false),
+        Command::Acme(_) | Command::Check => Ok(false),
     }
 }

--- a/crates/rginx-app/src/cli.rs
+++ b/crates/rginx-app/src/cli.rs
@@ -25,6 +25,7 @@ pub struct Cli {
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum Command {
+    Acme(AcmeArgs),
     Check,
     Snapshot(SnapshotArgs),
     SnapshotVersion,
@@ -37,6 +38,24 @@ pub enum Command {
     Traffic(WindowArgs),
     Peers,
     Upstreams(WindowArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct AcmeArgs {
+    #[command(subcommand)]
+    pub command: AcmeCommand,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AcmeCommand {
+    Issue(AcmeIssueArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+#[command(group = ArgGroup::new("mode").required(true).args(["once"]))]
+pub struct AcmeIssueArgs {
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub once: bool,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/crates/rginx-app/src/cli/tests.rs
+++ b/crates/rginx-app/src/cli/tests.rs
@@ -3,8 +3,9 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 
 use super::{
-    Cli, Command, DeltaArgs, PurgeCacheArgs, SignalCommand, SnapshotArgs, SnapshotModuleArg,
-    WaitArgs, WindowArgs, installed_config_path, pid_path_for_config,
+    AcmeArgs, AcmeCommand, AcmeIssueArgs, Cli, Command, DeltaArgs, PurgeCacheArgs, SignalCommand,
+    SnapshotArgs, SnapshotModuleArg, WaitArgs, WindowArgs, installed_config_path,
+    pid_path_for_config,
 };
 
 #[test]
@@ -71,6 +72,16 @@ fn cli_accepts_status_subcommand() {
     let cli = Cli::try_parse_from(["rginx", "status"]).expect("cli should parse");
 
     assert!(matches!(cli.command, Some(Command::Status)));
+}
+
+#[test]
+fn cli_accepts_one_shot_acme_issue_subcommand() {
+    let cli = Cli::try_parse_from(["rginx", "acme", "issue", "--once"]).expect("cli should parse");
+
+    assert!(matches!(
+        cli.command,
+        Some(Command::Acme(AcmeArgs { command: AcmeCommand::Issue(AcmeIssueArgs { once: true }) }))
+    ));
 }
 
 #[test]

--- a/crates/rginx-app/src/main.rs
+++ b/crates/rginx-app/src/main.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, anyhow};
 use clap::Parser;
 
 use crate::check::{build_check_summary, print_check_success};
-use crate::cli::{Cli, Command, pid_path_for_config};
+use crate::cli::{AcmeCommand, Cli, Command, pid_path_for_config};
 use crate::pid_file::PidFileGuard;
 use crate::runtime::build_runtime;
 use crate::signal::send_signal_from_pid_file;
@@ -43,6 +43,13 @@ fn main() -> anyhow::Result<()> {
     rginx_observability::init_logging()
         .map_err(|error| anyhow!("failed to initialize logging: {error}"))?;
 
+    if let Some(Command::Acme(args)) = cli.command.as_ref() {
+        return match &args.command {
+            AcmeCommand::Issue(issue) if issue.once => run_acme_issue_once(&cli.config),
+            _ => unreachable!("clap enforces the one-shot ACME command shape"),
+        };
+    }
+
     let config = rginx_config::load_and_compile(&cli.config)
         .with_context(|| format!("failed to load {}", cli.config.display()))?;
 
@@ -57,6 +64,9 @@ fn main() -> anyhow::Result<()> {
             runtime
                 .block_on(rginx_runtime::run(cli.config, config))
                 .context("runtime exited with an error")
+        }
+        Some(Command::Acme(_)) => {
+            unreachable!("ACME subcommands return before standard config initialization")
         }
         Some(Command::Check) => unreachable!("`check` subcommand and `-t` conflict at clap level"),
         Some(
@@ -86,4 +96,32 @@ fn run_check_only(
 
     print_check_success(config_path, build_check_summary(config));
     Ok(())
+}
+
+fn run_acme_issue_once(config_path: &std::path::Path) -> anyhow::Result<()> {
+    let config = rginx_config::load_and_compile_for_acme_issue(config_path)
+        .with_context(|| format!("failed to load {}", config_path.display()))?;
+    let runtime = build_runtime(config.runtime.worker_threads)
+        .context("failed to construct tokio runtime")?;
+    let summary = runtime
+        .block_on(rginx_runtime::acme::issue_once(&config))
+        .context("one-shot ACME issuance failed")?;
+
+    if summary.is_success() {
+        println!(
+            "acme issue completed: total={} issued={} skipped={}",
+            summary.total, summary.issued, summary.skipped
+        );
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "acme issue completed with failures: {}",
+        summary
+            .failures
+            .iter()
+            .map(|failure| format!("{} ({})", failure.scope, failure.error))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
 }

--- a/crates/rginx-config/src/compile/mod.rs
+++ b/crates/rginx-config/src/compile/mod.rs
@@ -126,6 +126,7 @@ pub fn compile_with_base_and_options(
                 &upstreams,
                 base_dir,
                 options.allow_missing_managed_tls_identity,
+                &managed_identity_pairs,
             )
         })
         .collect::<Result<Vec<_>>>()?;

--- a/crates/rginx-config/src/compile/mod.rs
+++ b/crates/rginx-config/src/compile/mod.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
+use std::{collections::HashSet, path::PathBuf};
 
 use crate::model::Config;
+use crate::model::VirtualHostConfig;
 use rginx_core::{ConfigSnapshot, Result, VirtualHost};
 
 use crate::validate::validate;
@@ -37,13 +39,27 @@ const DEFAULT_GRPC_HEALTH_CHECK_PATH: &str = "/grpc.health.v1.Health/Check";
 
 use path::resolve_path;
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CompileOptions {
+    pub allow_missing_managed_tls_identity: bool,
+}
+
 pub fn compile(raw: Config) -> Result<ConfigSnapshot> {
     compile_with_base(raw, Path::new("."))
 }
 
 pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<ConfigSnapshot> {
+    compile_with_base_and_options(raw, base_dir, CompileOptions::default())
+}
+
+pub fn compile_with_base_and_options(
+    raw: Config,
+    base_dir: impl AsRef<Path>,
+    options: CompileOptions,
+) -> Result<ConfigSnapshot> {
     validate(&raw)?;
     let base_dir = base_dir.as_ref();
+    let managed_identity_pairs = collect_managed_identity_pairs(&raw.servers, base_dir);
 
     let Config {
         runtime,
@@ -61,15 +77,33 @@ pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<Conf
     let any_vhost_tls = raw_servers.iter().any(|vhost| vhost.tls.is_some());
     let any_vhost_listen = raw_servers.iter().any(|vhost| !vhost.listen.is_empty());
     let (listeners, default_server_names) = if any_vhost_listen {
-        let listeners = server::compile_vhost_listeners(&raw_servers, &server, base_dir)?;
+        let listeners = server::compile_vhost_listeners(
+            &raw_servers,
+            &server,
+            base_dir,
+            options.allow_missing_managed_tls_identity,
+            &managed_identity_pairs,
+        )?;
         (listeners, server.server_names.clone())
     } else if raw_listeners.is_empty() {
-        let compiled_server = server::compile_legacy_server(server, base_dir, any_vhost_tls)?;
+        let compiled_server = server::compile_legacy_server(
+            server,
+            base_dir,
+            any_vhost_tls,
+            options.allow_missing_managed_tls_identity,
+            &managed_identity_pairs,
+        )?;
         (vec![compiled_server.listener.clone()], compiled_server.server_names)
     } else {
         let default_server_header = server.server_header;
         let default_server_names = server.server_names;
-        let listeners = server::compile_listeners(raw_listeners, default_server_header, base_dir)?;
+        let listeners = server::compile_listeners(
+            raw_listeners,
+            default_server_header,
+            base_dir,
+            options.allow_missing_managed_tls_identity,
+            &managed_identity_pairs,
+        )?;
         (listeners, default_server_names)
     };
     let mut upstreams = upstream::compile_upstreams(raw_upstreams, base_dir)?;
@@ -91,6 +125,7 @@ pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<Conf
                 vhost_config,
                 &upstreams,
                 base_dir,
+                options.allow_missing_managed_tls_identity,
             )
         })
         .collect::<Result<Vec<_>>>()?;
@@ -113,6 +148,23 @@ pub fn compile_with_base(raw: Config, base_dir: impl AsRef<Path>) -> Result<Conf
         cache_zones,
         upstreams,
     })
+}
+
+fn collect_managed_identity_pairs(
+    raw_servers: &[VirtualHostConfig],
+    base_dir: &Path,
+) -> HashSet<(PathBuf, PathBuf)> {
+    raw_servers
+        .iter()
+        .filter_map(|vhost| {
+            let tls = vhost.tls.as_ref()?;
+            tls.acme.as_ref()?;
+            Some((
+                resolve_path(base_dir, tls.cert_path.clone()),
+                resolve_path(base_dir, tls.key_path.clone()),
+            ))
+        })
+        .collect()
 }
 #[cfg(test)]
 mod tests;

--- a/crates/rginx-config/src/compile/server.rs
+++ b/crates/rginx-config/src/compile/server.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
 use rginx_core::{Listener, Result, VirtualHostTls};
 
@@ -7,6 +8,7 @@ use crate::model::{ListenerConfig, ServerConfig, VirtualHostConfig, VirtualHostT
 mod fields;
 mod http3;
 mod listener;
+mod listener_managed_identity;
 mod tls;
 
 #[cfg(test)]
@@ -33,8 +35,16 @@ pub(super) fn compile_legacy_server(
     server: ServerConfig,
     base_dir: &Path,
     any_vhost_tls: bool,
+    allow_missing_managed_tls_identity: bool,
+    managed_identity_pairs: &HashSet<(PathBuf, PathBuf)>,
 ) -> Result<CompiledServer> {
-    listener::compile_legacy_server(server, base_dir, any_vhost_tls)
+    listener::compile_legacy_server(
+        server,
+        base_dir,
+        any_vhost_tls,
+        allow_missing_managed_tls_identity,
+        managed_identity_pairs,
+    )
 }
 
 /// Compiles explicit listener blocks into runtime listener definitions.
@@ -42,8 +52,16 @@ pub(super) fn compile_listeners(
     listeners: Vec<ListenerConfig>,
     default_server_header: Option<String>,
     base_dir: &Path,
+    allow_missing_managed_tls_identity: bool,
+    managed_identity_pairs: &HashSet<(PathBuf, PathBuf)>,
 ) -> Result<Vec<Listener>> {
-    listener::compile_listeners(listeners, default_server_header, base_dir)
+    listener::compile_listeners(
+        listeners,
+        default_server_header,
+        base_dir,
+        allow_missing_managed_tls_identity,
+        managed_identity_pairs,
+    )
 }
 
 /// Compiles nginx-style `servers[].listen` entries into deduplicated runtime listeners.
@@ -51,14 +69,23 @@ pub(super) fn compile_vhost_listeners(
     vhosts: &[VirtualHostConfig],
     server_defaults: &ServerConfig,
     base_dir: &Path,
+    allow_missing_managed_tls_identity: bool,
+    managed_identity_pairs: &HashSet<(PathBuf, PathBuf)>,
 ) -> Result<Vec<Listener>> {
-    listener::compile_vhost_listeners(vhosts, server_defaults, base_dir)
+    listener::compile_vhost_listeners(
+        vhosts,
+        server_defaults,
+        base_dir,
+        allow_missing_managed_tls_identity,
+        managed_identity_pairs,
+    )
 }
 
 /// Compiles per-vhost TLS overrides into the runtime vhost TLS structure.
 pub(super) fn compile_virtual_host_tls(
     tls: Option<VirtualHostTlsConfig>,
     base_dir: &Path,
+    allow_missing_identity: bool,
 ) -> Result<Option<VirtualHostTls>> {
-    tls::compile_virtual_host_tls(tls, base_dir)
+    tls::compile_virtual_host_tls(tls, base_dir, allow_missing_identity)
 }

--- a/crates/rginx-config/src/compile/server/fields.rs
+++ b/crates/rginx-config/src/compile/server/fields.rs
@@ -30,6 +30,7 @@ pub(super) struct ServerFieldConfig {
     pub(super) response_write_timeout_secs: Option<u64>,
     pub(super) access_log_format: Option<String>,
     pub(super) tls: Option<ServerTlsConfig>,
+    pub(super) allow_missing_tls_identity: bool,
 }
 
 pub(super) fn compile_server_fields(
@@ -51,9 +52,10 @@ pub(super) fn compile_server_fields(
         response_write_timeout_secs,
         access_log_format,
         tls,
+        allow_missing_tls_identity,
     } = config;
 
-    let server_tls = compile_server_tls(tls, base_dir)?;
+    let server_tls = compile_server_tls(tls, base_dir, allow_missing_tls_identity)?;
     Ok(CompiledServerFields {
         server: Server {
             listen_addr: listen.parse()?,

--- a/crates/rginx-config/src/compile/server/listener.rs
+++ b/crates/rginx-config/src/compile/server/listener.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeMap, btree_map::Entry};
+use std::collections::{BTreeMap, HashSet, btree_map::Entry};
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rginx_core::{Error, Listener, Result};
 
@@ -9,11 +9,14 @@ use crate::model::{Http3Config, ListenerConfig, ServerConfig, VirtualHostConfig}
 use super::CompiledServer;
 use super::fields::{ServerFieldConfig, compile_server_fields};
 use super::http3::compile_http3;
+use super::listener_managed_identity::tls_identity_is_managed;
 
 pub(super) fn compile_legacy_server(
     server: ServerConfig,
     base_dir: &Path,
     any_vhost_tls: bool,
+    allow_missing_managed_tls_identity: bool,
+    managed_identity_pairs: &HashSet<(PathBuf, PathBuf)>,
 ) -> Result<CompiledServer> {
     let ServerConfig {
         listen,
@@ -36,6 +39,10 @@ pub(super) fn compile_legacy_server(
     } = server;
 
     let listen = listen.expect("legacy server listen should be validated before compile");
+    let allow_missing_tls_identity = allow_missing_managed_tls_identity
+        && tls
+            .as_ref()
+            .is_some_and(|tls| tls_identity_is_managed(tls, base_dir, managed_identity_pairs));
     let compiled = compile_server_fields(
         ServerFieldConfig {
             listen,
@@ -52,6 +59,7 @@ pub(super) fn compile_legacy_server(
             response_write_timeout_secs,
             access_log_format,
             tls,
+            allow_missing_tls_identity,
         },
         base_dir,
     )?;
@@ -79,6 +87,8 @@ pub(super) fn compile_listeners(
     listeners: Vec<ListenerConfig>,
     default_server_header: Option<String>,
     base_dir: &Path,
+    allow_missing_managed_tls_identity: bool,
+    managed_identity_pairs: &HashSet<(PathBuf, PathBuf)>,
 ) -> Result<Vec<Listener>> {
     listeners
         .into_iter()
@@ -103,6 +113,10 @@ pub(super) fn compile_listeners(
                 http3,
             } = listener;
 
+            let allow_missing_tls_identity = allow_missing_managed_tls_identity
+                && tls.as_ref().is_some_and(|tls| {
+                    tls_identity_is_managed(tls, base_dir, managed_identity_pairs)
+                });
             let compiled = compile_server_fields(
                 ServerFieldConfig {
                     listen,
@@ -119,6 +133,7 @@ pub(super) fn compile_listeners(
                     response_write_timeout_secs,
                     access_log_format,
                     tls,
+                    allow_missing_tls_identity,
                 },
                 base_dir,
             )?;
@@ -145,6 +160,8 @@ pub(super) fn compile_vhost_listeners(
     vhosts: &[VirtualHostConfig],
     server_defaults: &ServerConfig,
     base_dir: &Path,
+    allow_missing_managed_tls_identity: bool,
+    managed_identity_pairs: &HashSet<(PathBuf, PathBuf)>,
 ) -> Result<Vec<Listener>> {
     let mut bindings = BTreeMap::<SocketAddr, VhostListenerBinding>::new();
 
@@ -213,6 +230,10 @@ pub(super) fn compile_vhost_listeners(
                     response_write_timeout_secs: server_defaults.response_write_timeout_secs,
                     access_log_format: server_defaults.access_log_format.clone(),
                     tls,
+                    allow_missing_tls_identity: allow_missing_managed_tls_identity
+                        && server_defaults.tls.as_ref().is_some_and(|tls| {
+                            tls_identity_is_managed(tls, base_dir, managed_identity_pairs)
+                        }),
                 },
                 base_dir,
             )?;

--- a/crates/rginx-config/src/compile/server/listener_managed_identity.rs
+++ b/crates/rginx-config/src/compile/server/listener_managed_identity.rs
@@ -1,0 +1,13 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+pub(super) fn tls_identity_is_managed(
+    tls: &crate::model::ServerTlsConfig,
+    base_dir: &Path,
+    managed_identity_pairs: &HashSet<(PathBuf, PathBuf)>,
+) -> bool {
+    managed_identity_pairs.contains(&(
+        super::super::resolve_path(base_dir, tls.cert_path.clone()),
+        super::super::resolve_path(base_dir, tls.key_path.clone()),
+    ))
+}

--- a/crates/rginx-config/src/compile/server/tls.rs
+++ b/crates/rginx-config/src/compile/server/tls.rs
@@ -16,6 +16,7 @@ use policy::{
 pub(super) fn compile_server_tls(
     tls: Option<ServerTlsConfig>,
     base_dir: &Path,
+    allow_missing_identity: bool,
 ) -> Result<Option<ServerTls>> {
     let Some(ServerTlsConfig {
         cert_path,
@@ -45,6 +46,7 @@ pub(super) fn compile_server_tls(
         ocsp_staple_path,
         ocsp,
         "server TLS",
+        allow_missing_identity,
     )?;
 
     let client_auth = match client_auth {
@@ -73,6 +75,7 @@ pub(super) fn compile_server_tls(
 pub(super) fn compile_virtual_host_tls(
     tls: Option<VirtualHostTlsConfig>,
     base_dir: &Path,
+    allow_missing_identity: bool,
 ) -> Result<Option<VirtualHostTls>> {
     let Some(VirtualHostTlsConfig {
         cert_path,
@@ -94,6 +97,7 @@ pub(super) fn compile_virtual_host_tls(
         ocsp_staple_path,
         ocsp,
         "vhost TLS",
+        allow_missing_identity,
     )?;
 
     Ok(Some(VirtualHostTls {

--- a/crates/rginx-config/src/compile/server/tls/identity.rs
+++ b/crates/rginx-config/src/compile/server/tls/identity.rs
@@ -26,9 +26,10 @@ pub(super) fn compile_certificate_material(
     ocsp_staple_path: Option<String>,
     ocsp: Option<RawOcspConfig>,
     label: &str,
+    allow_missing_identity: bool,
 ) -> Result<CompiledCertificateMaterial> {
     let cert_path = super::super::super::resolve_path(base_dir, cert_path);
-    if !cert_path.is_file() {
+    if !allow_missing_identity && !cert_path.is_file() {
         return Err(Error::Config(format!(
             "{label} certificate file `{}` does not exist or is not a file",
             cert_path.display()
@@ -36,14 +37,15 @@ pub(super) fn compile_certificate_material(
     }
 
     let key_path = super::super::super::resolve_path(base_dir, key_path);
-    if !key_path.is_file() {
+    if !allow_missing_identity && !key_path.is_file() {
         return Err(Error::Config(format!(
             "{label} private key file `{}` does not exist or is not a file",
             key_path.display()
         )));
     }
 
-    let ocsp_staple_path = compile_ocsp_staple_path(base_dir, ocsp_staple_path, label)?;
+    let ocsp_staple_path =
+        compile_ocsp_staple_path(base_dir, ocsp_staple_path, label, allow_missing_identity)?;
     let ocsp = compile_ocsp_config(ocsp);
     let additional_certificates = additional_certificates
         .unwrap_or_default()
@@ -120,7 +122,8 @@ fn compile_certificate_bundle(
         )));
     }
 
-    let ocsp_staple_path = compile_ocsp_staple_path(base_dir, bundle.ocsp_staple_path, label)?;
+    let ocsp_staple_path =
+        compile_ocsp_staple_path(base_dir, bundle.ocsp_staple_path, label, false)?;
     let ocsp = compile_ocsp_config(bundle.ocsp);
 
     Ok(ServerCertificateBundle { cert_path, key_path, ocsp_staple_path, ocsp })
@@ -130,11 +133,12 @@ fn compile_ocsp_staple_path(
     base_dir: &Path,
     path: Option<String>,
     label: &str,
+    allow_missing_path: bool,
 ) -> Result<Option<PathBuf>> {
     match path {
         Some(path) => {
             let resolved = super::super::super::resolve_path(base_dir, path);
-            if !resolved.is_file() {
+            if !allow_missing_path && !resolved.is_file() {
                 return Err(Error::Config(format!(
                     "{label} OCSP staple file `{}` does not exist or is not a file",
                     resolved.display()

--- a/crates/rginx-config/src/compile/tests/acme.rs
+++ b/crates/rginx-config/src/compile/tests/acme.rs
@@ -194,3 +194,28 @@ fn compile_emits_managed_certificate_specs_for_acme_vhosts() {
     assert_eq!(spec.key_path, base_dir.path().join("managed.key"));
     assert_eq!(spec.challenge, rginx_core::AcmeChallengeType::Http01);
 }
+
+#[test]
+fn compile_allows_missing_managed_identity_files_for_acme_issue_mode() {
+    let base_dir = temp_base_dir("rginx-acme-missing-identity-");
+    let config = managed_acme_config(
+        "https://acme-staging-v02.api.letsencrypt.org/directory",
+        "state/acme",
+        None,
+        None,
+        vec!["api.example.com"],
+        vec!["api.example.com"],
+    );
+
+    let snapshot = crate::compile::compile_with_base_and_options(
+        config,
+        base_dir.path(),
+        crate::compile::CompileOptions { allow_missing_managed_tls_identity: true },
+    )
+    .expect("ACME issue mode should compile without existing managed certificate files");
+
+    assert_eq!(snapshot.managed_certificates.len(), 1);
+    let spec = &snapshot.managed_certificates[0];
+    assert_eq!(spec.cert_path, base_dir.path().join("managed.crt"));
+    assert_eq!(spec.key_path, base_dir.path().join("managed.key"));
+}

--- a/crates/rginx-config/src/compile/tests/acme.rs
+++ b/crates/rginx-config/src/compile/tests/acme.rs
@@ -74,6 +74,31 @@ fn managed_vhost(
     }
 }
 
+fn shared_tls_vhost(server_names: Vec<&str>, cert_path: &str, key_path: &str) -> VirtualHostConfig {
+    VirtualHostConfig {
+        listen: Vec::new(),
+        server_names: server_names.into_iter().map(str::to_string).collect(),
+        upstreams: Vec::new(),
+        locations: vec![test_location(
+            MatcherConfig::Exact("/".to_string()),
+            HandlerConfig::Return {
+                status: 200,
+                location: String::new(),
+                body: Some("shared\n".to_string()),
+            },
+        )],
+        tls: Some(crate::model::VirtualHostTlsConfig {
+            acme: None,
+            cert_path: cert_path.to_string(),
+            key_path: key_path.to_string(),
+            additional_certificates: None,
+            ocsp_staple_path: None,
+            ocsp: None,
+        }),
+        http3: None,
+    }
+}
+
 fn managed_acme_config(
     directory_url: &str,
     state_dir: &str,
@@ -218,4 +243,31 @@ fn compile_allows_missing_managed_identity_files_for_acme_issue_mode() {
     let spec = &snapshot.managed_certificates[0];
     assert_eq!(spec.cert_path, base_dir.path().join("managed.crt"));
     assert_eq!(spec.key_path, base_dir.path().join("managed.key"));
+}
+
+#[test]
+fn compile_allows_shared_managed_identity_files_for_acme_issue_mode() {
+    let base_dir = temp_base_dir("rginx-acme-shared-identity-");
+    let mut config = managed_acme_config(
+        "https://acme-staging-v02.api.letsencrypt.org/directory",
+        "state/acme",
+        None,
+        None,
+        vec!["api.example.com"],
+        vec!["api.example.com"],
+    );
+    config.servers.push(shared_tls_vhost(vec!["www.example.com"], "managed.crt", "managed.key"));
+
+    let snapshot = crate::compile::compile_with_base_and_options(
+        config,
+        base_dir.path(),
+        crate::compile::CompileOptions { allow_missing_managed_tls_identity: true },
+    )
+    .expect("shared managed identities should compile in ACME issue mode");
+
+    assert_eq!(snapshot.managed_certificates.len(), 1);
+    assert_eq!(
+        snapshot.vhosts[1].tls.as_ref().expect("shared vhost should keep TLS").cert_path,
+        base_dir.path().join("managed.crt")
+    );
 }

--- a/crates/rginx-config/src/compile/vhost.rs
+++ b/crates/rginx-config/src/compile/vhost.rs
@@ -17,6 +17,7 @@ pub(super) fn compile_virtual_host(
     config: VirtualHostConfig,
     upstreams: &HashMap<String, Arc<Upstream>>,
     base_dir: &Path,
+    allow_missing_managed_tls_identity: bool,
 ) -> Result<CompiledVirtualHost> {
     let VirtualHostConfig {
         listen: _,
@@ -49,7 +50,11 @@ pub(super) fn compile_virtual_host(
         &local_upstream_names,
         &vhost_id,
     )?;
-    let tls = super::server::compile_virtual_host_tls(tls, base_dir)?;
+    let tls = super::server::compile_virtual_host_tls(
+        tls.clone(),
+        base_dir,
+        allow_missing_managed_tls_identity && acme.is_some(),
+    )?;
     let managed_certificate = tls
         .as_ref()
         .and_then(|tls| super::acme::compile_managed_certificate_spec(vhost_id.clone(), tls, acme));

--- a/crates/rginx-config/src/compile/vhost.rs
+++ b/crates/rginx-config/src/compile/vhost.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use rginx_core::{ManagedCertificateSpec, Result, Upstream, VirtualHost};
@@ -18,6 +20,7 @@ pub(super) fn compile_virtual_host(
     upstreams: &HashMap<String, Arc<Upstream>>,
     base_dir: &Path,
     allow_missing_managed_tls_identity: bool,
+    managed_identity_pairs: &HashSet<(PathBuf, PathBuf)>,
 ) -> Result<CompiledVirtualHost> {
     let VirtualHostConfig {
         listen: _,
@@ -28,6 +31,10 @@ pub(super) fn compile_virtual_host(
         http3: _,
     } = config;
     let acme = tls.as_ref().and_then(|tls| tls.acme.clone());
+    let allow_missing_tls_identity = allow_missing_managed_tls_identity
+        && tls
+            .as_ref()
+            .is_some_and(|tls| tls_identity_is_managed(tls, base_dir, managed_identity_pairs));
     let local_upstream_names = raw_upstreams
         .iter()
         .map(|upstream| {
@@ -50,11 +57,7 @@ pub(super) fn compile_virtual_host(
         &local_upstream_names,
         &vhost_id,
     )?;
-    let tls = super::server::compile_virtual_host_tls(
-        tls.clone(),
-        base_dir,
-        allow_missing_managed_tls_identity && acme.is_some(),
-    )?;
+    let tls = super::server::compile_virtual_host_tls(tls, base_dir, allow_missing_tls_identity)?;
     let managed_certificate = tls
         .as_ref()
         .and_then(|tls| super::acme::compile_managed_certificate_spec(vhost_id.clone(), tls, acme));
@@ -64,4 +67,15 @@ pub(super) fn compile_virtual_host(
         upstreams: local_upstreams,
         managed_certificate,
     })
+}
+
+fn tls_identity_is_managed(
+    tls: &crate::model::VirtualHostTlsConfig,
+    base_dir: &Path,
+    managed_identity_pairs: &HashSet<(PathBuf, PathBuf)>,
+) -> bool {
+    managed_identity_pairs.contains(&(
+        super::resolve_path(base_dir, tls.cert_path.clone()),
+        super::resolve_path(base_dir, tls.key_path.clone()),
+    ))
 }

--- a/crates/rginx-config/src/lib.rs
+++ b/crates/rginx-config/src/lib.rs
@@ -18,6 +18,17 @@ pub fn load_and_compile(path: impl AsRef<Path>) -> Result<ConfigSnapshot> {
     compile::compile_with_base(raw, base_dir)
 }
 
+pub fn load_and_compile_for_acme_issue(path: impl AsRef<Path>) -> Result<ConfigSnapshot> {
+    let path = path.as_ref();
+    let raw = load::load_from_path(path)?;
+    let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    compile::compile_with_base_and_options(
+        raw,
+        base_dir,
+        compile::CompileOptions { allow_missing_managed_tls_identity: true },
+    )
+}
+
 pub fn load_and_compile_from_str(
     contents: &str,
     config_path: impl AsRef<Path>,

--- a/crates/rginx-http/src/handler/dispatch/acme.rs
+++ b/crates/rginx-http/src/handler/dispatch/acme.rs
@@ -1,0 +1,12 @@
+use crate::state::SharedState;
+
+const ACME_HTTP01_PREFIX: &str = "/.well-known/acme-challenge/";
+
+pub(super) fn http01_response(state: &SharedState, request_path: &str) -> Option<String> {
+    let token = request_path.strip_prefix(ACME_HTTP01_PREFIX)?;
+    if token.is_empty() || token.contains('/') {
+        return None;
+    }
+
+    state.acme_http01_response(token)
+}

--- a/crates/rginx-http/src/handler/dispatch/mod.rs
+++ b/crates/rginx-http/src/handler/dispatch/mod.rs
@@ -18,6 +18,7 @@ use super::grpc::{
 use super::response::{full_body, text_response};
 use super::*;
 
+mod acme;
 mod authorize;
 mod date;
 mod response;
@@ -108,6 +109,20 @@ pub async fn handle(
     let client_address =
         resolve_client_address(request.headers(), &listener.server, connection.as_ref());
     let downstream_scheme = if listener.tls_enabled() { "https" } else { "http" };
+    if let Some(challenge_response) = acme::http01_response(&state, &request_path) {
+        let finalized = finalize_downstream_response(
+            &method,
+            &request_headers,
+            &ResponseCompressionOptions::default(),
+            request_id_header,
+            text_response(StatusCode::OK, "text/plain; charset=utf-8", challenge_response),
+            grpc_request,
+            alt_svc_header,
+            server_header,
+        )
+        .await;
+        return finalized.response;
+    }
     let (selected_vhost_id, selected_route) = {
         let selected_vhost =
             select_vhost_for_request(config.as_ref(), request.headers(), request.uri());

--- a/crates/rginx-http/src/handler/tests/routing/handle.rs
+++ b/crates/rginx-http/src/handler/tests/routing/handle.rs
@@ -84,3 +84,49 @@ async fn handle_return_route_uses_numeric_body_and_ignores_non_redirect_location
     let body = response.into_body().collect().await.expect("body should collect").to_bytes();
     assert_eq!(body.as_ref(), b"299\n");
 }
+
+#[tokio::test]
+async fn handle_short_circuits_acme_http01_requests() {
+    let route = Route {
+        cache: None,
+        id: "server/routes[0]|exact:/.well-known/acme-challenge/demo-token".to_string(),
+        matcher: RouteMatcher::Exact("/.well-known/acme-challenge/demo-token".to_string()),
+        grpc_match: None,
+        action: RouteAction::Return(ReturnAction {
+            status: StatusCode::MOVED_PERMANENTLY,
+            location: "https://example.com/redirected".to_string(),
+            body: None,
+        }),
+        access_control: RouteAccessControl::default(),
+        rate_limit: None,
+        allow_early_data: false,
+        request_buffering: rginx_core::RouteBufferingPolicy::Auto,
+        response_buffering: rginx_core::RouteBufferingPolicy::Auto,
+        compression: rginx_core::RouteCompressionPolicy::Off,
+        compression_min_bytes: None,
+        compression_content_types: Vec::new(),
+        streaming_response_idle_timeout: None,
+    };
+    let config = test_config(test_vhost("server", Vec::new(), vec![route]), Vec::new());
+    let shared = crate::state::SharedState::from_config(config).expect("shared state should build");
+    shared.register_acme_http01_challenge("demo-token", "demo-key-authorization");
+
+    let request = Request::builder()
+        .uri("/.well-known/acme-challenge/demo-token")
+        .body(crate::handler::full_body(""))
+        .expect("request should build");
+    let connection = std::sync::Arc::new(ConnectionPeerAddrs {
+        socket_peer_addr: "192.0.2.10:44323".parse().unwrap(),
+        proxy_protocol_source_addr: None,
+        tls_client_identity: None,
+        tls_version: None,
+        tls_alpn: None,
+        early_data: false,
+    });
+
+    let response = crate::handler::handle(request, shared, connection, "default").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response.headers().get(http::header::LOCATION).is_none());
+    let body = response.into_body().collect().await.expect("body should collect").to_bytes();
+    assert_eq!(body.as_ref(), b"demo-key-authorization");
+}

--- a/crates/rginx-http/src/state/lifecycle.rs
+++ b/crates/rginx-http/src/state/lifecycle.rs
@@ -1,3 +1,4 @@
+mod acme;
 mod mtls;
 mod reload;
 mod status;

--- a/crates/rginx-http/src/state/lifecycle/acme.rs
+++ b/crates/rginx-http/src/state/lifecycle/acme.rs
@@ -1,0 +1,29 @@
+use super::super::*;
+
+impl SharedState {
+    pub fn register_acme_http01_challenge(
+        &self,
+        token: impl Into<String>,
+        key_authorization: impl Into<String>,
+    ) {
+        self.acme_http01_challenges
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(token.into(), key_authorization.into());
+    }
+
+    pub fn unregister_acme_http01_challenge(&self, token: &str) {
+        self.acme_http01_challenges
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(token);
+    }
+
+    pub fn acme_http01_response(&self, token: &str) -> Option<String> {
+        self.acme_http01_challenges
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(token)
+            .cloned()
+    }
+}

--- a/crates/rginx-http/src/state/mod.rs
+++ b/crates/rginx-http/src/state/mod.rs
@@ -93,6 +93,7 @@ pub struct SharedState {
     cache_component_versions: Arc<StdRwLock<HashMap<String, u64>>>,
     reload_history: Arc<Mutex<ReloadHistory>>,
     ocsp_statuses: Arc<StdRwLock<HashMap<String, OcspRuntimeStatusEntry>>>,
+    acme_http01_challenges: Arc<StdRwLock<HashMap<String, String>>>,
     config_path: Option<Arc<PathBuf>>,
 }
 
@@ -158,6 +159,7 @@ impl SharedState {
         *cache_component_versions.write().unwrap_or_else(|poisoned| poisoned.into_inner()) =
             cache::build_cache_zone_versions(prepared.config.as_ref(), None);
         let ocsp_statuses = Arc::new(StdRwLock::new(HashMap::new()));
+        let acme_http01_challenges = Arc::new(StdRwLock::new(HashMap::new()));
 
         Ok(Self {
             inner: Arc::new(RwLock::new(ActiveState {
@@ -185,6 +187,7 @@ impl SharedState {
             cache_component_versions,
             reload_history: Arc::new(Mutex::new(ReloadHistory::default())),
             ocsp_statuses,
+            acme_http01_challenges,
             config_path: config_path.map(Arc::new),
         })
     }

--- a/crates/rginx-runtime/Cargo.toml
+++ b/crates/rginx-runtime/Cargo.toml
@@ -13,10 +13,12 @@ description = "Runtime orchestration, reload, shutdown, and health checks for rg
 
 [dependencies]
 bytes.workspace = true
+http.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
 hyper-rustls.workspace = true
 hyper-util.workspace = true
+instant-acme.workspace = true
 libc = "0.2"
 quinn.workspace = true
 rginx-config = { path = "../rginx-config" }
@@ -32,3 +34,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
+tempfile = "3.27"

--- a/crates/rginx-runtime/src/acme/account.rs
+++ b/crates/rginx-runtime/src/acme/account.rs
@@ -1,0 +1,42 @@
+use instant_acme::{Account, NewAccount};
+use rginx_core::{AcmeSettings, Error, Result};
+
+use super::storage::{
+    PersistedAccountCredentials, load_account_credentials, store_account_credentials,
+};
+
+pub(crate) async fn load_or_create_account(settings: &AcmeSettings) -> Result<Account> {
+    if let Some(persisted) = load_account_credentials(settings)?
+        && persisted.directory_url == settings.directory_url
+    {
+        return Account::builder()
+            .map_err(|error| acme_error("failed to construct ACME account client", error))?
+            .from_credentials(persisted.credentials)
+            .await
+            .map_err(|error| acme_error("failed to restore persisted ACME account", error));
+    }
+
+    let contacts = settings.contacts.iter().map(String::as_str).collect::<Vec<_>>();
+    let (account, credentials) = Account::builder()
+        .map_err(|error| acme_error("failed to construct ACME account client", error))?
+        .create(
+            &NewAccount {
+                contact: contacts.as_slice(),
+                terms_of_service_agreed: true,
+                only_return_existing: false,
+            },
+            settings.directory_url.clone(),
+            None,
+        )
+        .await
+        .map_err(|error| acme_error("failed to create ACME account", error))?;
+    store_account_credentials(
+        settings,
+        &PersistedAccountCredentials { directory_url: settings.directory_url.clone(), credentials },
+    )?;
+    Ok(account)
+}
+
+pub(crate) fn acme_error(context: &str, error: impl std::fmt::Display) -> Error {
+    Error::Server(format!("{context}: {error}"))
+}

--- a/crates/rginx-runtime/src/acme/challenge.rs
+++ b/crates/rginx-runtime/src/acme/challenge.rs
@@ -1,0 +1,202 @@
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::sync::{Arc, RwLock as StdRwLock};
+
+use bytes::Bytes;
+use http::header::CONTENT_TYPE;
+use http::{Method, Request, Response, StatusCode};
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper_util::rt::TokioIo;
+use rginx_core::{ConfigSnapshot, Error, Result};
+use rginx_http::SharedState;
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use super::types::http01_listener_addrs;
+
+const ACME_HTTP01_PREFIX: &str = "/.well-known/acme-challenge/";
+
+pub(crate) trait ChallengeBackend: Send + Sync {
+    fn register_http01(&self, token: String, key_authorization: String);
+    fn unregister_http01(&self, token: &str);
+}
+
+#[derive(Clone)]
+pub(crate) struct RuntimeChallengeBackend {
+    state: SharedState,
+}
+
+impl RuntimeChallengeBackend {
+    pub(crate) fn new(state: SharedState) -> Self {
+        Self { state }
+    }
+}
+
+impl ChallengeBackend for RuntimeChallengeBackend {
+    fn register_http01(&self, token: String, key_authorization: String) {
+        self.state.register_acme_http01_challenge(token, key_authorization);
+    }
+
+    fn unregister_http01(&self, token: &str) {
+        self.state.unregister_acme_http01_challenge(token);
+    }
+}
+
+pub(crate) struct TemporaryChallengeServer {
+    backend: Arc<TemporaryChallengeStore>,
+    shutdown_tx: watch::Sender<bool>,
+    tasks: Vec<JoinHandle<()>>,
+}
+
+impl TemporaryChallengeServer {
+    pub(crate) async fn bind_for_config(config: &ConfigSnapshot) -> Result<Self> {
+        let listen_addrs = http01_listener_addrs(config);
+        if listen_addrs.is_empty() {
+            return Err(Error::Config(
+                "ACME HTTP-01 requires at least one plain HTTP listener on port 80".to_string(),
+            ));
+        }
+
+        let backend = Arc::new(TemporaryChallengeStore::default());
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let mut tasks = Vec::with_capacity(listen_addrs.len());
+
+        for listen_addr in listen_addrs {
+            let listener = TcpListener::bind(listen_addr).await.map_err(|error| {
+                Error::Server(format!(
+                    "failed to bind temporary ACME HTTP-01 listener on {listen_addr}: {error}"
+                ))
+            })?;
+            let store = backend.clone();
+            let shutdown = shutdown_tx.subscribe();
+            tasks.push(tokio::spawn(async move {
+                run_listener(listener, store, shutdown).await;
+            }));
+        }
+
+        Ok(Self { backend, shutdown_tx, tasks })
+    }
+
+    pub(crate) fn backend(&self) -> Arc<dyn ChallengeBackend> {
+        self.backend.clone()
+    }
+
+    pub(crate) async fn shutdown(self) {
+        let _ = self.shutdown_tx.send(true);
+        for task in self.tasks {
+            if let Err(error) = task.await
+                && !error.is_cancelled()
+            {
+                tracing::debug!(%error, "temporary ACME HTTP-01 listener task exited unexpectedly");
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct TemporaryChallengeStore {
+    challenges: StdRwLock<HashMap<String, String>>,
+}
+
+impl ChallengeBackend for TemporaryChallengeStore {
+    fn register_http01(&self, token: String, key_authorization: String) {
+        self.challenges
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(token, key_authorization);
+    }
+
+    fn unregister_http01(&self, token: &str) {
+        self.challenges.write().unwrap_or_else(|poisoned| poisoned.into_inner()).remove(token);
+    }
+}
+
+impl TemporaryChallengeStore {
+    fn response(&self, token: &str) -> Option<String> {
+        self.challenges.read().unwrap_or_else(|poisoned| poisoned.into_inner()).get(token).cloned()
+    }
+}
+
+async fn run_listener(
+    listener: TcpListener,
+    store: Arc<TemporaryChallengeStore>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    let listen_addr = listener.local_addr().ok();
+
+    loop {
+        tokio::select! {
+            changed = shutdown.changed() => {
+                match changed {
+                    Ok(()) if *shutdown.borrow() => break,
+                    Ok(()) => continue,
+                    Err(_) => break,
+                }
+            }
+            accepted = listener.accept() => {
+                match accepted {
+                    Ok((stream, _peer_addr)) => {
+                        let store = store.clone();
+                        tokio::spawn(async move {
+                            let service = service_fn(move |request: Request<Incoming>| {
+                                let store = store.clone();
+                                async move { Ok::<_, Infallible>(build_response(request, store)) }
+                            });
+                            if let Err(error) = http1::Builder::new()
+                                .serve_connection(TokioIo::new(stream), service)
+                                .await
+                            {
+                                tracing::debug!(%error, "temporary ACME HTTP-01 connection failed");
+                            }
+                        });
+                    }
+                    Err(error) => {
+                        if let Some(listen_addr) = listen_addr {
+                            tracing::warn!(%error, %listen_addr, "temporary ACME HTTP-01 listener stopped accepting");
+                        } else {
+                            tracing::warn!(%error, "temporary ACME HTTP-01 listener stopped accepting");
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn build_response(
+    request: Request<Incoming>,
+    store: Arc<TemporaryChallengeStore>,
+) -> Response<Full<Bytes>> {
+    let key_authorization = request
+        .uri()
+        .path()
+        .strip_prefix(ACME_HTTP01_PREFIX)
+        .filter(|token| !token.is_empty() && !token.contains('/'))
+        .and_then(|token| store.response(token));
+
+    match (request.method(), key_authorization) {
+        (&Method::GET, Some(body)) => text_response(StatusCode::OK, body),
+        (&Method::HEAD, Some(_)) => empty_response(StatusCode::OK),
+        _ => empty_response(StatusCode::NOT_FOUND),
+    }
+}
+
+fn text_response(status: StatusCode, body: String) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(Full::new(Bytes::from(body)))
+        .expect("temporary ACME HTTP-01 response should build")
+}
+
+fn empty_response(status: StatusCode) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .body(Full::new(Bytes::new()))
+        .expect("temporary ACME HTTP-01 response should build")
+}

--- a/crates/rginx-runtime/src/acme/challenge.rs
+++ b/crates/rginx-runtime/src/acme/challenge.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::io::ErrorKind;
 use std::sync::{Arc, RwLock as StdRwLock};
+use std::time::Duration;
 
 use bytes::Bytes;
 use http::header::CONTENT_TYPE;
@@ -155,6 +157,23 @@ async fn run_listener(
                         });
                     }
                     Err(error) => {
+                        if is_transient_accept_error(&error) {
+                            if let Some(listen_addr) = listen_addr {
+                                tracing::warn!(
+                                    %error,
+                                    %listen_addr,
+                                    "temporary ACME HTTP-01 listener accept failed transiently; retrying"
+                                );
+                            } else {
+                                tracing::warn!(
+                                    %error,
+                                    "temporary ACME HTTP-01 listener accept failed transiently; retrying"
+                                );
+                            }
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            continue;
+                        }
+
                         if let Some(listen_addr) = listen_addr {
                             tracing::warn!(%error, %listen_addr, "temporary ACME HTTP-01 listener stopped accepting");
                         } else {
@@ -166,6 +185,30 @@ async fn run_listener(
             }
         }
     }
+}
+
+pub(super) fn is_transient_accept_error(error: &std::io::Error) -> bool {
+    if matches!(
+        error.kind(),
+        ErrorKind::ConnectionAborted
+            | ErrorKind::ConnectionReset
+            | ErrorKind::Interrupted
+            | ErrorKind::TimedOut
+            | ErrorKind::WouldBlock
+            | ErrorKind::OutOfMemory
+    ) {
+        return true;
+    }
+
+    #[cfg(unix)]
+    if let Some(code) = error.raw_os_error() {
+        return matches!(
+            code,
+            libc::ECONNABORTED | libc::EMFILE | libc::ENFILE | libc::ENOBUFS | libc::ENOMEM
+        );
+    }
+
+    false
 }
 
 fn build_response(

--- a/crates/rginx-runtime/src/acme/mod.rs
+++ b/crates/rginx-runtime/src/acme/mod.rs
@@ -1,0 +1,87 @@
+use rginx_core::{ConfigSnapshot, Error, Result};
+use rginx_http::SharedState;
+use tokio::sync::watch;
+
+mod account;
+mod challenge;
+mod order;
+mod scheduler;
+mod storage;
+#[cfg(test)]
+mod tests;
+mod types;
+
+pub use types::{CertificateFailure, IssueSummary};
+
+use account::load_or_create_account;
+use challenge::{ChallengeBackend, TemporaryChallengeServer};
+use order::issue_and_store_managed_certificate;
+use types::{certificate_status_index, plan_reconcile};
+
+pub async fn run(state: SharedState, shutdown: watch::Receiver<bool>) {
+    scheduler::run(state, shutdown).await;
+}
+
+pub async fn issue_once(config: &ConfigSnapshot) -> Result<IssueSummary> {
+    let Some(settings) = config.acme.as_ref() else {
+        return Err(Error::Config(
+            "`rginx acme issue --once` requires top-level acme configuration".to_string(),
+        ));
+    };
+
+    let certificate_statuses = certificate_status_index(config);
+    let mut summary = IssueSummary::new(config.managed_certificates.len());
+    let mut pending = Vec::new();
+
+    for spec in &config.managed_certificates {
+        match plan_reconcile(spec, certificate_statuses.get(&spec.scope), settings) {
+            Some(plan) => pending.push((spec, plan)),
+            None => {
+                summary.skipped += 1;
+                tracing::info!(
+                    scope = %spec.scope,
+                    "managed certificate already satisfies current ACME spec"
+                );
+            }
+        }
+    }
+
+    if pending.is_empty() {
+        return Ok(summary);
+    }
+
+    let challenge_server = TemporaryChallengeServer::bind_for_config(config).await?;
+    let issue_result = async {
+        let account = load_or_create_account(settings).await?;
+        let challenge_backend: std::sync::Arc<dyn ChallengeBackend> = challenge_server.backend();
+
+        for (spec, plan) in pending {
+            tracing::info!(
+                scope = %spec.scope,
+                reason = %plan.describe(),
+                "issuing managed ACME certificate via one-shot flow"
+            );
+            match issue_and_store_managed_certificate(spec, &account, challenge_backend.clone())
+                .await
+            {
+                Ok(()) => {
+                    summary.issued += 1;
+                    tracing::info!(scope = %spec.scope, "managed ACME certificate issued");
+                }
+                Err(error) => {
+                    summary.failures.push(types::CertificateFailure {
+                        scope: spec.scope.clone(),
+                        error: error.to_string(),
+                    });
+                    tracing::warn!(scope = %spec.scope, %error, "managed ACME issuance failed");
+                }
+            }
+        }
+
+        Ok(summary)
+    }
+    .await;
+
+    challenge_server.shutdown().await;
+    issue_result
+}

--- a/crates/rginx-runtime/src/acme/order.rs
+++ b/crates/rginx-runtime/src/acme/order.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+
+use instant_acme::{
+    Account, AuthorizationStatus, ChallengeType, Identifier, NewOrder, OrderStatus,
+};
+use rginx_core::{Error, ManagedCertificateSpec, Result};
+
+use super::account::acme_error;
+use super::challenge::ChallengeBackend;
+use super::storage::write_certificate_pair;
+use super::types::acme_poll_retry_policy;
+
+pub(crate) async fn issue_and_store_managed_certificate(
+    spec: &ManagedCertificateSpec,
+    account: &Account,
+    challenge_backend: Arc<dyn ChallengeBackend>,
+) -> Result<()> {
+    let identifiers = spec.domains.iter().cloned().map(Identifier::Dns).collect::<Vec<_>>();
+    let mut order = account
+        .new_order(&NewOrder::new(identifiers.as_slice()))
+        .await
+        .map_err(|error| acme_error("failed to create ACME order", error))?;
+
+    let mut registered_tokens = Vec::<String>::new();
+    let result = async {
+        let mut authorizations = order.authorizations();
+        while let Some(result) = authorizations.next().await {
+            let mut authorization =
+                result.map_err(|error| acme_error("failed to fetch ACME authorization", error))?;
+            match authorization.status {
+                AuthorizationStatus::Pending => {}
+                AuthorizationStatus::Valid => continue,
+                other => {
+                    let identifier = authorization.identifier().to_string();
+                    return Err(Error::Server(format!(
+                        "ACME authorization for `{}` is in unexpected state `{other:?}`",
+                        identifier
+                    )));
+                }
+            }
+
+            let identifier = authorization.identifier().to_string();
+            let mut challenge =
+                authorization.challenge(ChallengeType::Http01).ok_or_else(|| {
+                    Error::Server(format!(
+                        "ACME authorization for `{}` does not provide an HTTP-01 challenge",
+                        identifier
+                    ))
+                })?;
+            if challenge.token.is_empty() {
+                return Err(Error::Server(format!(
+                    "ACME HTTP-01 challenge for `{}` is missing its token",
+                    challenge.identifier()
+                )));
+            }
+
+            let token = challenge.token.clone();
+            challenge_backend
+                .register_http01(token.clone(), challenge.key_authorization().as_str().to_string());
+            registered_tokens.push(token);
+            challenge.set_ready().await.map_err(|error| {
+                acme_error("failed to mark ACME HTTP-01 challenge ready", error)
+            })?;
+        }
+
+        let ready_status = order.poll_ready(&acme_poll_retry_policy()).await.map_err(|error| {
+            acme_error("failed while waiting for ACME order to become ready", error)
+        })?;
+        if ready_status != OrderStatus::Ready {
+            return Err(Error::Server(format!(
+                "ACME order for `{}` ended in unexpected state `{ready_status:?}`",
+                spec.scope
+            )));
+        }
+
+        let private_key_pem = order
+            .finalize()
+            .await
+            .map_err(|error| acme_error("failed to finalize ACME order", error))?;
+        let certificate_chain_pem = order
+            .poll_certificate(&acme_poll_retry_policy())
+            .await
+            .map_err(|error| acme_error("failed while waiting for ACME certificate", error))?;
+        write_certificate_pair(spec, &certificate_chain_pem, &private_key_pem)
+    }
+    .await;
+
+    for token in registered_tokens {
+        challenge_backend.unregister_http01(&token);
+    }
+
+    result
+}

--- a/crates/rginx-runtime/src/acme/scheduler.rs
+++ b/crates/rginx-runtime/src/acme/scheduler.rs
@@ -1,0 +1,193 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rginx_http::SharedState;
+use tokio::sync::watch;
+
+use super::account::load_or_create_account;
+use super::challenge::{ChallengeBackend, RuntimeChallengeBackend};
+use super::order::issue_and_store_managed_certificate;
+use super::types::{certificate_status_index, http01_listener_addrs, plan_reconcile};
+
+const DEFAULT_IDLE_INTERVAL: Duration = Duration::from_secs(300);
+const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(60);
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(6 * 60 * 60);
+
+#[derive(Debug, Clone)]
+struct RetryState {
+    failures: u32,
+    next_retry_at: Instant,
+}
+
+#[derive(Default)]
+struct RetryBackoff {
+    entries: HashMap<String, RetryState>,
+}
+
+impl RetryBackoff {
+    fn retain_scopes(&mut self, scopes: &HashSet<String>) {
+        self.entries.retain(|scope, _| scopes.contains(scope));
+    }
+
+    fn remaining_delay(&self, scope: &str) -> Option<Duration> {
+        self.entries
+            .get(scope)
+            .and_then(|state| state.next_retry_at.checked_duration_since(Instant::now()))
+    }
+
+    fn record_success(&mut self, scope: &str) {
+        self.entries.remove(scope);
+    }
+
+    fn record_failure(&mut self, scope: &str) -> Duration {
+        let failures =
+            self.entries.get(scope).map(|state| state.failures.saturating_add(1)).unwrap_or(1);
+        let exponent = failures.saturating_sub(1).min(8);
+        let retry_delay = std::cmp::min(INITIAL_RETRY_DELAY * (1 << exponent), MAX_RETRY_DELAY);
+        self.entries.insert(
+            scope.to_string(),
+            RetryState { failures, next_retry_at: Instant::now() + retry_delay },
+        );
+        retry_delay
+    }
+}
+
+pub(super) async fn run(state: SharedState, mut shutdown: watch::Receiver<bool>) {
+    let mut revisions = state.subscribe_updates();
+    let mut interval = tokio::time::interval(current_poll_interval(&state).await);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut retry_backoff = RetryBackoff::default();
+
+    if let Err(error) = reconcile_managed_certificates(&state, &mut retry_backoff).await {
+        tracing::warn!(%error, "initial ACME reconcile failed");
+    }
+
+    loop {
+        tokio::select! {
+            changed = shutdown.changed() => {
+                match changed {
+                    Ok(()) if *shutdown.borrow() => break,
+                    Ok(()) => continue,
+                    Err(_) => break,
+                }
+            }
+            changed = revisions.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                interval = tokio::time::interval(current_poll_interval(&state).await);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                if let Err(error) = reconcile_managed_certificates(&state, &mut retry_backoff).await {
+                    tracing::warn!(%error, "ACME reconcile after reload failed");
+                }
+            }
+            _ = interval.tick() => {
+                if let Err(error) = reconcile_managed_certificates(&state, &mut retry_backoff).await {
+                    tracing::warn!(%error, "periodic ACME reconcile failed");
+                }
+            }
+        }
+    }
+
+    tracing::info!("managed ACME reconciler stopped");
+}
+
+async fn current_poll_interval(state: &SharedState) -> Duration {
+    state
+        .current_config()
+        .await
+        .acme
+        .as_ref()
+        .map(|settings| settings.poll_interval)
+        .unwrap_or(DEFAULT_IDLE_INTERVAL)
+}
+
+async fn reconcile_managed_certificates(
+    state: &SharedState,
+    retry_backoff: &mut RetryBackoff,
+) -> Result<(), String> {
+    let config = state.current_config().await;
+    let Some(settings) = config.acme.as_ref() else {
+        retry_backoff.entries.clear();
+        return Ok(());
+    };
+    if config.managed_certificates.is_empty() {
+        retry_backoff.entries.clear();
+        return Ok(());
+    }
+
+    let active_scopes =
+        config.managed_certificates.iter().map(|spec| spec.scope.clone()).collect::<HashSet<_>>();
+    retry_backoff.retain_scopes(&active_scopes);
+
+    let certificate_statuses = certificate_status_index(config.as_ref());
+    let pending = config
+        .managed_certificates
+        .iter()
+        .filter_map(|spec| {
+            plan_reconcile(spec, certificate_statuses.get(&spec.scope), settings)
+                .map(|plan| (spec, plan))
+        })
+        .collect::<Vec<_>>();
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    if http01_listener_addrs(config.as_ref()).is_empty() {
+        for (spec, plan) in pending {
+            tracing::warn!(
+                scope = %spec.scope,
+                reason = %plan.describe(),
+                "managed ACME reconcile deferred because no plain HTTP listener is configured on port 80"
+            );
+        }
+        return Ok(());
+    }
+
+    let account = load_or_create_account(settings).await.map_err(|error| error.to_string())?;
+    let challenge_backend: Arc<dyn ChallengeBackend> =
+        Arc::new(RuntimeChallengeBackend::new(state.clone()));
+    let mut tls_acceptors_changed = false;
+
+    for (spec, plan) in pending {
+        if let Some(delay) = retry_backoff.remaining_delay(&spec.scope) {
+            tracing::debug!(
+                scope = %spec.scope,
+                retry_after_secs = delay.as_secs(),
+                "managed ACME reconcile is waiting for retry backoff"
+            );
+            continue;
+        }
+
+        tracing::info!(
+            scope = %spec.scope,
+            reason = %plan.describe(),
+            "reconciling managed ACME certificate"
+        );
+        match issue_and_store_managed_certificate(spec, &account, challenge_backend.clone()).await {
+            Ok(()) => {
+                retry_backoff.record_success(&spec.scope);
+                tls_acceptors_changed = true;
+                tracing::info!(scope = %spec.scope, "managed ACME certificate refreshed");
+            }
+            Err(error) => {
+                let retry_delay = retry_backoff.record_failure(&spec.scope);
+                tracing::warn!(
+                    scope = %spec.scope,
+                    %error,
+                    retry_after_secs = retry_delay.as_secs(),
+                    "managed ACME reconcile failed"
+                );
+            }
+        }
+    }
+
+    if tls_acceptors_changed {
+        state.refresh_tls_acceptors_from_current_config().await.map_err(|error| {
+            format!("failed to rebuild TLS acceptors after ACME certificate refresh: {error}")
+        })?;
+    }
+
+    Ok(())
+}

--- a/crates/rginx-runtime/src/acme/storage.rs
+++ b/crates/rginx-runtime/src/acme/storage.rs
@@ -50,8 +50,25 @@ pub(crate) fn write_certificate_pair(
     certificate_chain_pem: &str,
     private_key_pem: &str,
 ) -> Result<()> {
+    let previous_certificate = read_existing_file(&spec.cert_path)?;
     atomic_write(&spec.cert_path, certificate_chain_pem.as_bytes(), CERT_FILE_MODE)?;
-    atomic_write(&spec.key_path, private_key_pem.as_bytes(), PRIVATE_KEY_FILE_MODE)
+    if let Err(error) =
+        atomic_write(&spec.key_path, private_key_pem.as_bytes(), PRIVATE_KEY_FILE_MODE)
+    {
+        rollback_file(&spec.cert_path, previous_certificate.as_deref(), CERT_FILE_MODE).map_err(
+            |rollback_error| {
+                Error::Server(format!(
+                    "failed to persist private key for managed certificate `{}`: {error}; \
+                     failed to roll back certificate `{}`: {rollback_error}",
+                    spec.scope,
+                    spec.cert_path.display()
+                ))
+            },
+        )?;
+        return Err(error);
+    }
+
+    Ok(())
 }
 
 fn account_credentials_path(settings: &AcmeSettings) -> PathBuf {
@@ -59,7 +76,7 @@ fn account_credentials_path(settings: &AcmeSettings) -> PathBuf {
 }
 
 fn atomic_write(path: &Path, contents: &[u8], mode: u32) -> Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let parent = parent_directory(path);
     fs::create_dir_all(parent)?;
 
     let temp_path = temporary_path(path);
@@ -78,6 +95,21 @@ fn atomic_write(path: &Path, contents: &[u8], mode: u32) -> Result<()> {
     }
 
     write_result
+}
+
+fn read_existing_file(path: &Path) -> Result<Option<Vec<u8>>> {
+    match fs::read(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(Error::Io(error)),
+    }
+}
+
+fn rollback_file(path: &Path, previous_contents: Option<&[u8]>, mode: u32) -> Result<()> {
+    match previous_contents {
+        Some(contents) => atomic_write(path, contents, mode),
+        None => remove_file_if_exists(path),
+    }
 }
 
 fn create_temp_file(path: &Path, mode: u32) -> Result<File> {
@@ -106,6 +138,21 @@ fn temporary_path(path: &Path) -> PathBuf {
     let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     let file_name = path.file_name().and_then(|value| value.to_str()).unwrap_or("acme-material");
     path.with_file_name(format!("{file_name}.tmp-{timestamp_nanos}-{sequence}"))
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => {
+            sync_directory(parent_directory(path))?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Error::Io(error)),
+    }
+}
+
+pub(super) fn parent_directory(path: &Path) -> &Path {
+    path.parent().filter(|parent| !parent.as_os_str().is_empty()).unwrap_or_else(|| Path::new("."))
 }
 
 fn sync_directory(path: &Path) -> Result<()> {

--- a/crates/rginx-runtime/src/acme/storage.rs
+++ b/crates/rginx-runtime/src/acme/storage.rs
@@ -85,16 +85,17 @@ fn create_temp_file(path: &Path, mode: u32) -> Result<File> {
     {
         use std::os::unix::fs::OpenOptionsExt;
 
-        return OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .mode(mode)
-            .open(path)
-            .map_err(Error::from);
+        OpenOptions::new().create_new(true).write(true).mode(mode).open(path).map_err(Error::from)
     }
 
-    #[allow(unreachable_code)]
-    OpenOptions::new().create_new(true).write(true).open(path).map_err(Error::from)
+    #[cfg(not(unix))]
+    {
+        let _ = (path, mode);
+        Err(Error::Server(
+            "managed ACME certificate persistence requires Unix file permission semantics"
+                .to_string(),
+        ))
+    }
 }
 
 fn temporary_path(path: &Path) -> PathBuf {

--- a/crates/rginx-runtime/src/acme/storage.rs
+++ b/crates/rginx-runtime/src/acme/storage.rs
@@ -1,0 +1,113 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use instant_acme::AccountCredentials;
+use rginx_core::{AcmeSettings, Error, ManagedCertificateSpec, Result};
+use serde::{Deserialize, Serialize};
+
+const CERT_FILE_MODE: u32 = 0o644;
+const PRIVATE_KEY_FILE_MODE: u32 = 0o600;
+
+static TEMP_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct PersistedAccountCredentials {
+    pub(crate) directory_url: String,
+    pub(crate) credentials: AccountCredentials,
+}
+
+pub(crate) fn load_account_credentials(
+    settings: &AcmeSettings,
+) -> Result<Option<PersistedAccountCredentials>> {
+    let path = account_credentials_path(settings);
+    match fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).map(Some).map_err(|error| {
+            Error::Server(format!(
+                "failed to parse persisted ACME account credentials `{}`: {error}",
+                path.display()
+            ))
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(Error::Io(error)),
+    }
+}
+
+pub(crate) fn store_account_credentials(
+    settings: &AcmeSettings,
+    persisted: &PersistedAccountCredentials,
+) -> Result<()> {
+    let path = account_credentials_path(settings);
+    let bytes = serde_json::to_vec_pretty(persisted)
+        .map_err(|error| Error::Server(format!("failed to serialize ACME account: {error}")))?;
+    atomic_write(&path, &bytes, PRIVATE_KEY_FILE_MODE)
+}
+
+pub(crate) fn write_certificate_pair(
+    spec: &ManagedCertificateSpec,
+    certificate_chain_pem: &str,
+    private_key_pem: &str,
+) -> Result<()> {
+    atomic_write(&spec.cert_path, certificate_chain_pem.as_bytes(), CERT_FILE_MODE)?;
+    atomic_write(&spec.key_path, private_key_pem.as_bytes(), PRIVATE_KEY_FILE_MODE)
+}
+
+fn account_credentials_path(settings: &AcmeSettings) -> PathBuf {
+    settings.state_dir.join("account.json")
+}
+
+fn atomic_write(path: &Path, contents: &[u8], mode: u32) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+
+    let temp_path = temporary_path(path);
+    let write_result = (|| -> Result<()> {
+        let mut file = create_temp_file(&temp_path, mode)?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temp_path, path)?;
+        sync_directory(parent)?;
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    write_result
+}
+
+fn create_temp_file(path: &Path, mode: u32) -> Result<File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        return OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(mode)
+            .open(path)
+            .map_err(Error::from);
+    }
+
+    #[allow(unreachable_code)]
+    OpenOptions::new().create_new(true).write(true).open(path).map_err(Error::from)
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let timestamp_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let file_name = path.file_name().and_then(|value| value.to_str()).unwrap_or("acme-material");
+    path.with_file_name(format!("{file_name}.tmp-{timestamp_nanos}-{sequence}"))
+}
+
+fn sync_directory(path: &Path) -> Result<()> {
+    File::open(path)?.sync_all()?;
+    Ok(())
+}

--- a/crates/rginx-runtime/src/acme/tests.rs
+++ b/crates/rginx-runtime/src/acme/tests.rs
@@ -1,0 +1,179 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use rginx_core::{
+    AcmeChallengeType, AcmeSettings, ConfigSnapshot, Listener, ManagedCertificateSpec,
+    RuntimeSettings, Server, VirtualHost,
+};
+use rginx_http::TlsCertificateStatusSnapshot;
+
+use super::storage::write_certificate_pair;
+use super::types::{http01_listener_addrs, plan_reconcile};
+
+fn test_config(listeners: Vec<Listener>) -> ConfigSnapshot {
+    ConfigSnapshot {
+        runtime: RuntimeSettings {
+            shutdown_timeout: Duration::from_secs(1),
+            worker_threads: None,
+            accept_workers: 1,
+        },
+        acme: Some(AcmeSettings {
+            directory_url: "https://acme-staging-v02.api.letsencrypt.org/directory".to_string(),
+            contacts: Vec::new(),
+            state_dir: PathBuf::from("/tmp/rginx-acme-tests"),
+            renew_before: Duration::from_secs(30 * 86_400),
+            poll_interval: Duration::from_secs(3600),
+        }),
+        managed_certificates: Vec::new(),
+        listeners,
+        default_vhost: VirtualHost {
+            id: "server".to_string(),
+            server_names: Vec::new(),
+            routes: Vec::new(),
+            tls: None,
+        },
+        vhosts: Vec::new(),
+        cache_zones: HashMap::new(),
+        upstreams: HashMap::new(),
+    }
+}
+
+fn test_listener(listen_addr: &str, tls_enabled: bool) -> Listener {
+    Listener {
+        id: listen_addr.to_string(),
+        name: listen_addr.to_string(),
+        server: Server {
+            listen_addr: listen_addr.parse().unwrap(),
+            server_header: rginx_core::default_server_header(),
+            default_certificate: None,
+            trusted_proxies: Vec::new(),
+            client_ip_header: None,
+            keep_alive: true,
+            max_headers: None,
+            max_request_body_bytes: None,
+            max_connections: None,
+            header_read_timeout: None,
+            request_body_read_timeout: None,
+            response_write_timeout: None,
+            access_log_format: None,
+            tls: None,
+        },
+        tls_termination_enabled: tls_enabled,
+        proxy_protocol_enabled: false,
+        http3: None,
+    }
+}
+
+fn managed_spec() -> ManagedCertificateSpec {
+    ManagedCertificateSpec {
+        scope: "servers[0]".to_string(),
+        domains: vec!["api.example.com".to_string(), "www.example.com".to_string()],
+        cert_path: PathBuf::from("/tmp/api.example.com.crt"),
+        key_path: PathBuf::from("/tmp/api.example.com.key"),
+        challenge: AcmeChallengeType::Http01,
+    }
+}
+
+#[test]
+fn http01_listener_addrs_only_returns_plain_http_port_80_bindings() {
+    let config = test_config(vec![
+        test_listener("127.0.0.1:80", false),
+        test_listener("127.0.0.1:443", true),
+        test_listener("127.0.0.1:8080", false),
+    ]);
+
+    assert_eq!(http01_listener_addrs(&config), vec!["127.0.0.1:80".parse().unwrap()]);
+}
+
+#[test]
+fn plan_reconcile_detects_san_mismatch() {
+    let settings = test_config(Vec::new()).acme.unwrap();
+    let spec = managed_spec();
+    let status = TlsCertificateStatusSnapshot {
+        scope: spec.scope.clone(),
+        cert_path: spec.cert_path.clone(),
+        server_names: spec.domains.clone(),
+        subject: None,
+        issuer: None,
+        serial_number: None,
+        san_dns_names: vec!["api.example.com".to_string()],
+        fingerprint_sha256: Some("fingerprint".to_string()),
+        subject_key_identifier: None,
+        authority_key_identifier: None,
+        is_ca: Some(false),
+        path_len_constraint: None,
+        key_usage: None,
+        extended_key_usage: Vec::new(),
+        not_before_unix_ms: None,
+        not_after_unix_ms: None,
+        expires_in_days: Some(45),
+        chain_length: 1,
+        chain_subjects: Vec::new(),
+        chain_diagnostics: Vec::new(),
+        selected_as_default_for_listeners: Vec::new(),
+        ocsp_staple_configured: false,
+        additional_certificate_count: 0,
+    };
+
+    let plan = plan_reconcile(&spec, Some(&status), &settings)
+        .expect("SAN mismatch should trigger reconcile");
+    assert!(plan.describe().contains("SAN mismatch"));
+}
+
+#[test]
+fn plan_reconcile_skips_healthy_certificate() {
+    let settings = test_config(Vec::new()).acme.unwrap();
+    let spec = managed_spec();
+    let status = TlsCertificateStatusSnapshot {
+        scope: spec.scope.clone(),
+        cert_path: spec.cert_path.clone(),
+        server_names: spec.domains.clone(),
+        subject: None,
+        issuer: None,
+        serial_number: None,
+        san_dns_names: spec.domains.clone(),
+        fingerprint_sha256: Some("fingerprint".to_string()),
+        subject_key_identifier: None,
+        authority_key_identifier: None,
+        is_ca: Some(false),
+        path_len_constraint: None,
+        key_usage: None,
+        extended_key_usage: Vec::new(),
+        not_before_unix_ms: None,
+        not_after_unix_ms: None,
+        expires_in_days: Some(90),
+        chain_length: 1,
+        chain_subjects: Vec::new(),
+        chain_diagnostics: Vec::new(),
+        selected_as_default_for_listeners: Vec::new(),
+        ocsp_staple_configured: false,
+        additional_certificate_count: 0,
+    };
+
+    assert!(plan_reconcile(&spec, Some(&status), &settings).is_none());
+}
+
+#[test]
+fn write_certificate_pair_persists_both_outputs() {
+    let temp_dir = tempfile::tempdir().expect("tempdir should build");
+    let spec = ManagedCertificateSpec {
+        scope: "servers[0]".to_string(),
+        domains: vec!["api.example.com".to_string()],
+        cert_path: temp_dir.path().join("issued.crt"),
+        key_path: temp_dir.path().join("issued.key"),
+        challenge: AcmeChallengeType::Http01,
+    };
+
+    write_certificate_pair(&spec, "certificate-chain", "private-key")
+        .expect("certificate material should write");
+
+    assert_eq!(
+        std::fs::read_to_string(&spec.cert_path).expect("certificate should read"),
+        "certificate-chain"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&spec.key_path).expect("private key should read"),
+        "private-key"
+    );
+}

--- a/crates/rginx-runtime/src/acme/tests.rs
+++ b/crates/rginx-runtime/src/acme/tests.rs
@@ -1,7 +1,12 @@
 use std::collections::HashMap;
+use std::fs;
+use std::io::{Error as IoError, ErrorKind};
+use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use super::challenge::is_transient_accept_error;
+use super::storage::parent_directory;
 use rginx_core::{
     AcmeChallengeType, AcmeSettings, ConfigSnapshot, Listener, ManagedCertificateSpec,
     RuntimeSettings, Server, VirtualHost,
@@ -87,9 +92,31 @@ fn http01_listener_addrs_only_returns_plain_http_port_80_bindings() {
 }
 
 #[test]
+fn transient_accept_errors_are_retried() {
+    assert!(is_transient_accept_error(&IoError::from(ErrorKind::ConnectionAborted)));
+    assert!(is_transient_accept_error(&IoError::from(ErrorKind::OutOfMemory)));
+}
+
+#[test]
+fn permanent_accept_errors_stop_the_listener() {
+    assert!(!is_transient_accept_error(&IoError::from(ErrorKind::AddrInUse)));
+}
+
+#[test]
+fn bare_relative_paths_use_current_directory_as_parent() {
+    assert_eq!(parent_directory(Path::new("issued.crt")), Path::new("."));
+}
+
+#[test]
 fn plan_reconcile_detects_san_mismatch() {
     let settings = test_config(Vec::new()).acme.unwrap();
-    let spec = managed_spec();
+    let temp_dir = tempfile::tempdir().expect("tempdir should build");
+    let spec = ManagedCertificateSpec {
+        cert_path: temp_dir.path().join("issued.crt"),
+        key_path: temp_dir.path().join("issued.key"),
+        ..managed_spec()
+    };
+    fs::write(&spec.key_path, b"private-key").expect("private key should be written");
     let status = TlsCertificateStatusSnapshot {
         scope: spec.scope.clone(),
         cert_path: spec.cert_path.clone(),
@@ -124,7 +151,13 @@ fn plan_reconcile_detects_san_mismatch() {
 #[test]
 fn plan_reconcile_skips_healthy_certificate() {
     let settings = test_config(Vec::new()).acme.unwrap();
-    let spec = managed_spec();
+    let temp_dir = tempfile::tempdir().expect("tempdir should build");
+    let spec = ManagedCertificateSpec {
+        cert_path: temp_dir.path().join("issued.crt"),
+        key_path: temp_dir.path().join("issued.key"),
+        ..managed_spec()
+    };
+    fs::write(&spec.key_path, b"private-key").expect("private key should be written");
     let status = TlsCertificateStatusSnapshot {
         scope: spec.scope.clone(),
         cert_path: spec.cert_path.clone(),
@@ -155,6 +188,47 @@ fn plan_reconcile_skips_healthy_certificate() {
 }
 
 #[test]
+fn plan_reconcile_detects_missing_private_key() {
+    let settings = test_config(Vec::new()).acme.unwrap();
+    let temp_dir = tempfile::tempdir().expect("tempdir should build");
+    let spec = ManagedCertificateSpec {
+        cert_path: temp_dir.path().join("issued.crt"),
+        key_path: temp_dir.path().join("issued.key"),
+        ..managed_spec()
+    };
+    fs::write(&spec.cert_path, b"certificate-chain").expect("certificate should be written");
+    let status = TlsCertificateStatusSnapshot {
+        scope: spec.scope.clone(),
+        cert_path: spec.cert_path.clone(),
+        server_names: spec.domains.clone(),
+        subject: None,
+        issuer: None,
+        serial_number: None,
+        san_dns_names: spec.domains.clone(),
+        fingerprint_sha256: Some("fingerprint".to_string()),
+        subject_key_identifier: None,
+        authority_key_identifier: None,
+        is_ca: Some(false),
+        path_len_constraint: None,
+        key_usage: None,
+        extended_key_usage: Vec::new(),
+        not_before_unix_ms: None,
+        not_after_unix_ms: None,
+        expires_in_days: Some(90),
+        chain_length: 1,
+        chain_subjects: Vec::new(),
+        chain_diagnostics: Vec::new(),
+        selected_as_default_for_listeners: Vec::new(),
+        ocsp_staple_configured: false,
+        additional_certificate_count: 0,
+    };
+
+    let plan = plan_reconcile(&spec, Some(&status), &settings)
+        .expect("missing private key should trigger reconcile");
+    assert!(plan.describe().contains("private key file is missing"));
+}
+
+#[test]
 fn write_certificate_pair_persists_both_outputs() {
     let temp_dir = tempfile::tempdir().expect("tempdir should build");
     let spec = ManagedCertificateSpec {
@@ -176,4 +250,34 @@ fn write_certificate_pair_persists_both_outputs() {
         std::fs::read_to_string(&spec.key_path).expect("private key should read"),
         "private-key"
     );
+}
+
+#[test]
+fn write_certificate_pair_rolls_back_certificate_when_key_write_fails() {
+    let temp_dir = tempfile::tempdir().expect("tempdir should build");
+    let blocked_parent = temp_dir.path().join("blocked-parent");
+    fs::write(&blocked_parent, b"not-a-directory").expect("blocking file should be written");
+
+    let spec = ManagedCertificateSpec {
+        scope: "servers[0]".to_string(),
+        domains: vec!["api.example.com".to_string()],
+        cert_path: temp_dir.path().join("issued.crt"),
+        key_path: blocked_parent.join("issued.key"),
+        challenge: AcmeChallengeType::Http01,
+    };
+    fs::write(&spec.cert_path, b"old-certificate").expect("existing certificate should be written");
+
+    let error = write_certificate_pair(&spec, "new-certificate", "private-key")
+        .expect_err("key write should fail");
+
+    assert!(
+        error.to_string().contains("Not a directory")
+            || error.to_string().contains("not a directory")
+            || error.to_string().contains("File exists")
+    );
+    assert_eq!(
+        fs::read_to_string(&spec.cert_path).expect("certificate should read"),
+        "old-certificate"
+    );
+    assert!(!spec.key_path.exists());
 }

--- a/crates/rginx-runtime/src/acme/types.rs
+++ b/crates/rginx-runtime/src/acme/types.rs
@@ -37,6 +37,7 @@ impl IssueSummary {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ReconcileReason {
     MissingCertificate,
+    MissingPrivateKey,
     MissingCertificateMetadata,
     SanMismatch { expected: Vec<String>, actual: Vec<String> },
     Expiring { remaining_days: i64, renew_before_days: i64 },
@@ -51,6 +52,7 @@ impl ReconcilePlan {
     pub(crate) fn describe(&self) -> String {
         match &self.reason {
             ReconcileReason::MissingCertificate => "certificate file is missing".to_string(),
+            ReconcileReason::MissingPrivateKey => "private key file is missing".to_string(),
             ReconcileReason::MissingCertificateMetadata => {
                 "certificate metadata could not be inspected".to_string()
             }
@@ -96,6 +98,10 @@ pub(crate) fn plan_reconcile(
         Some(status) => status,
         None => return Some(ReconcilePlan { reason: ReconcileReason::MissingCertificate }),
     };
+
+    if !spec.key_path.is_file() {
+        return Some(ReconcilePlan { reason: ReconcileReason::MissingPrivateKey });
+    }
 
     if status.fingerprint_sha256.is_none() {
         return Some(ReconcilePlan {

--- a/crates/rginx-runtime/src/acme/types.rs
+++ b/crates/rginx-runtime/src/acme/types.rs
@@ -1,0 +1,143 @@
+use std::collections::{BTreeSet, HashMap};
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use instant_acme::RetryPolicy;
+use rginx_core::{AcmeSettings, ConfigSnapshot, ManagedCertificateSpec};
+use rginx_http::{TlsCertificateStatusSnapshot, tls_runtime_snapshot_for_config};
+
+const DAY_SECS: u64 = 86_400;
+const ACME_ORDER_POLL_TIMEOUT: Duration = Duration::from_secs(180);
+const ACME_ORDER_POLL_INITIAL_DELAY: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CertificateFailure {
+    pub scope: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueSummary {
+    pub total: usize,
+    pub issued: usize,
+    pub skipped: usize,
+    pub failures: Vec<CertificateFailure>,
+}
+
+impl IssueSummary {
+    pub(crate) fn new(total: usize) -> Self {
+        Self { total, issued: 0, skipped: 0, failures: Vec::new() }
+    }
+
+    pub fn is_success(&self) -> bool {
+        self.failures.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReconcileReason {
+    MissingCertificate,
+    MissingCertificateMetadata,
+    SanMismatch { expected: Vec<String>, actual: Vec<String> },
+    Expiring { remaining_days: i64, renew_before_days: i64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReconcilePlan {
+    pub(crate) reason: ReconcileReason,
+}
+
+impl ReconcilePlan {
+    pub(crate) fn describe(&self) -> String {
+        match &self.reason {
+            ReconcileReason::MissingCertificate => "certificate file is missing".to_string(),
+            ReconcileReason::MissingCertificateMetadata => {
+                "certificate metadata could not be inspected".to_string()
+            }
+            ReconcileReason::SanMismatch { expected, actual } => {
+                format!("certificate SAN mismatch expected={expected:?} actual={actual:?}")
+            }
+            ReconcileReason::Expiring { remaining_days, renew_before_days } => {
+                format!(
+                    "certificate expires in {remaining_days}d (renew_before={renew_before_days}d)"
+                )
+            }
+        }
+    }
+}
+
+pub(crate) fn certificate_status_index(
+    config: &ConfigSnapshot,
+) -> HashMap<String, TlsCertificateStatusSnapshot> {
+    tls_runtime_snapshot_for_config(config)
+        .certificates
+        .into_iter()
+        .map(|status| (status.scope.clone(), status))
+        .collect()
+}
+
+pub(crate) fn http01_listener_addrs(config: &ConfigSnapshot) -> Vec<SocketAddr> {
+    config
+        .listeners
+        .iter()
+        .filter(|listener| !listener.tls_enabled() && listener.server.listen_addr.port() == 80)
+        .map(|listener| listener.server.listen_addr)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+pub(crate) fn plan_reconcile(
+    spec: &ManagedCertificateSpec,
+    status: Option<&TlsCertificateStatusSnapshot>,
+    settings: &AcmeSettings,
+) -> Option<ReconcilePlan> {
+    let status = match status {
+        Some(status) => status,
+        None => return Some(ReconcilePlan { reason: ReconcileReason::MissingCertificate }),
+    };
+
+    if status.fingerprint_sha256.is_none() {
+        return Some(ReconcilePlan {
+            reason: if status.cert_path.is_file() {
+                ReconcileReason::MissingCertificateMetadata
+            } else {
+                ReconcileReason::MissingCertificate
+            },
+        });
+    }
+
+    let expected = normalized_domains(&spec.domains);
+    let actual = normalized_domains(&status.san_dns_names);
+    if expected != actual {
+        return Some(ReconcilePlan { reason: ReconcileReason::SanMismatch { expected, actual } });
+    }
+
+    let renew_before_days = renew_before_days(settings);
+    match status.expires_in_days {
+        Some(remaining_days) if remaining_days > renew_before_days => None,
+        Some(remaining_days) => Some(ReconcilePlan {
+            reason: ReconcileReason::Expiring { remaining_days, renew_before_days },
+        }),
+        None => Some(ReconcilePlan { reason: ReconcileReason::MissingCertificateMetadata }),
+    }
+}
+
+pub(crate) fn acme_poll_retry_policy() -> RetryPolicy {
+    RetryPolicy::new().initial_delay(ACME_ORDER_POLL_INITIAL_DELAY).timeout(ACME_ORDER_POLL_TIMEOUT)
+}
+
+fn renew_before_days(settings: &AcmeSettings) -> i64 {
+    let secs = settings.renew_before.as_secs();
+    secs.div_ceil(DAY_SECS) as i64
+}
+
+fn normalized_domains(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}

--- a/crates/rginx-runtime/src/bootstrap/mod.rs
+++ b/crates/rginx-runtime/src/bootstrap/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use rginx_core::{ConfigSnapshot, Result};
 use tokio::sync::{Notify, watch};
 
+use crate::acme;
 use crate::admin;
 use crate::cache;
 use crate::health;
@@ -54,6 +55,7 @@ pub async fn run(config_path: PathBuf, config: ConfigSnapshot) -> Result<()> {
         Some(tokio::spawn(cache::run(state.http.clone(), shutdown_tx.subscribe())));
     let mut health_task =
         Some(tokio::spawn(health::run(state.http.clone(), shutdown_tx.subscribe())));
+    let mut acme_task = Some(tokio::spawn(acme::run(state.http.clone(), shutdown_tx.subscribe())));
     let mut ocsp_task = Some(tokio::spawn(ocsp::run(state.http.clone(), shutdown_tx.subscribe())));
     crate::restart::notify_ready_if_requested()?;
 
@@ -109,6 +111,7 @@ pub async fn run(config_path: PathBuf, config: ConfigSnapshot) -> Result<()> {
             admin_task: &mut admin_task,
             cache_task: &mut cache_task,
             health_task: &mut health_task,
+            acme_task: &mut acme_task,
             ocsp_task: &mut ocsp_task,
         },
     )

--- a/crates/rginx-runtime/src/bootstrap/shutdown.rs
+++ b/crates/rginx-runtime/src/bootstrap/shutdown.rs
@@ -15,6 +15,7 @@ pub(super) struct ShutdownTasks<'a> {
     pub(super) admin_task: &'a mut Option<JoinHandle<std::io::Result<()>>>,
     pub(super) cache_task: &'a mut Option<JoinHandle<()>>,
     pub(super) health_task: &'a mut Option<JoinHandle<()>>,
+    pub(super) acme_task: &'a mut Option<JoinHandle<()>>,
     pub(super) ocsp_task: &'a mut Option<JoinHandle<()>>,
 }
 
@@ -26,7 +27,7 @@ pub(super) async fn graceful_shutdown(
     draining_listener_groups: &mut Vec<ListenerWorkerGroup>,
     tasks: ShutdownTasks<'_>,
 ) -> Result<()> {
-    let ShutdownTasks { admin_task, cache_task, health_task, ocsp_task } = tasks;
+    let ShutdownTasks { admin_task, cache_task, health_task, acme_task, ocsp_task } = tasks;
     let _ = shutdown_tx.send(true);
     initiate_shutdown_for_groups(active_listener_groups.values());
     initiate_shutdown_for_groups(draining_listener_groups.iter());
@@ -37,6 +38,7 @@ pub(super) async fn graceful_shutdown(
         join_admin_task(admin_task).await?;
         join_unit_task(cache_task, "cache cleanup").await?;
         join_unit_task(health_task, "active health").await?;
+        join_unit_task(acme_task, "managed ACME").await?;
         join_unit_task(ocsp_task, "OCSP refresh").await?;
         state.http.drain_background_tasks().await;
         Ok::<(), Error>(())
@@ -53,6 +55,7 @@ pub(super) async fn graceful_shutdown(
             abort_task(admin_task.as_ref());
             abort_task(cache_task.as_ref());
             abort_task(health_task.as_ref());
+            abort_task(acme_task.as_ref());
             abort_task(ocsp_task.as_ref());
 
             join_aborted_listener_worker_groups(
@@ -65,6 +68,7 @@ pub(super) async fn graceful_shutdown(
             join_admin_task_after_abort(admin_task).await;
             join_unit_task_after_abort(cache_task, "cache cleanup").await;
             join_unit_task_after_abort(health_task, "active health").await;
+            join_unit_task_after_abort(acme_task, "managed ACME").await;
             join_unit_task_after_abort(ocsp_task, "OCSP refresh").await;
 
             state.http.abort_background_tasks().await;

--- a/crates/rginx-runtime/src/bootstrap/shutdown/tests.rs
+++ b/crates/rginx-runtime/src/bootstrap/shutdown/tests.rs
@@ -94,6 +94,7 @@ async fn graceful_shutdown_waits_for_background_tasks_and_signals_shutdown() {
     let mut admin_task = Some(tokio::spawn(async { Ok::<(), std::io::Error>(()) }));
     let mut cache_task = Some(tokio::spawn(async {}));
     let mut health_task = Some(tokio::spawn(async {}));
+    let mut acme_task = Some(tokio::spawn(async {}));
     let mut ocsp_task = Some(tokio::spawn(async {}));
 
     graceful_shutdown(
@@ -106,6 +107,7 @@ async fn graceful_shutdown_waits_for_background_tasks_and_signals_shutdown() {
             admin_task: &mut admin_task,
             cache_task: &mut cache_task,
             health_task: &mut health_task,
+            acme_task: &mut acme_task,
             ocsp_task: &mut ocsp_task,
         },
     )
@@ -117,6 +119,7 @@ async fn graceful_shutdown_waits_for_background_tasks_and_signals_shutdown() {
     assert!(admin_task.is_none());
     assert!(cache_task.is_none());
     assert!(health_task.is_none());
+    assert!(acme_task.is_none());
     assert!(ocsp_task.is_none());
     assert!(active_listener_groups.is_empty());
     assert!(draining_listener_groups.is_empty());
@@ -139,6 +142,7 @@ async fn graceful_shutdown_aborts_pending_tasks_after_timeout() {
     let mut admin_task = Some(tokio::spawn(async { pending::<std::io::Result<()>>().await }));
     let mut cache_task = Some(tokio::spawn(async { pending::<()>().await }));
     let mut health_task = Some(tokio::spawn(async { pending::<()>().await }));
+    let mut acme_task = Some(tokio::spawn(async { pending::<()>().await }));
     let mut ocsp_task = Some(tokio::spawn(async { pending::<()>().await }));
 
     tokio::task::yield_now().await;
@@ -152,6 +156,7 @@ async fn graceful_shutdown_aborts_pending_tasks_after_timeout() {
             admin_task: &mut admin_task,
             cache_task: &mut cache_task,
             health_task: &mut health_task,
+            acme_task: &mut acme_task,
             ocsp_task: &mut ocsp_task,
         },
     )
@@ -163,6 +168,7 @@ async fn graceful_shutdown_aborts_pending_tasks_after_timeout() {
     assert!(admin_task.is_none());
     assert!(cache_task.is_none());
     assert!(health_task.is_none());
+    assert!(acme_task.is_none());
     assert!(ocsp_task.is_none());
     assert!(active_listener_groups.is_empty());
     assert!(draining_listener_groups.is_empty());

--- a/crates/rginx-runtime/src/lib.rs
+++ b/crates/rginx-runtime/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod acme;
 pub mod admin;
 pub mod bootstrap;
 mod cache;


### PR DESCRIPTION
## Summary
- add an `instant-acme` based runtime module for account persistence, order processing, HTTP-01 challenge handling, and atomic certificate/key writes
- add `rginx acme issue --once` for cold-start certificate issuance and allow managed TLS identities to compile before the first issuance
- add runtime reconcile/renewal wiring with HTTP-01 challenge short-circuiting and TCP TLS acceptor refresh after managed certificate updates

## Verification
- cargo test --workspace
- python3 ./scripts/run-modularization-gate.py
- ./scripts/run-clippy-gate.sh
