### PR TITLE
Complete ACME phase 5-7 support

### DIFF
--- a/ACME_SUPPORT_PLAN.md
+++ b/ACME_SUPPORT_PLAN.md
@@ -274,7 +274,7 @@
 实现方向：
 
 - 短期策略二选一：
-  - 限制 ACME 托管 listener 暂不启用 `http3`
+  - V1 采用：限制 ACME 托管 listener 暂不启用 `http3`
   - 或者补一条 HTTP/3 endpoint 的 server config 更新路径
 - ACME 成功后补一次 OCSP refresh，避免新证书刚切换时 staple 缺失
 

--- a/crates/rginx-app/src/admin_cli/status.rs
+++ b/crates/rginx-app/src/admin_cli/status.rs
@@ -2,6 +2,7 @@ use super::cache::print_status_cache;
 use super::socket::{query_admin_socket, unexpected_admin_response};
 use super::*;
 
+mod acme;
 mod listeners;
 mod runtime;
 mod tls;
@@ -12,6 +13,7 @@ pub(super) fn print_admin_status(config_path: &Path) -> anyhow::Result<()> {
         AdminResponse::Status(status) => {
             runtime::print_status_summary(&status);
             listeners::print_status_listeners(&status.listeners);
+            acme::print_status_acme(&status.acme);
             tls::print_status_tls(&status.tls);
             upstream_tls::print_status_upstream_tls(&status.upstream_tls);
             print_status_cache(&status.cache);

--- a/crates/rginx-app/src/admin_cli/status/acme.rs
+++ b/crates/rginx-app/src/admin_cli/status/acme.rs
@@ -1,0 +1,70 @@
+use crate::admin_cli::render::print_record;
+
+pub(super) fn print_status_acme(acme: &rginx_http::AcmeRuntimeSnapshot) {
+    let active_retry_count = acme
+        .managed_certificates
+        .iter()
+        .filter(|certificate| certificate.retry_after_unix_ms.is_some())
+        .count();
+    let last_error_count = acme
+        .managed_certificates
+        .iter()
+        .filter(|certificate| certificate.last_error.is_some())
+        .count();
+
+    print_record(
+        "status_acme",
+        [
+            ("enabled", acme.enabled.to_string()),
+            ("directory_url", acme.directory_url.clone().unwrap_or_else(|| "-".to_string())),
+            ("managed_certificates", acme.managed_certificates.len().to_string()),
+            ("retry_pending", active_retry_count.to_string()),
+            ("last_errors", last_error_count.to_string()),
+        ],
+    );
+
+    for certificate in &acme.managed_certificates {
+        print_record(
+            "status_acme_certificate",
+            [
+                ("scope", certificate.scope.clone()),
+                (
+                    "domains",
+                    if certificate.domains.is_empty() {
+                        "-".to_string()
+                    } else {
+                        certificate.domains.join(",")
+                    },
+                ),
+                ("managed", certificate.managed.to_string()),
+                ("challenge_type", certificate.challenge_type.clone()),
+                ("cert_path", certificate.cert_path.display().to_string()),
+                ("key_path", certificate.key_path.display().to_string()),
+                (
+                    "last_success_unix_ms",
+                    certificate
+                        .last_success_unix_ms
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                ),
+                (
+                    "next_renewal_unix_ms",
+                    certificate
+                        .next_renewal_unix_ms
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                ),
+                ("refreshes_total", certificate.refreshes_total.to_string()),
+                ("failures_total", certificate.failures_total.to_string()),
+                (
+                    "retry_after_unix_ms",
+                    certificate
+                        .retry_after_unix_ms
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                ),
+                ("last_error", certificate.last_error.clone().unwrap_or_else(|| "-".to_string())),
+            ],
+        );
+    }
+}

--- a/crates/rginx-app/src/admin_cli/status/runtime.rs
+++ b/crates/rginx-app/src/admin_cli/status/runtime.rs
@@ -108,6 +108,28 @@ pub(super) fn print_status_summary(status: &rginx_http::RuntimeStatusSnapshot) {
                 "http3_early_data_rejected_requests",
                 status.http3_early_data_rejected_requests.to_string(),
             ),
+            ("acme", if status.acme.enabled { "enabled" } else { "disabled" }.to_string()),
+            ("acme_managed_certificates", status.acme.managed_certificates.len().to_string()),
+            (
+                "acme_last_errors",
+                status
+                    .acme
+                    .managed_certificates
+                    .iter()
+                    .filter(|certificate| certificate.last_error.is_some())
+                    .count()
+                    .to_string(),
+            ),
+            (
+                "acme_retry_pending",
+                status
+                    .acme
+                    .managed_certificates
+                    .iter()
+                    .filter(|certificate| certificate.retry_after_unix_ms.is_some())
+                    .count()
+                    .to_string(),
+            ),
             ("tls_listeners", status.tls.listeners.len().to_string()),
             ("tls_certificates", status.tls.certificates.len().to_string()),
             ("tls_ocsp_entries", status.tls.ocsp.len().to_string()),

--- a/crates/rginx-app/src/check.rs
+++ b/crates/rginx-app/src/check.rs
@@ -1,3 +1,4 @@
+mod acme;
 mod render;
 mod routes;
 mod summary;

--- a/crates/rginx-app/src/check/acme.rs
+++ b/crates/rginx-app/src/check/acme.rs
@@ -1,0 +1,74 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use super::tls::TlsCheckDetails;
+
+pub(super) struct AcmeCheckDetails {
+    pub(super) enabled: bool,
+    pub(super) directory_url: Option<String>,
+    pub(super) state_dir: Option<PathBuf>,
+    pub(super) renew_before_days: Option<u64>,
+    pub(super) poll_interval_secs: Option<u64>,
+    pub(super) managed_certificates: Vec<AcmeManagedCertificateCheck>,
+}
+
+pub(super) struct AcmeManagedCertificateCheck {
+    pub(super) scope: String,
+    pub(super) domains: Vec<String>,
+    pub(super) managed: bool,
+    pub(super) challenge_type: String,
+    pub(super) cert_path: PathBuf,
+    pub(super) key_path: PathBuf,
+    pub(super) next_renewal_unix_ms: Option<u64>,
+}
+
+pub(super) fn acme_check_details(
+    config: &rginx_config::ConfigSnapshot,
+    tls: &TlsCheckDetails,
+) -> AcmeCheckDetails {
+    let certificate_statuses = tls
+        .certificates
+        .iter()
+        .flat_map(|status| {
+            let mut entries = vec![(status.scope.as_str(), status)];
+            if let Some(scope) = status.scope.strip_prefix("vhost:") {
+                entries.push((scope, status));
+            }
+            entries
+        })
+        .collect::<HashMap<_, _>>();
+
+    AcmeCheckDetails {
+        enabled: config.acme.is_some(),
+        directory_url: config.acme.as_ref().map(|settings| settings.directory_url.clone()),
+        state_dir: config.acme.as_ref().map(|settings| settings.state_dir.clone()),
+        renew_before_days: config
+            .acme
+            .as_ref()
+            .map(|settings| settings.renew_before.as_secs().div_ceil(86_400)),
+        poll_interval_secs: config.acme.as_ref().map(|settings| settings.poll_interval.as_secs()),
+        managed_certificates: config
+            .managed_certificates
+            .iter()
+            .map(|spec| AcmeManagedCertificateCheck {
+                scope: spec.scope.clone(),
+                domains: spec.domains.clone(),
+                managed: true,
+                challenge_type: spec.challenge.as_str().to_string(),
+                cert_path: spec.cert_path.clone(),
+                key_path: spec.key_path.clone(),
+                next_renewal_unix_ms: certificate_statuses
+                    .get(spec.scope.as_str())
+                    .and_then(|status| status.not_after_unix_ms)
+                    .and_then(|not_after_unix_ms| {
+                        config.acme.as_ref().map(|settings| {
+                            not_after_unix_ms.saturating_sub(
+                                u64::try_from(settings.renew_before.as_millis())
+                                    .unwrap_or(u64::MAX),
+                            )
+                        })
+                    }),
+            })
+            .collect(),
+    }
+}

--- a/crates/rginx-app/src/check/render.rs
+++ b/crates/rginx-app/src/check/render.rs
@@ -1,15 +1,18 @@
+mod acme;
 mod listeners;
 mod tls;
 
 use std::path::Path;
 
 use super::summary::CheckSummary;
+use acme::print_acme_details;
 
 pub(crate) fn print_check_success(config_path: &Path, summary: CheckSummary) {
     print_configuration_summary(config_path, &summary);
     listeners::print_listener_details(&summary);
     print_route_transport_details(&summary);
     print_cache_zone_details(&summary);
+    print_acme_details(&summary);
     tls::print_tls_details(&summary);
 }
 

--- a/crates/rginx-app/src/check/render/acme.rs
+++ b/crates/rginx-app/src/check/render/acme.rs
@@ -1,0 +1,43 @@
+use super::super::summary::CheckSummary;
+use super::render_string_list;
+
+pub(super) fn print_acme_details(summary: &CheckSummary) {
+    println!(
+        "acme_details=enabled={} directory_url={} state_dir={} renew_before_days={} poll_interval_secs={} managed_certificates={}",
+        summary.acme.enabled,
+        summary.acme.directory_url.as_deref().unwrap_or("-"),
+        summary
+            .acme
+            .state_dir
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        summary
+            .acme
+            .renew_before_days
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        summary
+            .acme
+            .poll_interval_secs
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        summary.acme.managed_certificates.len(),
+    );
+
+    for certificate in &summary.acme.managed_certificates {
+        println!(
+            "acme_certificate scope={} managed={} domains={} challenge_type={} cert_path={} key_path={} next_renewal_unix_ms={}",
+            certificate.scope,
+            certificate.managed,
+            render_string_list(&certificate.domains),
+            certificate.challenge_type,
+            certificate.cert_path.display(),
+            certificate.key_path.display(),
+            certificate
+                .next_renewal_unix_ms
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+        );
+    }
+}

--- a/crates/rginx-app/src/check/summary.rs
+++ b/crates/rginx-app/src/check/summary.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use super::acme::{AcmeCheckDetails, acme_check_details};
 use super::routes::{RouteTransportCheckDetails, route_transport_check_details};
 use super::tls::{TlsCheckDetails, tls_check_details};
 
@@ -20,6 +21,7 @@ pub(crate) struct CheckSummary {
     pub(super) worker_threads: Option<usize>,
     pub(super) accept_workers: usize,
     pub(super) route_transport: RouteTransportCheckDetails,
+    pub(super) acme: AcmeCheckDetails,
     pub(super) tls: TlsCheckDetails,
 }
 
@@ -67,6 +69,8 @@ pub(super) struct CheckListenerBindingSummary {
 
 pub(crate) fn build_check_summary(config: &rginx_config::ConfigSnapshot) -> CheckSummary {
     let route_transport = route_transport_check_details(config);
+    let tls = tls_check_details(config);
+    let acme = acme_check_details(config, &tls);
 
     CheckSummary {
         listener_model: listener_model(
@@ -96,7 +100,8 @@ pub(crate) fn build_check_summary(config: &rginx_config::ConfigSnapshot) -> Chec
         worker_threads: config.runtime.worker_threads,
         accept_workers: config.runtime.accept_workers,
         route_transport,
-        tls: tls_check_details(config),
+        acme,
+        tls,
     }
 }
 

--- a/crates/rginx-app/tests/admin/commands/status.rs
+++ b/crates/rginx-app/tests/admin/commands/status.rs
@@ -28,6 +28,9 @@ fn status_command_reads_local_admin_socket() {
     assert!(stdout.contains("http3_retry_issued_total=0"));
     assert!(stdout.contains("http3_request_body_stream_errors_total=0"));
     assert!(stdout.contains("active_connections=0"));
+    assert!(stdout.contains("acme=disabled"));
+    assert!(stdout.contains("acme_managed_certificates=0"));
+    assert!(stdout.contains("kind=status_acme enabled=false"));
     assert!(stdout.contains("mtls_listeners=0"));
     assert!(stdout.contains("reload_attempts=0"));
     assert!(stdout.contains("last_reload=-"));

--- a/crates/rginx-app/tests/admin/snapshot/core.rs
+++ b/crates/rginx-app/tests/admin/snapshot/core.rs
@@ -40,12 +40,13 @@ fn snapshot_command_returns_aggregate_json_snapshot() {
     let AdminResponse::Snapshot(snapshot) = response else {
         panic!("admin socket should return aggregate snapshot");
     };
-    assert_eq!(snapshot.schema_version, 14);
+    assert_eq!(snapshot.schema_version, 15);
     assert!(snapshot.captured_at_unix_ms > 0);
     assert!(snapshot.pid > 0);
     assert_eq!(snapshot.binary_version, env!("CARGO_PKG_VERSION"));
     assert_eq!(snapshot.included_modules, rginx_http::SnapshotModule::all());
     assert_eq!(snapshot.status.as_ref().map(|status| status.listeners.len()), Some(1));
+    assert_eq!(snapshot.status.as_ref().map(|status| status.acme.enabled), Some(false));
     assert_eq!(
         snapshot
             .status
@@ -66,11 +67,12 @@ fn snapshot_command_returns_aggregate_json_snapshot() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let snapshot: serde_json::Value =
         serde_json::from_str(&stdout).expect("snapshot command should print valid JSON");
-    assert_eq!(snapshot["schema_version"], serde_json::Value::from(14));
+    assert_eq!(snapshot["schema_version"], serde_json::Value::from(15));
     assert!(snapshot["captured_at_unix_ms"].as_u64().unwrap_or(0) > 0);
     assert!(snapshot["pid"].as_u64().unwrap_or(0) > 0);
     assert_eq!(snapshot["binary_version"], serde_json::Value::from(env!("CARGO_PKG_VERSION")));
     assert_eq!(snapshot["status"]["listeners"].as_array().map(Vec::len), Some(1));
+    assert_eq!(snapshot["status"]["acme"]["enabled"], serde_json::Value::from(false));
     assert_eq!(
         snapshot["status"]["listeners"][0]["listen_addr"],
         serde_json::Value::from(listen_addr.to_string())

--- a/crates/rginx-app/tests/check.rs
+++ b/crates/rginx-app/tests/check.rs
@@ -11,6 +11,8 @@ use rcgen::{
     KeyPair,
 };
 
+#[path = "check/acme.rs"]
+mod acme;
 #[path = "check/basic.rs"]
 mod basic;
 #[path = "check/helpers.rs"]

--- a/crates/rginx-app/tests/check/acme.rs
+++ b/crates/rginx-app/tests/check/acme.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+#[test]
+fn check_reports_managed_acme_configuration() {
+    let temp_dir = temp_dir("rginx-check-acme");
+    fs::create_dir_all(&temp_dir).expect("temp test dir should be created");
+    let config_path = temp_dir.join("acme.ron");
+    let cert_path = temp_dir.join("managed.crt");
+    let key_path = temp_dir.join("managed.key");
+
+    let mut params =
+        CertificateParams::new(vec!["api.example.com".to_string()]).expect("certificate params");
+    params.distinguished_name.push(DnType::CommonName, "api.example.com");
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    let key_pair = KeyPair::generate().expect("key pair should generate");
+    let certificate = params.self_signed(&key_pair).expect("certificate should self-sign");
+    fs::write(&cert_path, certificate.pem()).expect("certificate should be written");
+    fs::write(&key_path, key_pair.serialize_pem()).expect("private key should be written");
+
+    fs::write(
+        &config_path,
+        format!(
+            "Config(\n    runtime: RuntimeConfig(\n        shutdown_timeout_secs: 2,\n    ),\n    acme: Some(AcmeConfig(\n        directory_url: \"https://acme-staging-v02.api.letsencrypt.org/directory\",\n        contacts: [\"mailto:ops@example.com\"],\n        state_dir: \"state/acme\",\n        renew_before_days: Some(21),\n        poll_interval_secs: Some(600),\n    )),\n    listeners: [\n        ListenerConfig(\n            name: \"http\",\n            listen: \"127.0.0.1:80\",\n        ),\n        ListenerConfig(\n            name: \"https\",\n            listen: \"127.0.0.1:443\",\n            tls: Some(ServerTlsConfig(\n                cert_path: {:?},\n                key_path: {:?},\n            )),\n        ),\n    ],\n    server: ServerConfig(),\n    upstreams: [],\n    locations: [\n        LocationConfig(\n            matcher: Exact(\"/\"),\n            handler: Return(\n                status: 200,\n                location: \"\",\n                body: Some(\"default\\n\"),\n            ),\n        ),\n    ],\n    servers: [\n        VirtualHostConfig(\n            server_names: [\"api.example.com\"],\n            locations: [\n                LocationConfig(\n                    matcher: Exact(\"/\"),\n                    handler: Return(\n                        status: 200,\n                        location: \"\",\n                        body: Some(\"api\\n\"),\n                    ),\n                ),\n            ],\n            tls: Some(VirtualHostTlsConfig(\n                cert_path: {:?},\n                key_path: {:?},\n                acme: Some(VirtualHostAcmeConfig(\n                    domains: [\"api.example.com\"],\n                )),\n            )),\n        ),\n    ],\n)\n",
+            cert_path.display().to_string(),
+            key_path.display().to_string(),
+            cert_path.display().to_string(),
+            key_path.display().to_string(),
+        ),
+    )
+    .expect("managed ACME config should be written");
+
+    let output = run_rginx(["check", "--config", config_path.to_str().unwrap()]);
+
+    assert!(output.status.success(), "check should succeed: {}", render_output(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("acme_details=enabled=true"));
+    assert!(
+        stdout.contains("directory_url=https://acme-staging-v02.api.letsencrypt.org/directory")
+    );
+    assert!(stdout.contains(&format!("state_dir={}", temp_dir.join("state/acme").display())));
+    assert!(stdout.contains("renew_before_days=21"));
+    assert!(stdout.contains("poll_interval_secs=600"));
+    assert!(stdout.contains("managed_certificates=1"));
+    assert!(stdout.contains("acme_certificate scope=servers[0]"));
+    assert!(stdout.contains("domains=api.example.com"));
+    assert!(stdout.contains("challenge_type=http-01"));
+}

--- a/crates/rginx-config/src/validate/acme.rs
+++ b/crates/rginx-config/src/validate/acme.rs
@@ -12,6 +12,7 @@ pub(super) fn validate_acme(config: &Config) -> Result<()> {
     }
 
     let mut any_managed_vhost = false;
+    let mut managed_vhost_indexes = Vec::new();
     for (index, vhost) in config.servers.iter().enumerate() {
         let Some(tls) = vhost.tls.as_ref() else {
             continue;
@@ -21,6 +22,7 @@ pub(super) fn validate_acme(config: &Config) -> Result<()> {
         };
 
         any_managed_vhost = true;
+        managed_vhost_indexes.push(index);
         validate_vhost_acme(&format!("servers[{index}]"), vhost, tls, acme, config.acme.as_ref())?;
     }
 
@@ -29,6 +31,8 @@ pub(super) fn validate_acme(config: &Config) -> Result<()> {
             "ACME HTTP-01 requires at least one plain HTTP listener bound to port 80".to_string(),
         ));
     }
+
+    validate_managed_acme_http3_compatibility(config, &managed_vhost_indexes)?;
 
     Ok(())
 }
@@ -175,4 +179,43 @@ fn has_http01_listener(config: &Config) -> Result<bool> {
     // listener into a TLS termination point for that bind, so it cannot satisfy HTTP-01's
     // requirement for a plain HTTP listener on port 80.
     Ok(false)
+}
+
+fn validate_managed_acme_http3_compatibility(
+    config: &Config,
+    managed_vhost_indexes: &[usize],
+) -> Result<()> {
+    if managed_vhost_indexes.is_empty() {
+        return Ok(());
+    }
+
+    let any_vhost_listen = config.servers.iter().any(|vhost| !vhost.listen.is_empty());
+    if any_vhost_listen {
+        for vhost_index in managed_vhost_indexes {
+            let vhost = &config.servers[*vhost_index];
+            for (listen_index, listen) in vhost.listen.iter().enumerate() {
+                let owner = format!("servers[{vhost_index}].listen[{listen_index}]");
+                let parsed = crate::listen::parse_vhost_listen(&owner, listen)?;
+                if parsed.ssl && parsed.http3 {
+                    return Err(Error::Config(format!(
+                        "{owner} ACME-managed TLS does not support http3 hot certificate rotation yet"
+                    )));
+                }
+            }
+        }
+        return Ok(());
+    }
+
+    if let Some((listener_index, _)) = config
+        .listeners
+        .iter()
+        .enumerate()
+        .find(|(_, listener)| listener.tls.is_some() && listener.http3.is_some())
+    {
+        return Err(Error::Config(format!(
+            "listeners[{listener_index}] enables http3, which is not supported together with ACME-managed certificates yet"
+        )));
+    }
+
+    Ok(())
 }

--- a/crates/rginx-config/src/validate/tests/acme.rs
+++ b/crates/rginx-config/src/validate/tests/acme.rs
@@ -269,6 +269,65 @@ fn validate_rejects_managed_vhost_with_legacy_server_listen_only() {
 }
 
 #[test]
+fn validate_rejects_managed_vhost_with_http3_enabled_explicit_listener() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    enable_acme_listeners(&mut config);
+    config.listeners[1].http3 = Some(crate::model::Http3Config::default());
+    config.servers = vec![managed_vhost(vec!["api.example.com"], vec!["api.example.com"])];
+
+    let error = validate(&config)
+        .expect_err("managed ACME should reject explicit listeners with http3 enabled");
+    assert!(error.to_string().contains("listeners[1] enables http3"));
+}
+
+#[test]
+fn validate_rejects_managed_vhost_with_http3_enabled_vhost_binding() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    config.server.listen = None;
+
+    let mut vhost = managed_vhost(vec!["api.example.com"], vec!["api.example.com"]);
+    vhost.listen = vec!["127.0.0.1:80".to_string(), "127.0.0.1:443 ssl http2 http3".to_string()];
+    vhost.http3 = Some(crate::model::Http3Config::default());
+    config.servers = vec![vhost];
+
+    let error = validate(&config)
+        .expect_err("managed ACME should reject vhost listeners with http3 enabled");
+    assert!(
+        error.to_string().contains("servers[0].listen[1] ACME-managed TLS does not support http3")
+    );
+}
+
+#[test]
+fn validate_accepts_managed_vhost_when_unmanaged_http3_uses_separate_binding() {
+    let mut config = base_config();
+    config.acme = Some(valid_global_acme());
+    config.server.listen = None;
+
+    let mut managed = managed_vhost(vec!["api.example.com"], vec!["api.example.com"]);
+    managed.listen = vec!["127.0.0.1:80".to_string(), "127.0.0.1:443 ssl http2".to_string()];
+
+    let mut static_http3 = sample_vhost(vec!["static.example.com"]);
+    static_http3.listen =
+        vec!["127.0.0.1:8443 ssl http2 http3".to_string(), "127.0.0.1:8080".to_string()];
+    static_http3.http3 = Some(crate::model::Http3Config::default());
+    static_http3.tls = Some(VirtualHostTlsConfig {
+        acme: None,
+        cert_path: "static.crt".to_string(),
+        key_path: "static.key".to_string(),
+        additional_certificates: None,
+        ocsp_staple_path: None,
+        ocsp: None,
+    });
+
+    config.servers = vec![managed, static_http3];
+
+    validate(&config)
+        .expect("managed ACME should allow separate unmanaged http3 bindings in vhost mode");
+}
+
+#[test]
 fn validate_accepts_phase1_managed_vhost_configuration() {
     let mut config = base_config();
     config.acme = Some(valid_global_acme());

--- a/crates/rginx-core/src/config/acme.rs
+++ b/crates/rginx-core/src/config/acme.rs
@@ -6,6 +6,14 @@ pub enum AcmeChallengeType {
     Http01,
 }
 
+impl AcmeChallengeType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Http01 => "http-01",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AcmeSettings {
     pub directory_url: String,

--- a/crates/rginx-http/src/lib.rs
+++ b/crates/rginx-http/src/lib.rs
@@ -26,16 +26,17 @@ pub use client_ip::TlsClientIdentity;
 pub use proxy::{PeerHealthSnapshot, UpstreamHealthSnapshot};
 pub use server::serve;
 pub use state::{
-    CachePurgeResult, CacheStatsSnapshot, CacheZoneRuntimeSnapshot, GrpcTrafficSnapshot,
-    HttpCountersSnapshot, ListenerStatsSnapshot, MtlsStatusSnapshot, ReloadOutcomeSnapshot,
-    ReloadResultSnapshot, ReloadStatusSnapshot, RouteStatsSnapshot, RuntimeListenerBindingSnapshot,
-    RuntimeListenerSnapshot, RuntimeStatusSnapshot, SharedState, SnapshotDeltaSnapshot,
-    SnapshotModule, TlsCertificateStatusSnapshot, TlsDefaultCertificateBindingSnapshot,
-    TlsListenerStatusSnapshot, TlsOcspRefreshSpec, TlsOcspStatusSnapshot,
-    TlsReloadBoundarySnapshot, TlsRuntimeSnapshot, TlsSniBindingSnapshot, TlsVhostBindingSnapshot,
-    TrafficStatsSnapshot, UpstreamPeerStatsSnapshot, UpstreamStatsSnapshot,
-    UpstreamTlsStatusSnapshot, VhostStatsSnapshot, tls_ocsp_refresh_specs_for_config,
-    tls_reloadable_fields, tls_restart_required_fields, tls_runtime_snapshot_for_config,
+    AcmeManagedCertificateSnapshot, AcmeRuntimeSnapshot, CachePurgeResult, CacheStatsSnapshot,
+    CacheZoneRuntimeSnapshot, GrpcTrafficSnapshot, HttpCountersSnapshot, ListenerStatsSnapshot,
+    MtlsStatusSnapshot, ReloadOutcomeSnapshot, ReloadResultSnapshot, ReloadStatusSnapshot,
+    RouteStatsSnapshot, RuntimeListenerBindingSnapshot, RuntimeListenerSnapshot,
+    RuntimeStatusSnapshot, SharedState, SnapshotDeltaSnapshot, SnapshotModule,
+    TlsCertificateStatusSnapshot, TlsDefaultCertificateBindingSnapshot, TlsListenerStatusSnapshot,
+    TlsOcspRefreshSpec, TlsOcspStatusSnapshot, TlsReloadBoundarySnapshot, TlsRuntimeSnapshot,
+    TlsSniBindingSnapshot, TlsVhostBindingSnapshot, TrafficStatsSnapshot,
+    UpstreamPeerStatsSnapshot, UpstreamStatsSnapshot, UpstreamTlsStatusSnapshot,
+    VhostStatsSnapshot, tls_ocsp_refresh_specs_for_config, tls_reloadable_fields,
+    tls_restart_required_fields, tls_runtime_snapshot_for_config,
 };
 pub use tls::{
     build_ocsp_request_for_certificate, build_ocsp_request_for_certificate_with_options,

--- a/crates/rginx-http/src/state/lifecycle/acme.rs
+++ b/crates/rginx-http/src/state/lifecycle/acme.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use std::time::{Duration, SystemTime};
 
 impl SharedState {
     pub fn register_acme_http01_challenge(
@@ -25,5 +26,46 @@ impl SharedState {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .get(token)
             .cloned()
+    }
+
+    pub fn record_acme_refresh_success(&self, scope: &str) {
+        let mut statuses =
+            self.acme_statuses.write().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = statuses.entry(scope.to_string()).or_default();
+        entry.last_success_unix_ms = Some(unix_time_ms(SystemTime::now()));
+        entry.refreshes_total += 1;
+        entry.retry_after_unix_ms = None;
+        entry.last_error = None;
+        self.mark_snapshot_changed_components(true, false, false, false, false);
+        self.notify_snapshot_waiters();
+    }
+
+    pub fn record_acme_refresh_failure(
+        &self,
+        scope: &str,
+        error: impl Into<String>,
+        retry_after: Option<Duration>,
+    ) {
+        let mut statuses =
+            self.acme_statuses.write().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = statuses.entry(scope.to_string()).or_default();
+        entry.failures_total += 1;
+        entry.retry_after_unix_ms =
+            retry_after.and_then(|delay| SystemTime::now().checked_add(delay).map(unix_time_ms));
+        entry.last_error = Some(error.into());
+        self.mark_snapshot_changed_components(true, false, false, false, false);
+        self.notify_snapshot_waiters();
+    }
+
+    pub(super) fn sync_acme_statuses(&self, config: &ConfigSnapshot) {
+        let managed_scopes = config
+            .managed_certificates
+            .iter()
+            .map(|spec| spec.scope.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        self.acme_statuses
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .retain(|scope, _| managed_scopes.contains(scope.as_str()));
     }
 }

--- a/crates/rginx-http/src/state/lifecycle/reload.rs
+++ b/crates/rginx-http/src/state/lifecycle/reload.rs
@@ -120,6 +120,7 @@ impl SharedState {
         self.sync_peer_health_versions(prepared.config.as_ref());
         self.sync_upstream_stats(prepared.config.as_ref());
         self.sync_cache_versions(prepared.config.as_ref());
+        self.sync_acme_statuses(prepared.config.as_ref());
 
         let next_revision = {
             let mut state = self.inner.write().await;

--- a/crates/rginx-http/src/state/lifecycle/status.rs
+++ b/crates/rginx-http/src/state/lifecycle/status.rs
@@ -20,11 +20,14 @@ impl SharedState {
         let cache = CacheStatsSnapshot { zones: cache_manager.snapshot_with_shared_sync().await };
         let ocsp_statuses =
             self.ocsp_statuses.read().unwrap_or_else(|poisoned| poisoned.into_inner()).clone();
+        let acme_statuses =
+            self.acme_statuses.read().unwrap_or_else(|poisoned| poisoned.into_inner()).clone();
         let mtls = self.mtls_status_snapshot(config.as_ref());
         let tls = tls_runtime_snapshot_for_config_with_ocsp_statuses(
             config.as_ref(),
             Some(&ocsp_statuses),
         );
+        let acme = acme_runtime_snapshot(config.as_ref(), &tls.certificates, &acme_statuses);
         let listener_traffic =
             self.traffic_stats.read().unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut http3_active_connections = 0;
@@ -147,6 +150,7 @@ impl SharedState {
                 .counters
                 .downstream_http3_early_data_rejected_requests
                 .load(Ordering::Relaxed),
+            acme,
             tls,
             mtls,
             upstream_tls: upstream_tls_status_snapshots(config.as_ref()),
@@ -197,4 +201,59 @@ impl SharedState {
             active.entry(listener.id.clone()).or_insert_with(|| Arc::new(AtomicUsize::new(0)));
         }
     }
+}
+
+fn acme_runtime_snapshot(
+    config: &ConfigSnapshot,
+    certificates: &[TlsCertificateStatusSnapshot],
+    runtime_statuses: &HashMap<String, AcmeRuntimeStatusEntry>,
+) -> AcmeRuntimeSnapshot {
+    let certificate_statuses = certificates
+        .iter()
+        .flat_map(|status| {
+            let mut entries = vec![(status.scope.as_str(), status)];
+            if let Some(scope) = status.scope.strip_prefix("vhost:") {
+                entries.push((scope, status));
+            }
+            entries
+        })
+        .collect::<HashMap<_, _>>();
+
+    AcmeRuntimeSnapshot {
+        enabled: config.acme.is_some(),
+        directory_url: config.acme.as_ref().map(|settings| settings.directory_url.clone()),
+        managed_certificates: config
+            .managed_certificates
+            .iter()
+            .map(|spec| {
+                let certificate = certificate_statuses.get(spec.scope.as_str()).copied();
+                let runtime = runtime_statuses.get(spec.scope.as_str());
+                AcmeManagedCertificateSnapshot {
+                    scope: spec.scope.clone(),
+                    domains: spec.domains.clone(),
+                    managed: true,
+                    challenge_type: spec.challenge.as_str().to_string(),
+                    cert_path: spec.cert_path.clone(),
+                    key_path: spec.key_path.clone(),
+                    last_success_unix_ms: runtime.and_then(|entry| entry.last_success_unix_ms),
+                    next_renewal_unix_ms: next_renewal_unix_ms(certificate, config.acme.as_ref()),
+                    refreshes_total: runtime.map(|entry| entry.refreshes_total).unwrap_or(0),
+                    failures_total: runtime.map(|entry| entry.failures_total).unwrap_or(0),
+                    retry_after_unix_ms: runtime.and_then(|entry| entry.retry_after_unix_ms),
+                    last_error: runtime.and_then(|entry| entry.last_error.clone()),
+                }
+            })
+            .collect(),
+    }
+}
+
+fn next_renewal_unix_ms(
+    certificate: Option<&TlsCertificateStatusSnapshot>,
+    settings: Option<&rginx_core::AcmeSettings>,
+) -> Option<u64> {
+    let certificate = certificate?;
+    let settings = settings?;
+    let not_after_unix_ms = certificate.not_after_unix_ms?;
+    let renew_before_unix_ms = u64::try_from(settings.renew_before.as_millis()).unwrap_or(u64::MAX);
+    Some(not_after_unix_ms.saturating_sub(renew_before_unix_ms))
 }

--- a/crates/rginx-http/src/state/mod.rs
+++ b/crates/rginx-http/src/state/mod.rs
@@ -43,15 +43,16 @@ pub(super) struct PreparedState {
 pub use crate::cache::{CachePurgeResult, CacheZoneRuntimeSnapshot};
 pub use snapshots::ActiveState;
 pub use snapshots::{
-    CacheStatsSnapshot, GrpcTrafficSnapshot, Http3ListenerRuntimeSnapshot, HttpCountersSnapshot,
-    ListenerStatsSnapshot, MtlsStatusSnapshot, RecentTrafficStatsSnapshot,
-    RecentUpstreamStatsSnapshot, ReloadOutcomeSnapshot, ReloadResultSnapshot, ReloadStatusSnapshot,
-    RouteStatsSnapshot, RuntimeListenerBindingSnapshot, RuntimeListenerSnapshot,
-    RuntimeStatusSnapshot, SnapshotDeltaSnapshot, SnapshotModule, TlsCertificateStatusSnapshot,
-    TlsDefaultCertificateBindingSnapshot, TlsListenerStatusSnapshot, TlsOcspRefreshSpec,
-    TlsOcspStatusSnapshot, TlsReloadBoundarySnapshot, TlsRuntimeSnapshot, TlsSniBindingSnapshot,
-    TlsVhostBindingSnapshot, TrafficStatsSnapshot, UpstreamPeerStatsSnapshot,
-    UpstreamStatsSnapshot, UpstreamTlsStatusSnapshot, VhostStatsSnapshot,
+    AcmeManagedCertificateSnapshot, AcmeRuntimeSnapshot, CacheStatsSnapshot, GrpcTrafficSnapshot,
+    Http3ListenerRuntimeSnapshot, HttpCountersSnapshot, ListenerStatsSnapshot, MtlsStatusSnapshot,
+    RecentTrafficStatsSnapshot, RecentUpstreamStatsSnapshot, ReloadOutcomeSnapshot,
+    ReloadResultSnapshot, ReloadStatusSnapshot, RouteStatsSnapshot, RuntimeListenerBindingSnapshot,
+    RuntimeListenerSnapshot, RuntimeStatusSnapshot, SnapshotDeltaSnapshot, SnapshotModule,
+    TlsCertificateStatusSnapshot, TlsDefaultCertificateBindingSnapshot, TlsListenerStatusSnapshot,
+    TlsOcspRefreshSpec, TlsOcspStatusSnapshot, TlsReloadBoundarySnapshot, TlsRuntimeSnapshot,
+    TlsSniBindingSnapshot, TlsVhostBindingSnapshot, TrafficStatsSnapshot,
+    UpstreamPeerStatsSnapshot, UpstreamStatsSnapshot, UpstreamTlsStatusSnapshot,
+    VhostStatsSnapshot,
 };
 include!("counters/http.rs");
 include!("counters/rolling.rs");
@@ -93,6 +94,7 @@ pub struct SharedState {
     cache_component_versions: Arc<StdRwLock<HashMap<String, u64>>>,
     reload_history: Arc<Mutex<ReloadHistory>>,
     ocsp_statuses: Arc<StdRwLock<HashMap<String, OcspRuntimeStatusEntry>>>,
+    acme_statuses: Arc<StdRwLock<HashMap<String, AcmeRuntimeStatusEntry>>>,
     acme_http01_challenges: Arc<StdRwLock<HashMap<String, String>>>,
     config_path: Option<Arc<PathBuf>>,
 }
@@ -102,6 +104,15 @@ struct OcspRuntimeStatusEntry {
     last_refresh_unix_ms: Option<u64>,
     refreshes_total: u64,
     failures_total: u64,
+    last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct AcmeRuntimeStatusEntry {
+    last_success_unix_ms: Option<u64>,
+    refreshes_total: u64,
+    failures_total: u64,
+    retry_after_unix_ms: Option<u64>,
     last_error: Option<String>,
 }
 
@@ -159,6 +170,7 @@ impl SharedState {
         *cache_component_versions.write().unwrap_or_else(|poisoned| poisoned.into_inner()) =
             cache::build_cache_zone_versions(prepared.config.as_ref(), None);
         let ocsp_statuses = Arc::new(StdRwLock::new(HashMap::new()));
+        let acme_statuses = Arc::new(StdRwLock::new(HashMap::new()));
         let acme_http01_challenges = Arc::new(StdRwLock::new(HashMap::new()));
 
         Ok(Self {
@@ -187,6 +199,7 @@ impl SharedState {
             cache_component_versions,
             reload_history: Arc::new(Mutex::new(ReloadHistory::default())),
             ocsp_statuses,
+            acme_statuses,
             acme_http01_challenges,
             config_path: config_path.map(Arc::new),
         })

--- a/crates/rginx-http/src/state/snapshots/acme.rs
+++ b/crates/rginx-http/src/state/snapshots/acme.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcmeRuntimeSnapshot {
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directory_url: Option<String>,
+    pub managed_certificates: Vec<AcmeManagedCertificateSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcmeManagedCertificateSnapshot {
+    pub scope: String,
+    pub domains: Vec<String>,
+    pub managed: bool,
+    pub challenge_type: String,
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_success_unix_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_renewal_unix_ms: Option<u64>,
+    pub refreshes_total: u64,
+    pub failures_total: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_unix_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}

--- a/crates/rginx-http/src/state/snapshots/acme.rs
+++ b/crates/rginx-http/src/state/snapshots/acme.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct AcmeRuntimeSnapshot {
     pub enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/rginx-http/src/state/snapshots/mod.rs
+++ b/crates/rginx-http/src/state/snapshots/mod.rs
@@ -1,3 +1,4 @@
+mod acme;
 mod active;
 mod cache;
 mod delta;
@@ -8,6 +9,7 @@ mod tls;
 mod traffic;
 mod upstreams;
 
+pub use acme::{AcmeManagedCertificateSnapshot, AcmeRuntimeSnapshot};
 pub use active::ActiveState;
 pub use cache::CacheStatsSnapshot;
 pub use delta::{SnapshotDeltaSnapshot, SnapshotModule};

--- a/crates/rginx-http/src/state/snapshots/runtime.rs
+++ b/crates/rginx-http/src/state/snapshots/runtime.rs
@@ -29,6 +29,7 @@ pub struct RuntimeStatusSnapshot {
     pub http3_early_data_enabled_listeners: usize,
     pub http3_early_data_accepted_requests: u64,
     pub http3_early_data_rejected_requests: u64,
+    #[serde(default)]
     pub acme: AcmeRuntimeSnapshot,
     pub tls: TlsRuntimeSnapshot,
     pub mtls: MtlsStatusSnapshot,

--- a/crates/rginx-http/src/state/snapshots/runtime.rs
+++ b/crates/rginx-http/src/state/snapshots/runtime.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    CacheStatsSnapshot, MtlsStatusSnapshot, ReloadStatusSnapshot, TlsRuntimeSnapshot,
-    UpstreamTlsStatusSnapshot,
+    AcmeRuntimeSnapshot, CacheStatsSnapshot, MtlsStatusSnapshot, ReloadStatusSnapshot,
+    TlsRuntimeSnapshot, UpstreamTlsStatusSnapshot,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -29,6 +29,7 @@ pub struct RuntimeStatusSnapshot {
     pub http3_early_data_enabled_listeners: usize,
     pub http3_early_data_accepted_requests: u64,
     pub http3_early_data_rejected_requests: u64,
+    pub acme: AcmeRuntimeSnapshot,
     pub tls: TlsRuntimeSnapshot,
     pub mtls: MtlsStatusSnapshot,
     pub upstream_tls: Vec<UpstreamTlsStatusSnapshot>,

--- a/crates/rginx-http/src/state/tests/status.rs
+++ b/crates/rginx-http/src/state/tests/status.rs
@@ -7,6 +7,37 @@ use tempfile::tempdir;
 use crate::cache::{CacheLookup, CacheRequest};
 use crate::handler::full_body;
 
+fn managed_acme_status_config(cert_path: PathBuf, key_path: PathBuf) -> ConfigSnapshot {
+    let mut config = snapshot("127.0.0.1:8080");
+    config.acme = Some(rginx_core::AcmeSettings {
+        directory_url: "https://acme-staging-v02.api.letsencrypt.org/directory".to_string(),
+        contacts: vec!["mailto:ops@example.com".to_string()],
+        state_dir: PathBuf::from("/tmp/rginx-acme-status"),
+        renew_before: Duration::from_secs(30 * 86_400),
+        poll_interval: Duration::from_secs(3600),
+    });
+    config.managed_certificates = vec![rginx_core::ManagedCertificateSpec {
+        scope: "servers[0]".to_string(),
+        domains: vec!["api.example.com".to_string()],
+        cert_path: cert_path.clone(),
+        key_path: key_path.clone(),
+        challenge: rginx_core::AcmeChallengeType::Http01,
+    }];
+    config.vhosts = vec![VirtualHost {
+        id: "servers[0]".to_string(),
+        server_names: vec!["api.example.com".to_string()],
+        routes: Vec::new(),
+        tls: Some(rginx_core::VirtualHostTls {
+            cert_path,
+            key_path,
+            additional_certificates: Vec::new(),
+            ocsp_staple_path: None,
+            ocsp: rginx_core::OcspConfig::default(),
+        }),
+    }];
+    config
+}
+
 #[tokio::test]
 async fn status_snapshot_reports_runtime_summary() {
     let shared = SharedState::from_config_path(
@@ -54,10 +85,72 @@ async fn status_snapshot_reports_runtime_summary() {
     assert_eq!(status.tls.listeners[0].session_ticket_count, None);
     assert_eq!(status.tls.certificates.len(), 0);
     assert_eq!(status.tls.expiring_certificate_count, 0);
+    assert!(!status.acme.enabled);
+    assert!(status.acme.managed_certificates.is_empty());
     assert_eq!(status.mtls.configured_listeners, 0);
     assert_eq!(status.mtls.authenticated_requests, 0);
     assert_eq!(status.active_connections, 0);
     assert_eq!(status.reload.attempts_total, 0);
+}
+
+#[tokio::test]
+async fn status_snapshot_reports_acme_runtime_state() {
+    let temp = tempdir().expect("tempdir should build");
+    let cert_path = temp.path().join("managed.crt");
+    let key_path = temp.path().join("managed.key");
+
+    let mut params =
+        CertificateParams::new(vec!["api.example.com".to_string()]).expect("certificate params");
+    params.distinguished_name.push(DnType::CommonName, "api.example.com");
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    let key_pair = KeyPair::generate().expect("key pair should generate");
+    let certificate = params.self_signed(&key_pair).expect("certificate should self-sign");
+    fs::write(&cert_path, certificate.pem()).expect("certificate should be written");
+    fs::write(&key_path, key_pair.serialize_pem()).expect("private key should be written");
+
+    let shared =
+        SharedState::from_config(managed_acme_status_config(cert_path.clone(), key_path.clone()))
+            .expect("shared state should build");
+
+    shared.record_acme_refresh_failure(
+        "servers[0]",
+        "order pending",
+        Some(Duration::from_secs(90)),
+    );
+    shared.record_acme_refresh_success("servers[0]");
+
+    let status = shared.status_snapshot().await;
+    assert!(status.acme.enabled);
+    assert_eq!(
+        status.acme.directory_url.as_deref(),
+        Some("https://acme-staging-v02.api.letsencrypt.org/directory")
+    );
+    assert_eq!(status.acme.managed_certificates.len(), 1);
+    let managed = &status.acme.managed_certificates[0];
+    assert_eq!(managed.scope, "servers[0]");
+    assert_eq!(managed.domains, vec!["api.example.com".to_string()]);
+    assert!(managed.managed);
+    assert_eq!(managed.challenge_type, "http-01");
+    assert_eq!(managed.cert_path, cert_path);
+    assert_eq!(managed.key_path, key_path);
+    assert!(managed.last_success_unix_ms.is_some());
+    assert!(managed.next_renewal_unix_ms.is_some());
+    assert_eq!(managed.refreshes_total, 1);
+    assert_eq!(managed.failures_total, 1);
+    assert_eq!(managed.retry_after_unix_ms, None);
+    assert_eq!(managed.last_error, None);
+
+    let certificate = status
+        .tls
+        .certificates
+        .iter()
+        .find(|certificate| certificate.scope == "vhost:servers[0]")
+        .expect("managed vhost certificate should be present");
+    let expected_renewal = certificate
+        .not_after_unix_ms
+        .expect("certificate expiry should be present")
+        .saturating_sub(30_u64 * 86_400 * 1000);
+    assert_eq!(managed.next_renewal_unix_ms, Some(expected_renewal));
 }
 
 #[tokio::test]

--- a/crates/rginx-runtime/src/acme/lock.rs
+++ b/crates/rginx-runtime/src/acme/lock.rs
@@ -1,0 +1,54 @@
+use std::fs::{self, File, OpenOptions};
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+
+use rginx_core::{AcmeSettings, Error, Result};
+
+const ACME_STATE_LOCK_FILE: &str = ".acme.lock";
+
+#[derive(Debug)]
+pub(crate) struct AcmeStateLock {
+    _file: File,
+    #[cfg(test)]
+    path: PathBuf,
+}
+
+impl AcmeStateLock {
+    pub(crate) fn acquire(settings: &AcmeSettings) -> Result<Self> {
+        fs::create_dir_all(&settings.state_dir)?;
+        let path = lock_path(settings.state_dir.as_path());
+        let file =
+            OpenOptions::new().create(true).truncate(false).read(true).write(true).open(&path)?;
+        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if result == 0 {
+            return Ok(Self {
+                _file: file,
+                #[cfg(test)]
+                path,
+            });
+        }
+
+        let error = std::io::Error::last_os_error();
+        if matches!(error.raw_os_error(), Some(code) if code == libc::EWOULDBLOCK || code == libc::EAGAIN)
+        {
+            return Err(Error::Server(format!(
+                "ACME state directory lock `{}` is already held by another process",
+                path.display()
+            )));
+        }
+
+        Err(Error::Server(format!(
+            "failed to acquire ACME state directory lock `{}`: {error}",
+            path.display()
+        )))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn lock_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(ACME_STATE_LOCK_FILE)
+}

--- a/crates/rginx-runtime/src/acme/lock.rs
+++ b/crates/rginx-runtime/src/acme/lock.rs
@@ -49,6 +49,12 @@ impl AcmeStateLock {
     }
 }
 
+impl Drop for AcmeStateLock {
+    fn drop(&mut self) {
+        let _ = unsafe { libc::flock(self._file.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
 fn lock_path(state_dir: &Path) -> PathBuf {
     state_dir.join(ACME_STATE_LOCK_FILE)
 }

--- a/crates/rginx-runtime/src/acme/mod.rs
+++ b/crates/rginx-runtime/src/acme/mod.rs
@@ -4,6 +4,7 @@ use tokio::sync::watch;
 
 mod account;
 mod challenge;
+mod lock;
 mod order;
 mod scheduler;
 mod storage;
@@ -15,6 +16,7 @@ pub use types::{CertificateFailure, IssueSummary};
 
 use account::load_or_create_account;
 use challenge::{ChallengeBackend, TemporaryChallengeServer};
+use lock::AcmeStateLock;
 use order::issue_and_store_managed_certificate;
 use types::{certificate_status_index, plan_reconcile};
 
@@ -50,6 +52,7 @@ pub async fn issue_once(config: &ConfigSnapshot) -> Result<IssueSummary> {
         return Ok(summary);
     }
 
+    let _lock = AcmeStateLock::acquire(settings)?;
     let challenge_server = TemporaryChallengeServer::bind_for_config(config).await?;
     let issue_result = async {
         let account = load_or_create_account(settings).await?;

--- a/crates/rginx-runtime/src/acme/scheduler.rs
+++ b/crates/rginx-runtime/src/acme/scheduler.rs
@@ -7,6 +7,7 @@ use tokio::sync::watch;
 
 use super::account::load_or_create_account;
 use super::challenge::{ChallengeBackend, RuntimeChallengeBackend};
+use super::lock::AcmeStateLock;
 use super::order::issue_and_store_managed_certificate;
 use super::types::{certificate_status_index, http01_listener_addrs, plan_reconcile};
 
@@ -145,11 +146,7 @@ async fn reconcile_managed_certificates(
         return Ok(());
     }
 
-    let account = load_or_create_account(settings).await.map_err(|error| error.to_string())?;
-    let challenge_backend: Arc<dyn ChallengeBackend> =
-        Arc::new(RuntimeChallengeBackend::new(state.clone()));
-    let mut tls_acceptors_changed = false;
-
+    let mut work_items = Vec::new();
     for (spec, plan) in pending {
         if let Some(delay) = retry_backoff.remaining_delay(&spec.scope) {
             tracing::debug!(
@@ -159,7 +156,44 @@ async fn reconcile_managed_certificates(
             );
             continue;
         }
+        work_items.push((spec, plan));
+    }
+    if work_items.is_empty() {
+        return Ok(());
+    }
 
+    let _lock = match AcmeStateLock::acquire(settings) {
+        Ok(lock) => lock,
+        Err(error) => {
+            let message = error.to_string();
+            for (spec, _) in &work_items {
+                state.record_acme_refresh_failure(
+                    &spec.scope,
+                    message.clone(),
+                    Some(settings.poll_interval),
+                );
+                tracing::warn!(scope = %spec.scope, %message, "managed ACME reconcile skipped");
+            }
+            return Ok(());
+        }
+    };
+
+    let account = match load_or_create_account(settings).await {
+        Ok(account) => account,
+        Err(error) => {
+            let message = error.to_string();
+            for (spec, _) in &work_items {
+                let retry_delay = retry_backoff.record_failure(&spec.scope);
+                state.record_acme_refresh_failure(&spec.scope, message.clone(), Some(retry_delay));
+            }
+            return Err(message);
+        }
+    };
+    let challenge_backend: Arc<dyn ChallengeBackend> =
+        Arc::new(RuntimeChallengeBackend::new(state.clone()));
+    let mut certificates_changed = false;
+
+    for (spec, plan) in work_items {
         tracing::info!(
             scope = %spec.scope,
             reason = %plan.describe(),
@@ -168,11 +202,17 @@ async fn reconcile_managed_certificates(
         match issue_and_store_managed_certificate(spec, &account, challenge_backend.clone()).await {
             Ok(()) => {
                 retry_backoff.record_success(&spec.scope);
-                tls_acceptors_changed = true;
+                state.record_acme_refresh_success(&spec.scope);
+                certificates_changed = true;
                 tracing::info!(scope = %spec.scope, "managed ACME certificate refreshed");
             }
             Err(error) => {
                 let retry_delay = retry_backoff.record_failure(&spec.scope);
+                state.record_acme_refresh_failure(
+                    &spec.scope,
+                    error.to_string(),
+                    Some(retry_delay),
+                );
                 tracing::warn!(
                     scope = %spec.scope,
                     %error,
@@ -183,7 +223,11 @@ async fn reconcile_managed_certificates(
         }
     }
 
-    if tls_acceptors_changed {
+    if certificates_changed {
+        if let Err(error) = crate::ocsp::refresh_now(state).await {
+            tracing::warn!(%error, "managed ACME OCSP refresh failed");
+        }
+
         state.refresh_tls_acceptors_from_current_config().await.map_err(|error| {
             format!("failed to rebuild TLS acceptors after ACME certificate refresh: {error}")
         })?;

--- a/crates/rginx-runtime/src/acme/tests.rs
+++ b/crates/rginx-runtime/src/acme/tests.rs
@@ -6,15 +6,16 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use super::challenge::is_transient_accept_error;
+use super::lock::AcmeStateLock;
 use super::storage::parent_directory;
 use rginx_core::{
     AcmeChallengeType, AcmeSettings, ConfigSnapshot, Listener, ManagedCertificateSpec,
-    RuntimeSettings, Server, VirtualHost,
+    RuntimeSettings, Server, VirtualHost, VirtualHostTls,
 };
 use rginx_http::TlsCertificateStatusSnapshot;
 
 use super::storage::write_certificate_pair;
-use super::types::{http01_listener_addrs, plan_reconcile};
+use super::types::{certificate_status_index, http01_listener_addrs, plan_reconcile};
 
 fn test_config(listeners: Vec<Listener>) -> ConfigSnapshot {
     ConfigSnapshot {
@@ -103,8 +104,48 @@ fn permanent_accept_errors_stop_the_listener() {
 }
 
 #[test]
+fn acme_state_lock_rejects_concurrent_acquirers() {
+    let temp_dir = tempfile::tempdir().expect("tempdir should build");
+    let settings = AcmeSettings {
+        directory_url: "https://acme-staging-v02.api.letsencrypt.org/directory".to_string(),
+        contacts: Vec::new(),
+        state_dir: temp_dir.path().join("state"),
+        renew_before: Duration::from_secs(30 * 86_400),
+        poll_interval: Duration::from_secs(3600),
+    };
+
+    let first = AcmeStateLock::acquire(&settings).expect("first lock should succeed");
+    assert!(first.path().ends_with(".acme.lock"));
+
+    let error = AcmeStateLock::acquire(&settings).expect_err("second lock should fail");
+    assert!(error.to_string().contains("already held by another process"));
+}
+
+#[test]
 fn bare_relative_paths_use_current_directory_as_parent() {
     assert_eq!(parent_directory(Path::new("issued.crt")), Path::new("."));
+}
+
+#[test]
+fn certificate_status_index_maps_vhost_scope_to_managed_scope() {
+    let temp_dir = tempfile::tempdir().expect("tempdir should build");
+    let mut config = test_config(Vec::new());
+    config.vhosts = vec![VirtualHost {
+        id: "servers[0]".to_string(),
+        server_names: vec!["api.example.com".to_string()],
+        routes: Vec::new(),
+        tls: Some(VirtualHostTls {
+            cert_path: temp_dir.path().join("managed.crt"),
+            key_path: temp_dir.path().join("managed.key"),
+            additional_certificates: Vec::new(),
+            ocsp_staple_path: None,
+            ocsp: rginx_core::OcspConfig::default(),
+        }),
+    }];
+
+    let index = certificate_status_index(&config);
+    assert!(index.contains_key("servers[0]"));
+    assert!(index.contains_key("vhost:servers[0]"));
 }
 
 #[test]

--- a/crates/rginx-runtime/src/acme/types.rs
+++ b/crates/rginx-runtime/src/acme/types.rs
@@ -71,11 +71,14 @@ impl ReconcilePlan {
 pub(crate) fn certificate_status_index(
     config: &ConfigSnapshot,
 ) -> HashMap<String, TlsCertificateStatusSnapshot> {
-    tls_runtime_snapshot_for_config(config)
-        .certificates
-        .into_iter()
-        .map(|status| (status.scope.clone(), status))
-        .collect()
+    let mut index = HashMap::new();
+    for status in tls_runtime_snapshot_for_config(config).certificates {
+        if let Some(scope) = status.scope.strip_prefix("vhost:") {
+            index.insert(scope.to_string(), status.clone());
+        }
+        index.insert(status.scope.clone(), status);
+    }
+    index
 }
 
 pub(crate) fn http01_listener_addrs(config: &ConfigSnapshot) -> Vec<SocketAddr> {

--- a/crates/rginx-runtime/src/admin/mod.rs
+++ b/crates/rginx-runtime/src/admin/mod.rs
@@ -14,7 +14,7 @@ pub use socket::admin_socket_path_for_config;
 
 const INSTALLED_CONFIG_PATH: &str = "/etc/rginx/rginx.ron";
 const INSTALLED_ADMIN_SOCKET_PATH: &str = "/run/rginx/admin.sock";
-const ADMIN_SNAPSHOT_SCHEMA_VERSION: u32 = 14;
+const ADMIN_SNAPSHOT_SCHEMA_VERSION: u32 = 15;
 const DEFAULT_RECENT_WINDOW_SECS: u64 = 60;
 const EXTENDED_RECENT_WINDOW_SECS: u64 = 300;
 

--- a/crates/rginx-runtime/src/admin/tests.rs
+++ b/crates/rginx-runtime/src/admin/tests.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use super::{INSTALLED_ADMIN_SOCKET_PATH, admin_socket_path_for_config};
+use super::{AdminResponse, INSTALLED_ADMIN_SOCKET_PATH, admin_socket_path_for_config};
 
 #[test]
 fn installed_config_uses_run_admin_socket() {
@@ -16,4 +16,83 @@ fn custom_config_uses_neighbor_admin_socket() {
         admin_socket_path_for_config(Path::new("/tmp/site.ron")),
         PathBuf::from("/tmp/site.admin.sock")
     );
+}
+
+#[test]
+fn status_response_accepts_older_payload_without_acme_snapshot() {
+    let response = serde_json::json!({
+        "type": "Status",
+        "data": {
+            "revision": 1,
+            "config_path": null,
+            "listeners": [],
+            "worker_threads": null,
+            "accept_workers": 0,
+            "total_vhosts": 0,
+            "total_routes": 0,
+            "total_upstreams": 0,
+            "tls_enabled": false,
+            "http3_active_connections": 0,
+            "http3_active_request_streams": 0,
+            "http3_retry_issued_total": 0,
+            "http3_retry_failed_total": 0,
+            "http3_request_accept_errors_total": 0,
+            "http3_request_resolve_errors_total": 0,
+            "http3_request_body_stream_errors_total": 0,
+            "http3_response_stream_errors_total": 0,
+            "http3_early_data_enabled_listeners": 0,
+            "http3_early_data_accepted_requests": 0,
+            "http3_early_data_rejected_requests": 0,
+            "tls": {
+                "listeners": [],
+                "certificates": [],
+                "ocsp": [],
+                "vhost_bindings": [],
+                "sni_bindings": [],
+                "sni_conflicts": [],
+                "default_certificate_bindings": [],
+                "reload_boundary": {
+                    "reloadable_fields": [],
+                    "restart_required_fields": []
+                },
+                "expiring_certificate_count": 0
+            },
+            "mtls": {
+                "configured_listeners": 0,
+                "optional_listeners": 0,
+                "required_listeners": 0,
+                "authenticated_connections": 0,
+                "authenticated_requests": 0,
+                "anonymous_requests": 0,
+                "handshake_failures_total": 0,
+                "handshake_failures_missing_client_cert": 0,
+                "handshake_failures_unknown_ca": 0,
+                "handshake_failures_bad_certificate": 0,
+                "handshake_failures_certificate_revoked": 0,
+                "handshake_failures_verify_depth_exceeded": 0,
+                "handshake_failures_other": 0
+            },
+            "upstream_tls": [],
+            "cache": {
+                "zones": []
+            },
+            "active_connections": 0,
+            "reload": {
+                "attempts_total": 0,
+                "successes_total": 0,
+                "failures_total": 0,
+                "last_result": null
+            }
+        }
+    });
+
+    let decoded: AdminResponse =
+        serde_json::from_value(response).expect("older status payload should still decode");
+    let AdminResponse::Status(status) = decoded else {
+        panic!("expected status response");
+    };
+
+    assert!(!status.acme.enabled);
+    assert!(status.acme.directory_url.is_none());
+    assert!(status.acme.managed_certificates.is_empty());
 }

--- a/crates/rginx-runtime/src/ocsp/mod.rs
+++ b/crates/rginx-runtime/src/ocsp/mod.rs
@@ -25,6 +25,8 @@ pub async fn run(state: SharedState, shutdown: watch::Receiver<bool>) {
     scheduler::run(state, shutdown).await;
 }
 
+/// Refreshes OCSP staples immediately and returns whether callers should rebuild TLS acceptors
+/// to pick up changed staple files. This helper does not rebuild TLS acceptors by itself.
 pub async fn refresh_now(state: &SharedState) -> Result<bool, String> {
     scheduler::refresh_now(state).await
 }

--- a/crates/rginx-runtime/src/ocsp/mod.rs
+++ b/crates/rginx-runtime/src/ocsp/mod.rs
@@ -24,3 +24,7 @@ const OCSP_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 pub async fn run(state: SharedState, shutdown: watch::Receiver<bool>) {
     scheduler::run(state, shutdown).await;
 }
+
+pub async fn refresh_now(state: &SharedState) -> Result<bool, String> {
+    scheduler::refresh_now(state).await
+}

--- a/crates/rginx-runtime/src/ocsp/scheduler.rs
+++ b/crates/rginx-runtime/src/ocsp/scheduler.rs
@@ -18,7 +18,7 @@ pub(super) async fn run(state: SharedState, mut shutdown: watch::Receiver<bool>)
         }
     };
 
-    if let Err(error) = refresh_ocsp_staples(&state, &client).await {
+    if let Err(error) = refresh_ocsp_staples_and_reload(&state, &client).await {
         tracing::warn!(%error, "initial OCSP refresh failed");
     }
 
@@ -39,12 +39,12 @@ pub(super) async fn run(state: SharedState, mut shutdown: watch::Receiver<bool>)
                 if changed.is_err() {
                     break;
                 }
-                if let Err(error) = refresh_ocsp_staples(&state, &client).await {
+                if let Err(error) = refresh_ocsp_staples_and_reload(&state, &client).await {
                     tracing::warn!(%error, "OCSP refresh after reload failed");
                 }
             }
             _ = interval.tick() => {
-                if let Err(error) = refresh_ocsp_staples(&state, &client).await {
+                if let Err(error) = refresh_ocsp_staples_and_reload(&state, &client).await {
                     tracing::warn!(%error, "periodic OCSP refresh failed");
                 }
             }
@@ -54,7 +54,24 @@ pub(super) async fn run(state: SharedState, mut shutdown: watch::Receiver<bool>)
     tracing::info!("dynamic OCSP refresher stopped");
 }
 
-async fn refresh_ocsp_staples(state: &SharedState, client: &OcspClient) -> Result<(), String> {
+pub(super) async fn refresh_now(state: &SharedState) -> Result<bool, String> {
+    let client = build_ocsp_client()?;
+    refresh_ocsp_staples(state, &client).await
+}
+
+async fn refresh_ocsp_staples_and_reload(
+    state: &SharedState,
+    client: &OcspClient,
+) -> Result<(), String> {
+    let tls_acceptors_changed = refresh_ocsp_staples(state, client).await?;
+    refresh_tls_acceptors_if_needed(state, tls_acceptors_changed).await?;
+    Ok(())
+}
+
+pub(super) async fn refresh_ocsp_staples(
+    state: &SharedState,
+    client: &OcspClient,
+) -> Result<bool, String> {
     let config = state.current_config().await;
     let mut tls_acceptors_changed = false;
 
@@ -138,6 +155,5 @@ async fn refresh_ocsp_staples(state: &SharedState, client: &OcspClient) -> Resul
         }
     }
 
-    refresh_tls_acceptors_if_needed(state, tls_acceptors_changed).await?;
-    Ok(())
+    Ok(tls_acceptors_changed)
 }


### PR DESCRIPTION
## Summary
- block ACME-managed certificates on HTTP/3-enabled downstream listeners for v1 consistency
- trigger OCSP refresh after ACME certificate updates and add state_dir locking for ACME operations
- expose ACME runtime/config status through status, snapshot, and check output with tests

## Validation
- cargo fmt --all
- cargo test --workspace
- python3 ./scripts/run-modularization-gate.py
- ./scripts/run-clippy-gate.sh